### PR TITLE
Fixed a few bad translations (Polish)

### DIFF
--- a/assets/i18n/strings_pl.i18n.json
+++ b/assets/i18n/strings_pl.i18n.json
@@ -7,12 +7,12 @@
     "advanced": "Zaawansowane",
     "cancel": "Anuluj",
     "close": "Zamknij",
-    "confirm": "Potwierdzij",
+    "confirm": "Potwierdź",
     "continueStr": "Dalej",
     "copy": "Kopiuj",
-    "copiedToClipboard": "Z Kopiowane do Schowka",
-    "decline": "Odrzuc",
-    "done": "Gotowy",
+    "copiedToClipboard": "Skopiowane do Schowka",
+    "decline": "Odrzuć",
+    "done": "Gotowe",
     "edit": "Edytuj",
     "error": "Błąd",
     "example": "Przykład",
@@ -31,14 +31,14 @@
     "restart": "Restartuj",
     "settings": "Ustawienia",
     "skipped": "Pominięty",
-    "start": "Zaczni",
-    "stop": "Zatrzymać",
-    "save": "Zapisaj",
+    "start": "Zacznij",
+    "stop": "Zatrzymaj",
+    "save": "Zapisz",
     "unchanged": "Bez Zmian",
     "unknown": "Nieznany"
   },
   "receiveTab": {
-    "title": "Odbieraj",
+    "title": "Odbierz",
     "infoBox": {
       "ip": "IP:",
       "port": "Port:",
@@ -68,10 +68,10 @@
     "title": "Ustawienia",
     "general": {
       "title": "Ogólne",
-      "theme": "Temat",
+      "theme": "Motyw",
       "themeOptions": {
         "system": "System",
-        "dark": "Cziemny",
+        "dark": "Ciemny",
         "light": "Jasny"
       },
       "language": "Język",
@@ -83,7 +83,7 @@
       "launchMinimized": "Autostart: Start ukryty"
     },
     "receive": {
-      "title": "Odbieraj",
+      "title": "Odbierz",
       "quickSave": "@:general.quickSave",
       "destination": "Miejsce docelowe",
       "saveToGallery": "Zapisz multimedia w galerii"
@@ -182,23 +182,23 @@
       "Mądry"
     ],
     "fruits": [
-      "Jabko",
+      "Jabłko",
       "Awokado",
       "Banan",
       "Jeżyna",
       "Jagoda",
-      "Brokuły",
+      "Brokuł",
       "Marchewka",
       "Wiśnia",
       "Kokos",
-      "Winogron",
+      "Winogrono",
       "Cytryna",
       "Sałata",
       "Mango",
       "Melon",
       "Pieczarka",
       "Cebula",
-      "Pomarańcz",
+      "Pomarańcza",
       "Papaja",
       "Brzoskwinia",
       "Gruszka",
@@ -222,7 +222,7 @@
     },
     "cancelSession": {
       "title": "Anuluj transfer plików",
-      "content": "Czy napewno?"
+      "content": "Czy na pewno?"
     },
     "fileNameInput": {
       "title": "Wpisz imię",
@@ -240,7 +240,7 @@
       "title": "Szybkie akcje",
       "counter": "Licznik",
       "prefix": "Prefiks",
-      "padZero": "Podkładka z zerami",
+      "padZero": "Wypchnij zerami",
       "sortBeforeCount": "Wcześniej posortuj alfabetycznie",
       "random": "Losowy"
     },


### PR DESCRIPTION
This PR fixes some grammar and spelling mistakes, and also some bad translation attempts (e.g. `padZero` being translated as "a (mouse)pad with zeros").
There are still a couple of things to improve but I don't have enough context to provide accurate translations.