### PR TITLE
fix: typo error (MacOS -> macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Links: [Homepage](https://localsend.org)
 - [Building](#building)
   - [Android](#android)
   - [iOS](#ios)
-  - [MacOS](#macos)
+  - [macOS](#macos)
   - [Windows](#windows)
   - [Linux](#linux)
 
@@ -111,7 +111,7 @@ flutter build appbundle
 flutter build ipa
 ```
 
-### MacOS
+### macOS
 
 ```bash
 flutter build macos

--- a/lib/util/native/device_info_helper.dart
+++ b/lib/util/native/device_info_helper.dart
@@ -47,7 +47,7 @@ Future<DeviceInfoResult> getDeviceInfo() async {
         deviceModel = 'Linux';
         break;
       case TargetPlatform.macOS:
-        deviceModel = 'MacOS';
+        deviceModel = 'macOS';
         break;
       case TargetPlatform.windows:
         deviceModel = 'Windows';

--- a/lib/util/platform_strings.dart
+++ b/lib/util/platform_strings.dart
@@ -12,7 +12,7 @@ extension TargetPlatformExt on TargetPlatform {
       case TargetPlatform.linux:
         return 'Linux';
       case TargetPlatform.macOS:
-        return 'MacOS';
+        return 'macOS';
       case TargetPlatform.windows:
         return 'Windows';
     }


### PR DESCRIPTION
![CleanShot 2023-04-06 at 13 37 38@2x](https://user-images.githubusercontent.com/3842474/230281467-bf3a4a44-02d3-4899-b5f2-6e2ab3f8905d.png)

source: https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html