### PR TITLE
fix: multiline property of message input dialog

### DIFF
--- a/lib/widget/dialogs/message_input_dialog.dart
+++ b/lib/widget/dialogs/message_input_dialog.dart
@@ -24,7 +24,7 @@ class _MessageInputDialogState extends State<MessageInputDialog> {
             key: ValueKey('m-$_multiline'),
             initialValue: _text,
             keyboardType: _multiline ? TextInputType.multiline : TextInputType.text,
-            maxLines: null,
+            maxLines: _multiline ? null : 1,
             autofocus: true,
             onChanged: (s) {
               setState(() => _text = s);
@@ -50,7 +50,9 @@ class _MessageInputDialogState extends State<MessageInputDialog> {
       actions: [
         TextButton(
           style: ElevatedButton.styleFrom(
-            foregroundColor: Theme.of(context).brightness == Brightness.dark ? Theme.of(context).buttonTheme.colorScheme!.onPrimary : null,
+            foregroundColor: Theme.of(context).brightness == Brightness.dark
+                ? Theme.of(context).buttonTheme.colorScheme!.onPrimary
+                : null,
           ),
           onPressed: () => context.pop(),
           child: Text(t.general.cancel),


### PR DESCRIPTION
### Goals
- multiline checkbox of message input dialog changes behavior of text field, making it horizontally scrollable when disabled

closes #73 