### PR TITLE
Add strings file for spanish (Spain).

### DIFF
--- a/assets/i18n/strings_es-ES.i18n.json
+++ b/assets/i18n/strings_es-ES.i18n.json
@@ -50,14 +50,14 @@
     "selection": {
       "title": "Selección",
       "files": "Ficheros: {files}",
-      "size": "Tamaño:: {size}"
+      "size": "Tamaño: {size}"
     },
     "picker": {
       "file": "Fichero",
       "media": "Media",
       "text": "Texto"
     },
-    "shareIntentInfo": "También puedes usar la opción \"Share\" de tu dispositivo para seleccionar ficheros más facilmente.",
+    "shareIntentInfo": "También puedes usar la opción \"Compartir\" de tu dispositivo para seleccionar ficheros más fácilmente.",
     "nearbyDevices": "Dispositivos Cercanos",
     "thisDevice": "Este dispositivo",
     "scan": "Buscar dispositivos",
@@ -140,75 +140,7 @@
     "title": "Changelog"
   },
   "aliasGenerator": {
-    "@info": "Locales diferentes pueden tener palabras diferentes, pueden no coincidir 1:1",
-    "adjectives": [
-      "Adorable",
-      "Bonito",
-      "Grande",
-      "Brillante",
-      "Limpio",
-      "Inteligente",
-      "Guay",
-      "Lindo",
-      "Astuto",
-      "Determinado",
-      "Energético",
-      "Eficiente",
-      "Fantástico",
-      "Rápido",
-      "Buen",
-      "Fresco",
-      "Bueno",
-      "Espléndido",
-      "Genial",
-      "Guapo",
-      "Caliente",
-      "Amable",
-      "Encantador",
-      "Místico",
-      "Ordenado",
-      "Hermoso",
-      "Paciente",
-      "Precioso",
-      "Poderoso",
-      "Rico",
-      "Secreto",
-      "Listo",
-      "Sólido",
-      "Especial",
-      "Stratégico",
-      "Fuerte",
-      "Arreglado",
-      "Sabio"
-    ],
-    "fruits": [
-      "Manzana",
-      "Aguacate",
-      "Plátano",
-      "Mora",
-      "Arándano",
-      "Brócoli",
-      "Zanahoria",
-      "Cereza",
-      "Coco",
-      "Uva",
-      "Limón",
-      "Lechuga",
-      "Mango",
-      "Melón",
-      "Seta",
-      "Cebolla",
-      "Naranja",
-      "Papaya",
-      "Melocotón",
-      "Pera",
-      "Piña",
-      "Patata",
-      "Calabaz",
-      "Frambuesa",
-      "Fresa",
-      "Tomate"
-    ]
+    "@info": "Uses English version",
   },
   "dialogs": {
     "addFile": {
@@ -246,7 +178,7 @@
     },
     "quickSaveNotice": {
       "title": "@:general.quickSave",
-      "content": "Las solicitudes de archivos se aceptan automáticamente. Ten en cuenta que cualquiera en la red local puede enviarte ficheros."
+      "content": "Las solicitudes de archivos se aceptan automáticamente. Ten en cuenta que cualquiera en la red local podrá enviarte ficheros."
     }
   },
   "tray": {

--- a/assets/i18n/strings_es-ES.i18n.json
+++ b/assets/i18n/strings_es-ES.i18n.json
@@ -1,0 +1,257 @@
+{
+  "locale": "Español",
+  "appName": "LocalSend",
+  "general": {
+    "accept": "Aceptar",
+    "add": "Añadir",
+    "advanced": "Avanzado",
+    "cancel": "Cancelar",
+    "close": "Cerrar",
+    "confirm": "Confirmar",
+    "continueStr": "Continuar",
+    "copy": "Copiar",
+    "copiedToClipboard": "Copiado al Portapapeles",
+    "decline": "Rechazar",
+    "done": "Hecho",
+    "edit": "Editar",
+    "error": "Error",
+    "example": "Ejemplo",
+    "files": "Ficheros",
+    "finished": "Finalizado",
+    "hide": "Ocultar",
+    "off": "Apagado",
+    "offline": "Desconectado",
+    "on": "Encendido",
+    "online": "En línea",
+    "open": "Abrir",
+    "queue": "Cola",
+    "quickSave": "Guardado Rápido",
+    "renamed": "Renombrado",
+    "reset": "Resetear",
+    "restart": "Reiniciar",
+    "settings": "Ajustes",
+    "skipped": "Omitido",
+    "start": "Iniciar",
+    "stop": "Detener",
+    "save": "Guardar",
+    "unchanged": "Sin Cambios",
+    "unknown": "Desconocido"
+  },
+  "receiveTab": {
+    "title": "Recibir",
+    "infoBox": {
+      "ip": "IP:",
+      "port": "Puerto:",
+      "alias": "Alias:"
+    }
+  },
+  "sendTab": {
+    "title": "Enviar",
+    "selection": {
+      "title": "Selección",
+      "files": "Ficheros: {files}",
+      "size": "Tamaño:: {size}"
+    },
+    "picker": {
+      "file": "Fichero",
+      "media": "Media",
+      "text": "Texto"
+    },
+    "shareIntentInfo": "También puedes usar la opción \"Share\" de tu dispositivo para seleccionar ficheros más facilmente.",
+    "nearbyDevices": "Dispositivos Cercanos",
+    "thisDevice": "Este dispositivo",
+    "scan": "Buscar dispositivos",
+    "help": "Asegúrate de que el destino elegido está en la misma red Wi-Fi.",
+    "placeItems": "Selecciona items para compartir."
+  },
+  "settingsTab": {
+    "title": "Ajustes",
+    "general": {
+      "title": "General",
+      "theme": "Tema",
+      "themeOptions": {
+        "system": "Sistema",
+        "dark": "Oscuro",
+        "light": "Claro"
+      },
+      "language": "Lenguaje",
+      "languageOptions": {
+        "system": "Sistema"
+      },
+      "minimizeToTray": "Cerrar: Minimizar ventana",
+      "launchAtStartup": "Inicio automático",
+      "launchMinimized": "Inicio automático: Iniciar minimizado"
+    },
+    "receive": {
+      "title": "Recivir",
+      "quickSave": "@:general.quickSave",
+      "destination": "Destino",
+      "saveToGallery": "Guardar media en la galería"
+    },
+    "network": {
+      "title": "Red",
+      "needRestart": "Reiniciar el servidor para aplicar los ajustes.",
+      "server": "Servidor",
+      "alias": "Alias",
+      "port": "Puerto"
+    }
+  },
+  "selectedFilesPage": {
+    "deleteAll": "Eliminar todo"
+  },
+  "receivePage": {
+    "subTitle": {
+      "one": "quiere enviarte un fichero.",
+      "other": "quiere enviarte {n} ficheros."
+    },
+    "subTitleMessage": "te ha enviado un mensaje:",
+    "subTitleLink": "te ha enviado un link:",
+    "canceled": "El remitente ha cancelado la petición."
+  },
+  "receiveOptionsPage": {
+    "title": "Opciones",
+    "destination": "@:settingsTab.receive.destination",
+    "appDirectory": "(directorio @:appName)"
+  },
+  "sendPage": {
+    "waiting": "Esperando respuesta...",
+    "rejected": "El destino ha rechazado la petición."
+  },
+  "progressPage": {
+    "titleSending": "Enviando ficheros",
+    "titleReceiving": "Reciviendo ficheros",
+    "savedToGallery": "Guardado en fotos",
+    "total": {
+      "title": {
+        "sending": "Progreso total ({time})",
+        "finishedError": "Finalizado con error",
+        "canceledSender": "Cancelado por remitente",
+        "canceledReceiver": "Canceled by destino"
+      },
+      "count": "Ficheros: {curr} / {n}",
+      "size": "Tamaño: {curr} / {n}",
+      "speed": "Velocidad: {speed}/s"
+    }
+  },
+  "aboutPage": {
+    "title": "Sobre LocalSend"
+  },
+  "changelogPage": {
+    "title": "Changelog"
+  },
+  "aliasGenerator": {
+    "@info": "Locales diferentes pueden tener palabras diferentes, pueden no coincidir 1:1",
+    "adjectives": [
+      "Adorable",
+      "Bonito",
+      "Grande",
+      "Brillante",
+      "Limpio",
+      "Inteligente",
+      "Guay",
+      "Lindo",
+      "Astuto",
+      "Determinado",
+      "Energético",
+      "Eficiente",
+      "Fantástico",
+      "Rápido",
+      "Buen",
+      "Fresco",
+      "Bueno",
+      "Espléndido",
+      "Genial",
+      "Guapo",
+      "Caliente",
+      "Amable",
+      "Encantador",
+      "Místico",
+      "Ordenado",
+      "Hermoso",
+      "Paciente",
+      "Precioso",
+      "Poderoso",
+      "Rico",
+      "Secreto",
+      "Listo",
+      "Sólido",
+      "Especial",
+      "Stratégico",
+      "Fuerte",
+      "Arreglado",
+      "Sabio"
+    ],
+    "fruits": [
+      "Manzana",
+      "Aguacate",
+      "Plátano",
+      "Mora",
+      "Arándano",
+      "Brócoli",
+      "Zanahoria",
+      "Cereza",
+      "Coco",
+      "Uva",
+      "Limón",
+      "Lechuga",
+      "Mango",
+      "Melón",
+      "Seta",
+      "Cebolla",
+      "Naranja",
+      "Papaya",
+      "Melocotón",
+      "Pera",
+      "Piña",
+      "Patata",
+      "Calabaz",
+      "Frambuesa",
+      "Fresa",
+      "Tomate"
+    ]
+  },
+  "dialogs": {
+    "addFile": {
+      "title": "Añadir a selección",
+      "content": "¿Qué quieres añadir?"
+    },
+    "addressInput": {
+      "title": "Introducir dirección",
+      "hashtag": "Hashtag",
+      "ip": "Dirección IP"
+    },
+    "cancelSession": {
+      "title": "Cancelar transferencia de archivos",
+      "content": "¿Realmente quieres cancelar la transferencia de archivos?"
+    },
+    "fileNameInput": {
+      "title": "Introduce el nombre",
+      "original": "Original: {original}"
+    },
+    "messageInput": {
+      "title": "Escribe un mensaje",
+      "multiline": "Varias líneas"
+    },
+    "noFiles": {
+      "title": "Ningún fichero seleccionado",
+      "content": "Por favor selecciona al menos un fichero."
+    },
+    "quickActions": {
+      "title": "Acciones rápidas",
+      "counter": "Contador",
+      "prefix": "Prefijo",
+      "padZero": "Llenar con ceros",
+      "sortBeforeCount": "Ordenar alfabéticamente antes",
+      "random": "Aleatorio"
+    },
+    "quickSaveNotice": {
+      "title": "@:general.quickSave",
+      "content": "Las solicitudes de archivos se aceptan automáticamente. Ten en cuenta que cualquiera en la red local puede enviarte ficheros."
+    }
+  },
+  "tray": {
+    "@info": "Apple Guidelines are very strict about the 'close' wording.",
+    "open": "@:general.open",
+    "close": "Cerrar LocalSend"
+  }
+}

--- a/assets/i18n/strings_iw.i18n.json
+++ b/assets/i18n/strings_iw.i18n.json
@@ -1,0 +1,258 @@
+{
+	"locale": "עִברִית",
+	"appName": "LocalSend",
+	"general": {
+	  "accept": "קבל",
+	  "add": "הוסף",
+	  "advanced": "מִתקַדֵם",
+	  "cancel": "בַטֵל",
+	  "close": "סגור",
+	  "confirm": "אשר",
+	  "continueStr": "המשך",
+	  "copy": "הֶעתֵק",
+	  "copiedToClipboard": "הועתק ללוח",
+	  "decline": "סרב",
+	  "done": "בוצע",
+	  "edit": "ערוך",
+	  "error": "שְׁגִיאָה",
+	  "example": "דוגמא",
+	  "files": "קבצים",
+	  "finished": "נִגמָר",
+	  "hide": "הסתר",
+	  "off": "לא פעיל",
+	  "offline": "אין אינטרנט",
+	  "on": "פעיל",
+	  "online": "יש אינטרנט",
+	  "open": "פתוח",
+	  "queue": "תוֹר",
+	  "quickSave": "שמירה מהירה",
+	  "renamed": "שונה שם",
+	  "reset": "אִתחוּל",
+	  "restart": "הפעל מחדש",
+	  "settings": "הגדרות",
+	  "skipped": "דילג",
+	  "start": "התחל",
+	  "stop": "עֲצוֹר",
+	  "save": "שמור",
+	  "unchanged": "ללא שינוי",
+	  "unknown": "לא ידוע"
+	},
+	"receiveTab": {
+	  "title": "קבל",
+	  "infoBox": {
+		"ip": "IP:",
+		"port": "יציאה:",
+		"alias": "כינוי:"
+	  }
+	},
+	"sendTab": {
+	  "title": "שלח",
+	  "selection": {
+		"title": "בְּחִירָה",
+		"files": "קבצים: {files}",
+		"size": "גודל: {size}"
+	  },
+	  "picker": {
+		"file": "קוֹבֶץ",
+		"media": "מדיה",
+		"text": "טֶקסט"
+	  },
+	  "shareIntentInfo": "תוכל גם להשתמש בתכונה \"שתף\" של המכשיר הנייד שלך כדי לבחור קבצים ביתר קלות.",
+	  "nearbyDevices": "מכשירים בקרבת מקום",
+	  "thisDevice": "המכשיר הזה",
+	  "scan": "חפש מכשירים",
+	  "help": "אנא ודא שגם היעד הרצוי נמצא באותה רשת wifi.",
+	  "placeItems": "הצב פריטים לשיתוף."
+	},
+	"settingsTab": {
+	  "title": "הגדרות",
+	  "general": {
+		"title": "כללי",
+		"theme": "ערכת נושא",
+		"themeOptions": {
+		  "system": "מערכת",
+		  "dark": "כֵּהֶה",
+		  "light": "בָּהִיר"
+		},
+		"language": "שפה",
+		"languageOptions": {
+		  "system": "מערכת"
+		},
+		"minimizeToTray": "יציאה: מזעור למגש",
+		"launchAtStartup": "הפעלה אוטומטית לאחר הכניסה",
+		"launchMinimized": "הפעלה אוטומטית: התחל מוסתר"
+	  },
+	  "receive": {
+		"title": "קבל",
+		"quickSave": "@:general.quickSave",
+		"destination": "יַעַד",
+		"saveToGallery": "שמור מדיה לגלריה"
+	  },
+	  "network": {
+		"title": "רֶשֶׁת",
+		"needRestart": "הפעל מחדש את השרת כדי להחיל את ההגדרות!",
+		"server": "שרת",
+		"alias": "כינוי",
+		"port": "יציאה"
+	  }
+	},
+	"selectedFilesPage": {
+	  "deleteAll": "מחק הכל"
+	},
+	"receivePage": {
+	  "subTitle": {
+		"one": "רוצה לשלוח לך קובץ.",
+		"other": "רוצה לשלוח לך {n} קבצים."
+	  },
+	  "subTitleMessage": "שלח לך הודעה:",
+	  "subTitleLink": "שלח לך קישור:",
+	  "canceled": "השולח ביטל את הבקשה."
+	},
+	"receiveOptionsPage": {
+	  "title": "אפשרויות",
+	  "destination": "@:settingsTab.receive.destination",
+	  "appDirectory": "(@:appName folder)"
+	},
+	"sendPage": {
+	  "waiting": "מחכה לתגובה...",
+	  "rejected": "הנמען דחה את הבקשה."
+	},
+	"progressPage": {
+	  "titleSending": "שולח קבצים",
+	  "titleReceiving": "מקבל קבצים",
+	  "savedToGallery": "נשמר בתמונות",
+	  "total": {
+		"title": {
+		  "sending": "סה\"כ התקדמות ({time})",
+		  "finishedError": "הסתיים עם שגיאה",
+		  "canceledSender": "בוטל על ידי השולח",
+		  "canceledReceiver": "בוטל על ידי הצד המקבל"
+		},
+		"count": "קבצים: {curr} / {n}",
+		"size": "גודל: {curr} / {n}",
+		"speed": "מְהִירוּת: {speed}/שְׁנִיָה"
+	  }
+	},
+	"aboutPage": {
+	  "title": "אודות LocalSend"
+	},
+	"changelogPage": {
+	  "title": "יומן שינויים"
+	},
+	"aliasGenerator": {
+	  "@info": "למקומים שונים עשויות להיות מילים שונות, ייתכן שהן לא תואמות 1:1",
+	  "adjectives": [
+		"מקסים",
+		"יפה",
+		"גָדוֹל",
+		"בָּהִיר",
+		"נָקִי",
+		"נבון",
+		"קריר",
+		"חָמוּד",
+		"עַרמוּמִי",
+		"נחושה בדעתה",
+		"נִמרָץ",
+		"יָעִיל",
+		"פַנטַסטִי",
+		"מָהִיר",
+		"בסדר גמור",
+		"טָרִי",
+		"טוֹב",
+		"מאוד יפה",
+		"נהדר",
+		"נאה",
+		"חַם",
+		"טוֹב לֵב",
+		"חביב",
+		"מִיסטִי",
+		"מְסוּדָר וְנָקִי",
+		"נֶחְמָד",
+		"סבלני",
+		"יפה",
+		"חָזָק",
+		"עָשִׁיר",
+		"סודי",
+		"חכם",
+		"מוצק",
+		"מיוחד",
+		"אסטרטגי",
+		"חָזָק",
+		"מסודר",
+		"חכם"
+	  ],
+	  "fruits": [
+		"תפוח עץ",
+		"אבוקדו",
+		"בננה",
+		"אוכמניות",
+		"אוכמניות",
+		"ברוקולי",
+		"גזר",
+		"דובדבן",
+		"קוקוס",
+		"ענבים",
+		"לימון",
+		"חסה",
+		"מנגו",
+		"מֵלוֹן",
+		"פטריות",
+		"בצל",
+		"תפוז",
+		"פפאיה",
+		"אפרסק",
+		"אגס",
+		"אננס",
+		"תפוח אדמה",
+		"דלעת",
+		"פֶּטֶל",
+		"תּוּת",
+		"עגבניות"
+	  ]
+	},
+	"dialogs": {
+	  "addFile": {
+		"title": "הוסף לבחירה",
+		"content": "מה אתה רוצה להוסיף?"
+	  },
+	  "addressInput": {
+		"title": "הכנס כתובת",
+		"hashtag": "סולמית",
+		"ip": "כתובת ה - IP"
+	  },
+	  "cancelSession": {
+		"title": "בטל את העברת הקבצים",
+		"content": "האם אתה באמת רוצה לבטל את העברת הקבצים?"
+	  },
+	  "fileNameInput": {
+		"title": "הזן את שם הקובץ",
+		"original": "מְקוֹרִי: {original}"
+	  },
+	  "messageInput": {
+		"title": "הקלד הודעה",
+		"multiline": "מרובה שורות"
+	  },
+	  "noFiles": {
+		"title": "אף קובץ לא נבחר",
+		"content": "אנא בחר קובץ אחד לפחות."
+	  },
+	  "quickActions": {
+		"title": "פעולות מהירות",
+		"counter": "מוֹנֶה",
+		"prefix": "קידומת",
+		"padZero": "רפידה עם אפסים",
+		"sortBeforeCount": "מיון לפי אלפביתי מראש",
+		"random": "אַקרַאִי"
+	  },
+	  "quickSaveNotice": {
+		"title": "@:general.quickSave",
+		"content": "בקשות לקבצים מתקבלות אוטומטית. שים לב שכל אחד ברשת המקומית יכול לשלוח לך קבצים."
+	  }
+	},
+	"tray": {
+	  "@info": "הנחיות אפל מקפידות מאוד על הניסוח 'קרוב'.",
+	  "open": "@:general.open",
+	  "close": "צא מ-LocalSend"
+	}
+  }
+  

--- a/assets/i18n/strings_pl.i18n.json
+++ b/assets/i18n/strings_pl.i18n.json
@@ -7,12 +7,12 @@
     "advanced": "Zaawansowane",
     "cancel": "Anuluj",
     "close": "Zamknij",
-    "confirm": "Potwierdzij",
+    "confirm": "Potwierdź",
     "continueStr": "Dalej",
     "copy": "Kopiuj",
-    "copiedToClipboard": "Z Kopiowane do Schowka",
-    "decline": "Odrzuc",
-    "done": "Gotowy",
+    "copiedToClipboard": "Skopiowane do Schowka",
+    "decline": "Odrzuć",
+    "done": "Gotowe",
     "edit": "Edytuj",
     "error": "Błąd",
     "example": "Przykład",
@@ -31,14 +31,14 @@
     "restart": "Restartuj",
     "settings": "Ustawienia",
     "skipped": "Pominięty",
-    "start": "Zaczni",
-    "stop": "Zatrzymać",
-    "save": "Zapisaj",
+    "start": "Zacznij",
+    "stop": "Zatrzymaj",
+    "save": "Zapisz",
     "unchanged": "Bez Zmian",
     "unknown": "Nieznany"
   },
   "receiveTab": {
-    "title": "Odbieraj",
+    "title": "Odbierz",
     "infoBox": {
       "ip": "IP:",
       "port": "Port:",
@@ -68,10 +68,10 @@
     "title": "Ustawienia",
     "general": {
       "title": "Ogólne",
-      "theme": "Temat",
+      "theme": "Motyw",
       "themeOptions": {
         "system": "System",
-        "dark": "Cziemny",
+        "dark": "Ciemny",
         "light": "Jasny"
       },
       "language": "Język",
@@ -83,7 +83,7 @@
       "launchMinimized": "Autostart: Start ukryty"
     },
     "receive": {
-      "title": "Odbieraj",
+      "title": "Odbierz",
       "quickSave": "@:general.quickSave",
       "destination": "Miejsce docelowe",
       "saveToGallery": "Zapisz multimedia w galerii"
@@ -182,23 +182,23 @@
       "Mądry"
     ],
     "fruits": [
-      "Jabko",
+      "Jabłko",
       "Awokado",
       "Banan",
       "Jeżyna",
       "Jagoda",
-      "Brokuły",
+      "Brokuł",
       "Marchewka",
       "Wiśnia",
       "Kokos",
-      "Winogron",
+      "Winogrono",
       "Cytryna",
       "Sałata",
       "Mango",
       "Melon",
       "Pieczarka",
       "Cebula",
-      "Pomarańcz",
+      "Pomarańcza",
       "Papaja",
       "Brzoskwinia",
       "Gruszka",
@@ -222,7 +222,7 @@
     },
     "cancelSession": {
       "title": "Anuluj transfer plików",
-      "content": "Czy napewno?"
+      "content": "Czy na pewno?"
     },
     "fileNameInput": {
       "title": "Wpisz imię",
@@ -240,7 +240,7 @@
       "title": "Szybkie akcje",
       "counter": "Licznik",
       "prefix": "Prefiks",
-      "padZero": "Podkładka z zerami",
+      "padZero": "Wypchnij zerami",
       "sortBeforeCount": "Wcześniej posortuj alfabetycznie",
       "random": "Losowy"
     },

--- a/assets/i18n/strings_zh-Hant_HK.i18n.json
+++ b/assets/i18n/strings_zh-Hant_HK.i18n.json
@@ -1,0 +1,188 @@
+{
+  "locale": "繁體中文 – 香港",
+  "appName": "LocalSend",
+  "general": {
+    "accept": "接受",
+    "add": "新增",
+    "advanced": "進階",
+    "cancel": "取消",
+    "close": "關閉",
+    "confirm": "確認",
+    "continueStr": "繼續",
+    "copy": "複製",
+    "copiedToClipboard": "已複製到剪貼簿",
+    "decline": "拒絕",
+    "done": "完成",
+    "edit": "編輯",
+    "error": "錯誤",
+    "example": "範例",
+    "files": "檔案",
+    "finished": "已完成",
+    "hide": "隱藏",
+    "off": "閂",
+    "offline": "離線",
+    "on": "開",
+    "online": "線上",
+    "open": "開啟",
+    "queue": "佇列",
+    "quickSave": "快速儲存",
+    "renamed": "改咗名",
+    "reset": "重設",
+    "restart": "重新啟動",
+    "settings": "設定",
+    "skipped": "已跳過",
+    "start": "開始",
+    "stop": "停止",
+    "save": "儲存",
+    "unchanged": "冇改過",
+    "unknown": "未知"
+  },
+  "receiveTab": {
+    "title": "接收",
+    "infoBox": {
+      "ip": "IP：",
+      "port": "埠：",
+      "alias": "別名："
+    }
+  },
+  "sendTab": {
+    "title": "傳送",
+    "selection": {
+      "title": "揀選",
+      "files": "檔案：{files}",
+      "size": "大細：{size}"
+    },
+    "picker": {
+      "file": "檔案",
+      "media": "媒體",
+      "text": "文字"
+    },
+    "shareIntentInfo": "用你裝置嘅「分享」功能以更方便揀選檔案。",
+    "nearbyDevices": "附近裝置",
+    "thisDevice": "此裝置",
+    "scan": "掃描裝置",
+    "help": "請確保目標裝置駁緊同一個 Wi-Fi 網路。",
+    "placeItems": "將要分享嘅檔案拉過嚟呢度"
+  },
+  "settingsTab": {
+    "title": "設定",
+    "general": {
+      "title": "一般",
+      "theme": "主題",
+      "themeOptions": {
+        "system": "跟機",
+        "dark": "暗色",
+        "light": "亮色"
+      },
+      "language": "語言",
+      "languageOptions": {
+        "system": "跟機"
+      },
+      "minimizeToTray": "退出嗰陣縮細做通知圖示",
+      "launchAtStartup": "開機自動啟動",
+      "launchMinimized": "自動啟動成通知圖示"
+    },
+    "receive": {
+      "title": "接收",
+      "quickSave": "@:general.quickSave",
+      "destination": "儲存位置",
+      "saveToGallery": "save 落相簿"
+    },
+    "network": {
+      "title": "網路",
+      "needRestart": "重新啟動伺服器以使設定生效",
+      "server": "伺服器",
+      "alias": "別名",
+      "port": "埠"
+    }
+  },
+  "selectedFilesPage": {
+    "deleteAll": "全部刪除"
+  },
+  "receivePage": {
+    "subTitle": {
+      "one": "想 send 1 個檔案畀你。",
+      "other": "想 send {n} 個檔案畀你。"
+    },
+    "subTitleMessage": "send 咗條訊息畀你：",
+    "subTitleLink": "send 咗條 link 畀你：",
+    "canceled": "對方取消咗個請求。"
+  },
+  "receiveOptionsPage": {
+    "title": "設定",
+    "destination": "@:settingsTab.receive.destination",
+    "appDirectory": "（@:appName 資料夾）"
+  },
+  "sendPage": {
+    "waiting": "等緊回應……",
+    "rejected": "對方拒絕咗個請求。"
+  },
+  "progressPage": {
+    "titleSending": "send 緊……",
+    "titleReceiving": "接收緊……",
+    "savedToGallery": "成功 save 咗落相簿",
+    "total": {
+      "title": {
+        "sending": "進度：{time}",
+        "finishedError": "搞掂，不過有 error",
+        "canceledSender": "傳送者取消咗",
+        "canceledReceiver": "接收者取消咗"
+      },
+      "count": "檔案：{curr} / {n}",
+      "size": "大細：{curr} / {n}",
+      "speed": "速度：{speed}/s"
+    }
+  },
+  "aboutPage": {
+    "title": "關於 LocalSend"
+  },
+  "changelogPage": {
+    "title": "更新記錄"
+  },
+  "aliasGenerator": {
+    "@info": "Uses English version"
+  },
+  "dialogs": {
+    "addFile": {
+      "title": "將檔案加至選擇",
+      "content": "揀選要加入嘅檔案"
+    },
+    "addressInput": {
+      "title": "輸入地址",
+      "hashtag": "Hashtag",
+      "ip": "IP 地址"
+    },
+    "cancelSession": {
+      "title": "取消檔案傳輸",
+      "content": "你係咪要放棄傳輸檔案？"
+    },
+    "fileNameInput": {
+      "title": "輸入檔案名稱",
+      "original": "原名：{original}"
+    },
+    "messageInput": {
+      "title": "輸入訊息",
+      "multiline": "多行"
+    },
+    "noFiles": {
+      "title": "冇揀選檔案",
+      "content": "最少需要揀選一個檔案。"
+    },
+    "quickActions": {
+      "title": "快速動作",
+      "counter": "計數器",
+      "prefix": "前綴",
+      "padZero": "補零",
+      "sortBeforeCount": "事前跟字母排序",
+      "random": "隨機"
+    },
+    "quickSaveNotice": {
+      "title": "@:general.quickSave",
+      "content": "自動接受所有檔案傳輸請求。留意返，噉樣會令呢個網路嘅所有人都 send 得嘢畀你。"
+    }
+  },
+    "tray": {
+    "open": "@:general.open",
+    "close": "退出 LocalSend"
+  }
+}


### PR DESCRIPTION
This pull request adds strings_es-ES.i18n.json file with a translation to Spanish. I think they are mostly correct. However I wasn't able to run the app (Flutter refuses to work for me), so I haven't seen them in context. 
It needs to be noted that the alias generator won't make much sense in Spanish as adjectives change depending on the noun but it's better than nothing.