### PR TITLE
avoid creating text files when sending simple text links or messages

### DIFF
--- a/lib/init.dart
+++ b/lib/init.dart
@@ -144,7 +144,7 @@ Future<void> postInit(BuildContext context, WidgetRef ref, bool appStart, void F
 Future<void> _handleSharedIntent(SharedMedia payload, WidgetRef ref) async {
   final message = payload.content;
   if (message != null && message.trim().isNotEmpty) {
-    ref.read(selectedSendingFilesProvider.notifier).addMessage(message);
+    ref.read(selectedSendingFilesProvider.notifier).addPlainTextMessage(message);
   }
   await ref.read(selectedSendingFilesProvider.notifier).addFiles(
         files: payload.attachments?.where((a) => a != null).cast<SharedAttachment>() ?? <SharedAttachment>[],

--- a/lib/model/file_type.dart
+++ b/lib/model/file_type.dart
@@ -8,7 +8,9 @@ enum FileType {
   pdf(Icons.description),
   text(Icons.subject),
   apk(Icons.android),
-  other(Icons.file_present_sharp);
+  other(Icons.file_present_sharp),
+  utf8Raw(Icons.subject)
+  ;
 
   const FileType(this.icon);
 

--- a/lib/model/state/server/receive_session_state.dart
+++ b/lib/model/state/server/receive_session_state.dart
@@ -30,6 +30,6 @@ class ReceiveSessionState with _$ReceiveSessionState {
   /// Message requests must contain a single text file with preview included.
   String? get message {
     final firstFile = files.values.first.file;
-    return files.length == 1 && firstFile.fileType == FileType.text ? firstFile.preview : null;
+    return files.length == 1 && (file.fileType == FileType.text || file.fileType == FileType.utf8Raw) ? firstFile.preview : null;
   }
 }

--- a/lib/model/state/server/receive_session_state.dart
+++ b/lib/model/state/server/receive_session_state.dart
@@ -30,6 +30,6 @@ class ReceiveSessionState with _$ReceiveSessionState {
   /// Message requests must contain a single text file with preview included.
   String? get message {
     final firstFile = files.values.first.file;
-    return files.length == 1 && (file.fileType == FileType.text || file.fileType == FileType.utf8Raw) ? firstFile.preview : null;
+    return files.length == 1 && (firstFile.fileType == FileType.text || firstFile.fileType == FileType.utf8Raw) ? firstFile.preview : null;
   }
 }

--- a/lib/pages/selected_files_page.dart
+++ b/lib/pages/selected_files_page.dart
@@ -52,7 +52,7 @@ class SelectedFilesPage extends ConsumerWidget {
           ...selectedFiles.mapIndexed(
             (index, file) {
               final String? message;
-              if (file.fileType == FileType.text && file.bytes != null) {
+              if ((file.fileType == FileType.text || file.fileType == FileType.utf8Raw) && file.bytes != null) {
                 message = utf8.decode(file.bytes!);
               } else {
                 message = null;
@@ -87,7 +87,7 @@ class SelectedFilesPage extends ConsumerWidget {
                               ],
                             ),
                           ),
-                          if (file.fileType == FileType.text && file.bytes != null)
+                          if ((file.fileType == FileType.text || file.fileType == FileType.utf8Raw) && file.bytes != null)
                             TextButton(
                               style: TextButton.styleFrom(
                                 foregroundColor: Theme.of(context).colorScheme.onSurface,
@@ -96,7 +96,7 @@ class SelectedFilesPage extends ConsumerWidget {
                                 final result = await showDialog<String>(context: context, builder: (_) => MessageInputDialog(initialText: message));
                                 if (result != null) {
                                   ref.read(selectedSendingFilesProvider.notifier).removeAt(index);
-                                  ref.read(selectedSendingFilesProvider.notifier).addMessage(result, index: index);
+                                  ref.read(selectedSendingFilesProvider.notifier).addPlainTextMessage(result, index: index);
                                 }
                               },
                               child: const Icon(Icons.edit),

--- a/lib/provider/network/send_provider.dart
+++ b/lib/provider/network/send_provider.dart
@@ -71,7 +71,7 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
               fileName: file.name,
               size: file.size,
               fileType: file.fileType,
-              preview: files.length == 1 && (file.fileType == FileType.text || file.fileType == FileType.utf8Raw) && files.first.bytes != null
+              preview: files.length == 1 && (files.first.fileType == FileType.text || files.first.fileType == FileType.utf8Raw) && files.first.bytes != null
                   ? utf8.decode(files.first.bytes!) // send simple message by embedding it into the preview
                   : null,
             ),

--- a/lib/provider/network/send_provider.dart
+++ b/lib/provider/network/send_provider.dart
@@ -71,7 +71,7 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
               fileName: file.name,
               size: file.size,
               fileType: file.fileType,
-              preview: files.length == 1 && files.first.fileType == FileType.text && files.first.bytes != null
+              preview: files.length == 1 && (file.fileType == FileType.text || file.fileType == FileType.utf8Raw) && files.first.bytes != null
                   ? utf8.decode(files.first.bytes!) // send simple message by embedding it into the preview
                   : null,
             ),

--- a/lib/provider/selection/selected_sending_files_provider.dart
+++ b/lib/provider/selection/selected_sending_files_provider.dart
@@ -33,11 +33,22 @@ class SelectedSendingFilesNotifier extends Notifier<List<CrossFile>> {
 
   /// Add a simple message
   /// Internally, the message will be stored into [CrossFile.bytes] as UTF-8
-  void addMessage(String message, {int? index}) {
+  void addPlainTextMessage(String message, {bool? sendAsTxtFile, int? index}) {
     final List<int> bytes = utf8.encode(message);
+
+    String fileName = message;
+    FileType fileType = FileType.utf8Raw;
+
+    // If we elect to send a plain text message as a file (perhaps if the content is too long over X characters) 
+    // we'll generate a filename for this file.
+    if (sendAsTxtFile ?? false) {
+      fileName = '${_uuid.v4()}.txt';
+      fileType = FileType.text;
+    }
+
     final file = CrossFile(
-      name: '${_uuid.v4()}.txt',
-      fileType: FileType.text,
+      name: fileName,
+      fileType: fileType,
       size: bytes.length,
       thumbnail: null,
       asset: null,

--- a/lib/util/native/file_picker.dart
+++ b/lib/util/native/file_picker.dart
@@ -119,7 +119,7 @@ enum FilePickerOption {
       case FilePickerOption.text:
         final result = await showDialog<String>(context: context, builder: (_) => const MessageInputDialog());
         if (result != null) {
-          ref.read(selectedSendingFilesProvider.notifier).addMessage(result);
+          ref.read(selectedSendingFilesProvider.notifier).addPlainTextMessage(result);
         }
         break;
       case FilePickerOption.app:


### PR DESCRIPTION
Transfer text as text instead of text files. Perhaps we can decide on a character count at which point text will be sent as a .txt file (perhaps > 4000 characters similar to discord), otherwise send the message as plain text.

Will open later PR's for refactoring the way the history/receive page looks. Also will add support for one click opening links if a url is detected in plain text message