### PR TITLE
fix: Alias generation properly localised

### DIFF
--- a/lib/init.dart
+++ b/lib/init.dart
@@ -30,13 +30,6 @@ Future<PersistenceService> preInit(List<String> args) async {
 
   final persistenceService = await PersistenceService.initialize();
 
-  final locale = persistenceService.getLocale();
-  if (locale == null) {
-    LocaleSettings.useDeviceLocale();
-  } else {
-    LocaleSettings.setLocale(locale);
-  }
-
   // Register default plural resolver
   for (final locale in AppLocale.values) {
     if ([AppLocale.en, AppLocale.de].contains(locale)) {

--- a/lib/provider/persistence_provider.dart
+++ b/lib/provider/persistence_provider.dart
@@ -53,6 +53,22 @@ class PersistenceService {
   static Future<PersistenceService> initialize() async {
     final prefs = await SharedPreferences.getInstance();
 
+    //Locale configuration upon persistence initialisation to prevent unlocalised Alias generation
+    final persistedLocale = prefs.getString(_localeKey);
+    late AppLocale? currentLocale;
+    if (persistedLocale == null) {
+      currentLocale = LocaleSettings.useDeviceLocale();
+    } else {
+      currentLocale = AppLocale.values.firstWhereOrNull((locale) => locale.languageTag == persistedLocale);
+    }
+
+    if(currentLocale != null) {
+      LocaleSettings.setLocale(currentLocale);
+      if(persistedLocale == null) {
+        await prefs.setString(_localeKey, currentLocale.languageTag);
+      }
+    }
+
     if (prefs.getInt(_version) == null) {
       await prefs.setInt(_version, 1);
     }


### PR DESCRIPTION
I noticed the Alias generation function was called before the actual locale info being set, thus the app was never aware the of the language it should generate the Alias, but with this fix it works fine!

![image](https://user-images.githubusercontent.com/39922116/229265502-0b999884-638c-450f-a193-e73de14212b5.png)
