### PR TITLE
Add Japanese localization

### DIFF
--- a/assets/i18n/strings_ja.i18n.json
+++ b/assets/i18n/strings_ja.i18n.json
@@ -153,7 +153,7 @@
       "ip": "IPアドレス"
     },
     "cancelSession": {
-      "title": "ファイル転送をキャンセルする",
+      "title": "ファイル転送をキャンセル",
       "content": "本当にファイル転送をキャンセルしますか？"
     },
     "fileNameInput": {

--- a/assets/i18n/strings_ja.i18n.json
+++ b/assets/i18n/strings_ja.i18n.json
@@ -1,0 +1,188 @@
+{
+  "locale": "日本語",
+  "appName": "LocalSend",
+  "general": {
+    "accept": "承諾",
+    "add": "追加",
+    "advanced": "詳細",
+    "cancel": "キャンセル",
+    "close": "閉じる",
+    "confirm": "確認",
+    "continueStr": "続行",
+    "copy": "コピー",
+    "copiedToClipboard": "クリップボードにコピーしました",
+    "decline": "拒否",
+    "done": "完了",
+    "edit": "編集",
+    "error": "エラー",
+    "example": "例",
+    "files": "ファイル",
+    "finished": "完了しました",
+    "hide": "隠す",
+    "off": "オフ",
+    "offline": "オフライン",
+    "on": "オン",
+    "online": "オンライン",
+    "open": "開く",
+    "queue": "順番待ち",
+    "quickSave": "クイックセーブ",
+    "renamed": "改名済み",
+    "reset": "リセット",
+    "restart": "再起動",
+    "settings": "設定",
+    "skipped": "スキップ済み",
+    "start": "開始",
+    "stop": "停止",
+    "save": "保存",
+    "unchanged": "未変更",
+    "unknown": "不明"
+  },
+  "receiveTab": {
+    "title": "受信",
+    "infoBox": {
+      "ip": "IP:",
+      "port": "ポート:",
+      "alias": "エイリアス:"
+    }
+  },
+  "sendTab": {
+    "title": "送信",
+    "selection": {
+      "title": "選択",
+      "files": "ファイル数: {files}",
+      "size": "サイズ: {size}"
+    },
+    "picker": {
+      "file": "ファイル",
+      "media": "メディア",
+      "text": "テキスト"
+    },
+    "shareIntentInfo": "モバイルデバイスの「共有」機能を使うと、より簡単にファイルを選択できます。",
+    "nearbyDevices": "近くのデバイス",
+    "thisDevice": "このデバイス",
+    "scan": "デバイスを検索",
+    "help": "目標のデバイスが同じWi-Fiネットワーク内にあることを確認してください。",
+    "placeItems": "ドロップして共有します。"
+  },
+  "settingsTab": {
+    "title": "設定",
+    "general": {
+      "title": "一般",
+      "theme": "テーマ",
+      "themeOptions": {
+        "system": "システム",
+        "dark": "ダーク",
+        "light": "ライト"
+      },
+      "language": "言語",
+      "languageOptions": {
+        "system": "システム"
+      },
+      "minimizeToTray": "終了: トレイに最小化",
+      "launchAtStartup": "ログイン時に自動起動",
+      "launchMinimized": "自動起動: 隠れた状態で開始"
+    },
+    "receive": {
+      "title": "受信",
+      "quickSave": "@:general.quickSave",
+      "destination": "保存先",
+      "saveToGallery": "メディアをギャラリーに保存"
+    },
+    "network": {
+      "title": "ネットワーク",
+      "needRestart": "設定を反映するにはサーバーを再起動してください！",
+      "server": "サーバー",
+      "alias": "エイリアス",
+      "port": "ポート"
+    }
+  },
+  "selectedFilesPage": {
+    "deleteAll": "すべて削除"
+  },
+  "receivePage": {
+    "subTitle": {
+      "one": "がファイルを送信しようとしています。",
+      "other": "が{n}件のファイルを送信しようとしています。"
+    },
+    "subTitleMessage": "がメッセージを送信しました:",
+    "subTitleLink": "がリンクを送信しました:",
+    "canceled": "送信者がリクエストをキャンセルしました。"
+  },
+  "receiveOptionsPage": {
+    "title": "オプション",
+    "destination": "@:settingsTab.receive.destination",
+    "appDirectory": "(@:appName フォルダー)"
+  },
+  "sendPage": {
+    "waiting": "返答を待っています...",
+    "rejected": "受信者がリクエストを拒否しました。"
+  },
+  "progressPage": {
+    "titleSending": "ファイルを送信中",
+    "titleReceiving": "ファイルを受信中",
+    "savedToGallery": "写真に保存しました",
+    "total": {
+      "title": {
+        "sending": "総進捗 ({time})",
+        "finishedError": "エラーで終了しました",
+        "canceledSender": "送信者によりキャンセルされました",
+        "canceledReceiver": "受信者よりキャンセルされました"
+      },
+      "count": "ファイル: {curr} / {n}",
+      "size": "サイズ: {curr} / {n}",
+      "speed": "速度: {speed}/s"
+    }
+  },
+  "aboutPage": {
+    "title": "LocalSendについて"
+  },
+  "changelogPage": {
+    "title": "更新履歴"
+  },
+  "aliasGenerator": {
+    "@info": "Inherits from the English version"
+  },
+  "dialogs": {
+    "addFile": {
+      "title": "選択に追加",
+      "content": "何を追加しますか？"
+    },
+    "addressInput": {
+      "title": "アドレスを入力",
+      "hashtag": "ハッシュタグ",
+      "ip": "IPアドレス"
+    },
+    "cancelSession": {
+      "title": "ファイル転送をキャンセルする",
+      "content": "本当にファイル転送をキャンセルしますか？"
+    },
+    "fileNameInput": {
+      "title": "ファイル名を入力",
+      "original": "元の名前: {original}"
+    },
+    "messageInput": {
+      "title": "メッセージを入力",
+      "multiline": "複数行"
+    },
+    "noFiles": {
+      "title": "ファイルが選択されていません",
+      "content": "少なくとも1つのファイルを選択してください。"
+    },
+    "quickActions": {
+      "title": "クイックアクション",
+      "counter": "カウンター",
+      "prefix": "接頭辞",
+      "padZero": "ゼロで埋める",
+      "sortBeforeCount": "事前にアルファベット順で並べる",
+      "random": "ランダム"
+    },
+    "quickSaveNotice": {
+      "title": "@:general.quickSave",
+      "content": "ファイルリクエストが自動で承諾されます。ローカルネットワーク内の全員がファイルを送信できるので注意してください。"
+    }
+  },
+  "tray": {
+    "open": "@:general.open",
+    "close": "LocalSendを終了"
+  }
+}


### PR DESCRIPTION
Hi, I just found and tried this app, and it's working really great! I was waiting for an open-source, cross-platform alternative to AirDrop like this so that I can move files between my Linux laptop and iOS devices.

I made a Japanese localization for the app and I hope it gets merged. I don't have Flutter installed so I haven't tested it in real app, but I was able to look around and find where each string is used, so I believe the translations are not out of context.