### PR TITLE
feat: Restore window size and position

### DIFF
--- a/lib/init.dart
+++ b/lib/init.dart
@@ -19,7 +19,6 @@ import 'package:localsend_app/util/platform_check.dart';
 import 'package:localsend_app/util/snackbar.dart';
 import 'package:localsend_app/util/tray_helper.dart';
 import 'package:routerino/routerino.dart';
-import 'package:screen_retriever/screen_retriever.dart';
 import 'package:share_handler/share_handler.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -82,7 +81,9 @@ Future<PersistenceService> preInit(List<String> args) async {
 
     // initialize size and position
     await WindowManager.instance.ensureInitialized();
-    await dimensionsConfiguration(persistenceService);
+
+    await WindowDimensionProvider(persistenceService).dimensionsConfiguration();
+
     if (!args.contains(launchAtStartupArg) || !persistenceService.isAutoStartLaunchMinimized()) {
       // We show this app, when (1) app started manually, (2) app should not start minimized
       // In other words: only start minimized when launched on startup and "launchMinimized" is configured
@@ -93,34 +94,6 @@ Future<PersistenceService> preInit(List<String> args) async {
   return persistenceService;
 }
 
-Future<void> dimensionsConfiguration(PersistenceService persistenceService) async {
-  await WindowManager.instance.setMinimumSize(const Size(400, 500));
-  final primaryDisplay = await ScreenRetriever.instance.getPrimaryDisplay();
-  final width = (primaryDisplay.visibleSize ?? primaryDisplay.size).width;
-  
-  //TODO: Temporary replacement to a settigns toggle
-  //persistenceService.getRememberLastPosition();
-  const rememberLastPosition = true;
-  if (rememberLastPosition) {
-    final dimensions = WindowDimensionProvider(persistenceService).getDimensions();
-    if(dimensions.isEmpty) {
-      await setInitialSize(width);
-    } else {
-      await WindowManager.instance.setPosition(Offset(dimensions[0], dimensions[1]));
-      await WindowManager.instance.setSize(Size(dimensions[2], dimensions[3]));
-    }
-  } else {
-    await setInitialSize(width);
-  }
-}
-
-Future<void> setInitialSize(double width) async {
-  if (width >= 1200) {
-    // make initial window size bigger as our display is big enough
-    await WindowManager.instance.setSize(const Size(900, 600));
-  }
-  await WindowManager.instance.center();
-}
 
 StreamSubscription? _sharedMediaSubscription;
 

--- a/lib/provider/persistence_provider.dart
+++ b/lib/provider/persistence_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -67,11 +68,6 @@ class PersistenceService {
       await prefs.setString(_themeKey, ThemeMode.system.name);
     }
 
-    return PersistenceService._(prefs);
-  }
-
-  static Future<PersistenceService> getPersistence() async {
-    final prefs = await SharedPreferences.getInstance();
     return PersistenceService._(prefs);
   }
 
@@ -217,17 +213,17 @@ class PersistenceService {
     await _prefs.setDouble(_windowWidth, width);
   }
 
-  List<double> getWindowLastDimensions() {
+  Map<OffsetBase, OffsetBase>? getWindowLastDimensions() {
     final offsetX = _prefs.getDouble(_windowOffsetX);
     final offsetY = _prefs.getDouble(_windowOffsetY);
     final width = _prefs.getDouble(_windowWidth);
     final height = _prefs.getDouble(_windowHeight);
-    final positionsArray = [offsetX, offsetY, width, height];
-    final nullValues = positionsArray.any((element) => element == null);
-    if (!nullValues) {
-      return List<double>.unmodifiable(positionsArray);
-    } else {
-      return [];
+    if (offsetX != null && offsetY != null && width != null && height != null) {
+      Size size = Size(width, height);
+      Offset position = Offset(offsetX, offsetY);
+      final dimensions = { size: size, position: position };
+      return dimensions;
     }
+    return null;
   }
 }

--- a/lib/provider/persistence_provider.dart
+++ b/lib/provider/persistence_provider.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -8,6 +7,7 @@ import 'package:localsend_app/constants.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/receive_history_entry.dart';
 import 'package:localsend_app/model/send_mode.dart';
+import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/util/alias_generator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
@@ -213,17 +213,17 @@ class PersistenceService {
     await _prefs.setDouble(_windowWidth, width);
   }
 
-  Map<OffsetBase, OffsetBase>? getWindowLastDimensions() {
+  WindowDimensions getWindowLastDimensions() {
+    Size? size;
+    Offset? position;
     final offsetX = _prefs.getDouble(_windowOffsetX);
     final offsetY = _prefs.getDouble(_windowOffsetY);
     final width = _prefs.getDouble(_windowWidth);
     final height = _prefs.getDouble(_windowHeight);
-    if (offsetX != null && offsetY != null && width != null && height != null) {
-      Size size = Size(width, height);
-      Offset position = Offset(offsetX, offsetY);
-      final dimensions = { size: size, position: position };
-      return dimensions;
-    }
-    return null;
+    if (width != null && height != null) size = Size(width, height);
+    if (offsetX != null && offsetY != null) position = Offset(offsetX, offsetY);
+
+    final dimensions = {size: size, position: position};
+    return dimensions;
   }
 }

--- a/lib/provider/persistence_provider.dart
+++ b/lib/provider/persistence_provider.dart
@@ -21,6 +21,12 @@ const _version = 'ls_version';
 // Received file history
 const _receiveHistory = 'ls_receive_history';
 
+//App Window Offset and Size info
+const _windowOffsetX = 'ls_window_offset_x';
+const _windowOffsetY = 'ls_window_offset_y';
+const _windowWidth = 'ls_window_width';
+const _windowHeight = 'ls_window_height';
+
 // Settings
 const _showToken = 'ls_show_token';
 const _aliasKey = 'ls_alias';
@@ -61,6 +67,11 @@ class PersistenceService {
       await prefs.setString(_themeKey, ThemeMode.system.name);
     }
 
+    return PersistenceService._(prefs);
+  }
+
+  static Future<PersistenceService> getPersistence() async {
+    final prefs = await SharedPreferences.getInstance();
     return PersistenceService._(prefs);
   }
 
@@ -188,5 +199,35 @@ class PersistenceService {
 
   Future<void> setSendMode(SendMode mode) async {
     await _prefs.setString(_sendMode, mode.name);
+  }
+
+  Future<void> setWindowOffsetX(double x) async {
+    await _prefs.setDouble(_windowOffsetX, x);
+  }
+
+  Future<void> setWindowOffsetY(double y) async {
+    await _prefs.setDouble(_windowOffsetY, y);
+  }
+
+  Future<void> setWindowHeight(double height) async {
+    await _prefs.setDouble(_windowHeight, height);
+  }
+
+  Future<void> setWindowWidth(double width) async {
+    await _prefs.setDouble(_windowWidth, width);
+  }
+
+  List<double> getWindowLastDimensions() {
+    final offsetX = _prefs.getDouble(_windowOffsetX);
+    final offsetY = _prefs.getDouble(_windowOffsetY);
+    final width = _prefs.getDouble(_windowWidth);
+    final height = _prefs.getDouble(_windowHeight);
+    final positionsArray = [offsetX, offsetY, width, height];
+    final nullValues = positionsArray.any((element) => element == null);
+    if (!nullValues) {
+      return List<double>.unmodifiable(positionsArray);
+    } else {
+      return [];
+    }
   }
 }

--- a/lib/provider/window_dimensions_provider.dart
+++ b/lib/provider/window_dimensions_provider.dart
@@ -3,11 +3,14 @@ import 'package:localsend_app/provider/persistence_provider.dart';
 import 'package:screen_retriever/screen_retriever.dart';
 import 'package:window_manager/window_manager.dart';
 
+//Records are a better alternative, but they are currently experimental
+typedef WindowDimensions = Map<OffsetBase?, OffsetBase?>?;
+
 class WindowDimensionProvider {
   final PersistenceService service;
   final Size minimalSize = const Size(400, 500);
   final Size defaultSize = const Size(900, 600);
-  Map<OffsetBase, OffsetBase>? currentDimensions = {};
+  WindowDimensions currentDimensions;
 
   WindowDimensionProvider(this.service);
 
@@ -16,7 +19,7 @@ class WindowDimensionProvider {
     final primaryDisplay = await ScreenRetriever.instance.getPrimaryDisplay();
     final hasEnoughWidth = (primaryDisplay.visibleSize ?? primaryDisplay.size).width >= 1200 ? true : false;
     
-    getPersistedDimensions();
+    _getPersistedDimensions();
     final Size? persistedSize = currentDimensions?.entries.first.value as Size?;
     final Offset? persistedOffset = currentDimensions?.entries.last.value as Offset?;
 
@@ -36,7 +39,23 @@ class WindowDimensionProvider {
     ]);
   }
 
-  void getPersistedDimensions() {
+  Future<void> storePosition({ required Offset windowOffset }) async {
+    await Future.wait([
+      service.setWindowOffsetX(windowOffset.dx),
+      service.setWindowOffsetY(windowOffset.dy),
+    ]);
+    _getPersistedDimensions();
+  }
+
+  Future<void> storeSize({ required Size windowSize }) async {
+    await Future.wait([
+      service.setWindowHeight(windowSize.height),
+      service.setWindowWidth(windowSize.width)
+    ]);
+    _getPersistedDimensions();
+  }
+
+  void _getPersistedDimensions() {
      currentDimensions = service.getWindowLastDimensions();
   }
 

--- a/lib/provider/window_dimensions_provider.dart
+++ b/lib/provider/window_dimensions_provider.dart
@@ -1,10 +1,28 @@
 import 'dart:ui';
 import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:screen_retriever/screen_retriever.dart';
+import 'package:window_manager/window_manager.dart';
 
 class WindowDimensionProvider {
   final PersistenceService service;
+  final Size minimalSize = const Size(400, 500);
+  final Size defaultSize = const Size(900, 600);
+  Map<OffsetBase, OffsetBase>? currentDimensions = {};
 
   WindowDimensionProvider(this.service);
+
+  Future<void> dimensionsConfiguration() async {
+    await WindowManager.instance.setMinimumSize(minimalSize);
+    final primaryDisplay = await ScreenRetriever.instance.getPrimaryDisplay();
+    final hasEnoughWidth = (primaryDisplay.visibleSize ?? primaryDisplay.size).width >= 1200 ? true : false;
+    
+    getPersistedDimensions();
+    final Size? persistedSize = currentDimensions?.entries.first.value as Size?;
+    final Offset? persistedOffset = currentDimensions?.entries.last.value as Offset?;
+
+    await WindowManager.instance.setSize(hasEnoughWidth ? persistedSize ?? defaultSize : persistedSize ?? minimalSize);
+    persistedOffset == null ? await WindowManager.instance.center() : await WindowManager.instance.setPosition(persistedOffset);
+  }
 
   Future<void> storeDimensions({
     required Offset windowOffset,
@@ -18,8 +36,8 @@ class WindowDimensionProvider {
     ]);
   }
 
-  List<double> getDimensions() {
-    return service.getWindowLastDimensions();
+  void getPersistedDimensions() {
+     currentDimensions = service.getWindowLastDimensions();
   }
 
 }

--- a/lib/provider/window_dimensions_provider.dart
+++ b/lib/provider/window_dimensions_provider.dart
@@ -1,0 +1,25 @@
+import 'dart:ui';
+import 'package:localsend_app/provider/persistence_provider.dart';
+
+class WindowDimensionProvider {
+  final PersistenceService service;
+
+  WindowDimensionProvider(this.service);
+
+  Future<void> storeDimensions({
+    required Offset windowOffset,
+    required Size windowSize,
+  }) async {
+    await Future.wait([
+      service.setWindowOffsetX(windowOffset.dx),
+      service.setWindowOffsetY(windowOffset.dy),
+      service.setWindowHeight(windowSize.height),
+      service.setWindowWidth(windowSize.width)
+    ]);
+  }
+
+  List<double> getDimensions() {
+    return service.getWindowLastDimensions();
+  }
+
+}

--- a/lib/widget/watcher/window_watcher.dart
+++ b/lib/widget/watcher/window_watcher.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/util/platform_check.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -45,7 +47,11 @@ class _WindowWatcherState extends State<WindowWatcher> with WindowListener {
   }
 
   @override
-  void onWindowClose() {
+  Future<void> onWindowClose() async {
+    PersistenceService persistenceService = await PersistenceService.getPersistence();
+    final windowOffset = await windowManager.getPosition();
+    final windowSize = await windowManager.getSize();
+    await WindowDimensionProvider(persistenceService).storeDimensions(windowOffset: windowOffset, windowSize: windowSize);
     widget.onClose();
   }
 

--- a/lib/widget/watcher/window_watcher.dart
+++ b/lib/widget/watcher/window_watcher.dart
@@ -20,6 +20,10 @@ class WindowWatcher extends ConsumerStatefulWidget {
 }
 
 class _WindowWatcherState extends ConsumerState<WindowWatcher> with WindowListener {
+  WindowDimensionProvider? windowDimensionProvider;
+
+  WindowDimensionProvider _ensureDimensionsProvider() => WindowDimensionProvider(ref.watch(persistenceProvider));
+
   @override
   Widget build(BuildContext context) {
     return widget.child;
@@ -48,11 +52,25 @@ class _WindowWatcherState extends ConsumerState<WindowWatcher> with WindowListen
   }
 
   @override
+  Future<void> onWindowMoved() async {
+    windowDimensionProvider ??= _ensureDimensionsProvider();
+    final windowOffset = await windowManager.getPosition();
+    await windowDimensionProvider?.storePosition(windowOffset: windowOffset);
+  }
+
+  @override
+  Future<void> onWindowResized() async {
+    windowDimensionProvider ??= _ensureDimensionsProvider();
+    final windowSize = await windowManager.getSize();
+    await windowDimensionProvider?.storeSize(windowSize: windowSize);
+  }
+
+  @override
   Future<void> onWindowClose() async {
-    PersistenceService persistenceService = ref.watch(persistenceProvider);
+    windowDimensionProvider ??= _ensureDimensionsProvider();
     final windowOffset = await windowManager.getPosition();
     final windowSize = await windowManager.getSize();
-    await WindowDimensionProvider(persistenceService).storeDimensions(windowOffset: windowOffset, windowSize: windowSize);
+    await windowDimensionProvider?.storeDimensions(windowOffset: windowOffset, windowSize: windowSize);
     widget.onClose();
   }
 

--- a/lib/widget/watcher/window_watcher.dart
+++ b/lib/widget/watcher/window_watcher.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:localsend_app/provider/persistence_provider.dart';
 import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/util/platform_check.dart';
 import 'package:window_manager/window_manager.dart';
 
-class WindowWatcher extends StatefulWidget {
+class WindowWatcher extends ConsumerStatefulWidget {
   final Widget child;
   final VoidCallback onClose;
 
@@ -15,10 +16,10 @@ class WindowWatcher extends StatefulWidget {
   });
 
   @override
-  State<WindowWatcher> createState() => _WindowWatcherState();
+  ConsumerState<WindowWatcher> createState() => _WindowWatcherState();
 }
 
-class _WindowWatcherState extends State<WindowWatcher> with WindowListener {
+class _WindowWatcherState extends ConsumerState<WindowWatcher> with WindowListener {
   @override
   Widget build(BuildContext context) {
     return widget.child;
@@ -48,7 +49,7 @@ class _WindowWatcherState extends State<WindowWatcher> with WindowListener {
 
   @override
   Future<void> onWindowClose() async {
-    PersistenceService persistenceService = await PersistenceService.getPersistence();
+    PersistenceService persistenceService = ref.watch(persistenceProvider);
     final windowOffset = await windowManager.getPosition();
     final windowSize = await windowManager.getSize();
     await WindowDimensionProvider(persistenceService).storeDimensions(windowOffset: windowOffset, windowSize: windowSize);


### PR DESCRIPTION
Initial setup to enable restoring the position and size of the app! 

- Setting up Persistence for the required App Window data ☑
- Changes to `init.dart` ☑
- Interface changes to accommodate the option to allow the feature ☒
- Setting up Persistence for the boolean config value ☒

Currently the information is saved on the window watcher onWindowClose method but, perhaps, some other method would be more suitable.

Solves #296 