### PR TITLE
ci: bump Winget Releaser to v2 & add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: LocalSend.LocalSend
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
v2 fixes a critical error in the action: https://github.com/vedantmgoyal2009/winget-releaser/issues/84

Additionally, add Dependabot to bump dependencies automatically.