### PR TITLE
Web UI styles added and small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can help translating this app to other languages!
 ### Bug fixes and improvements
 
 - **Bug Fixes:** If you find a bug, please create a pull request with a clear description of the issue and how to fix it.
-- **Improvements:** Have an idea for how to improve LocalSend? Please create an issue first so we can discuss why the improvement is needed.
+- **Improvements:** Have an idea for how to improve LocalSend? Please create an issue first, so we can discuss why the improvement is needed.
 
 For more information, see the [contributing guide](https://github.com/localsend/localsend/blob/main/CONTRIBUTING.md).
 
@@ -175,6 +175,6 @@ Feel free to open a pull request. There is a `snap` branch to play with.
 
 ## Contributors
 
-<a align="center" href="https://github.com/localsend/localsend/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=localsend/localsend" />
+<a href="https://github.com/localsend/localsend/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=localsend/localsend"  alt="Localsend Contributors"/>
 </a>

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -6,21 +6,161 @@
     <title>LocalSend</title>
     <script src="main.js"></script>
     <style>
-        table, th, td {
-            border: 1px solid black;
-            border-collapse: collapse;
+        :root {
+            --gray: rgba(236, 240, 241, 1);
+            --black: rgba(38, 38, 38, 1);
+            --teal: rgba(0, 150, 136, 1);
+            --p-1: 1rem;
+            --p-2: 2rem;
         }
 
-        th, td {
-            padding: 10px;
+        html {
+            font-family: sans-serif, system-ui;
+            color: var(--black);
+            height: 100%;
+            font-size: 16px;
         }
 
-        .size-cell {
-            white-space: nowrap;
+        body {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+            line-height: 1.5;
+            align-items: center;
         }
 
         a {
             text-decoration: none;
+        }
+
+        a:link {
+            color: blue;
+        }
+
+        *,
+        *::before,
+        *::after {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+            font-family: inherit;
+            border: 0;
+            outline: 0;
+            color: inherit;
+        }
+
+        #file-list {
+            padding: var(--p-2);
+            width: fit-content;;
+        }
+
+        .size-cell {
+            background-color: var(--teal);
+            white-space: nowrap;
+        }
+
+        .filesTable {
+            border-collapse: collapse;
+            width: 100%;
+            border: 1px solid;
+        }
+
+        .filesTable tr th {
+            padding: 5px;
+        }
+
+
+        .filesTable tr td {
+            padding: 5px;
+            text-align: center;
+            font-weight: 500;
+            word-wrap: break-word;
+            max-width: 75vw;
+        }
+
+        .filesTable tr th:not(:first-of-type) {
+            width: calc(100% / 8);
+        }
+
+        .filesTable tbody tr:nth-of-type(2n + 2) {
+            background-color: var(--gray);
+        }
+
+        @media (max-width: 1124px) {
+            #file-list  {
+                width: 100%;
+            }
+
+            .filesTable {
+                margin-left: -10px;
+                border: 0;
+            }
+
+            .filesTable thead {
+                display: none;
+            }
+
+            .filesTable tbody {
+                display: flex;
+                flex-wrap: wrap;
+            }
+
+            .filesTable tbody tr {
+                display: flex;
+                flex-direction: column;
+                margin-top: 10px;
+                width: calc(50% - 10px);
+                margin-left: 10px;
+            }
+
+            .filesTable tr {
+                border-radius: 5px !important;
+            }
+
+            .filesTable tr td {
+                border: 1px solid var(--gray);
+            }
+
+            .filesTable tbody tr td {
+                padding: 5px 10px !important;
+                text-align: right !important;
+                position: relative;
+            }
+
+            .filesTable tbody tr td:before {
+                position: absolute;
+                left: 5px;
+                content: "";
+                width: 100px;
+                height: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                top: 0;
+                background-repeat: no-repeat;
+                background-size: contain;
+                background-position: left;
+            }
+
+            .filesTable tbody tr:nth-of-type(2n + 2) {
+                background-color: transparent;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .filesTable {
+                margin-left: 0;
+                border: 0;
+            }
+
+            .filesTable tr td {
+                max-width: 90vw;
+            }
+
+            .filesTable tbody tr {
+                width: 100%;
+                margin-left: 0;
+            }
         }
     </style>
 </head>
@@ -29,7 +169,7 @@
     This site requires JavaScript. I will only be visible if you have it disabled.
 </noscript>
 
-<h1>LocalSend</h1>
+<h1 style="padding: var(--p-1)">LocalSend</h1>
 <p id="status-text"></p>
 
 <div id="file-list"></div>

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -7,9 +7,9 @@
     <script src="main.js"></script>
     <style>
         :root {
-            --gray: rgba(236, 240, 241, 1);
-            --black: rgba(38, 38, 38, 1);
-            --teal: rgba(0, 150, 136, 1);
+            --gray: rgb(236, 240, 241);
+            --black: rgb(38, 38, 38);
+            --teal: rgb(38,166,154);
             --p-1: 1rem;
             --p-2: 2rem;
         }
@@ -51,7 +51,8 @@
 
         #file-list {
             padding: var(--p-2);
-            width: fit-content;;
+            min-width: 50vw;
+            width: fit-content;
         }
 
         .size-cell {
@@ -96,6 +97,14 @@
                 border: 0;
             }
 
+            a::after {
+                content: "(" attr(sizeData) ")";
+            }
+
+            .size-cell {
+                display: none;
+            }
+
             .filesTable thead {
                 display: none;
             }
@@ -125,6 +134,7 @@
                 padding: 5px 10px !important;
                 text-align: right !important;
                 position: relative;
+                height: 100%;
             }
 
             .filesTable tbody tr td:before {

--- a/assets/web/main.js
+++ b/assets/web/main.js
@@ -26,11 +26,11 @@ async function requestFiles() {
   document.getElementById('status-text').innerText = `${i18n.files} (${Object.keys(data.files).length})`;
 
   document.getElementById('file-list').innerHTML = `
-    <table>
+    <table class="filesTable">
       <thead>
         <tr>
           <th>${i18n.fileName}</th>
-          <th>${i18n.size}</th>
+          <th class="size-cell">${i18n.size}</th>
         </tr>
       </thead>
       <tbody>

--- a/assets/web/main.js
+++ b/assets/web/main.js
@@ -37,7 +37,7 @@ async function requestFiles() {
         ${Object.keys(files).map((key) => `
           <tr>
             <td>
-              <a href="${BASE_URL}/receive?sessionId=${sessionId}&fileId=${key}" target="_blank">
+              <a sizeData="${formatBytes(files[key].size)}" href="${BASE_URL}/receive?sessionId=${sessionId}&fileId=${key}" target="_blank">
                 ${files[key].fileName}
               </a>
             </td>

--- a/lib/util/user_agent_analyzer.dart
+++ b/lib/util/user_agent_analyzer.dart
@@ -22,15 +22,15 @@ class UserAgentAnalyzer {
 
   String? getOS(String userAgent) {
     print(userAgent);
-    if (userAgent.contains("Windows")) {
+    if (userAgent.contains("Win")) {
       return "Windows";
     } else if (userAgent.contains("Android")) {
       return "Android";
-    } else if (userAgent.contains("Macintosh") || userAgent.contains("Mac OS")) {
+    } else if (userAgent.contains("Macintosh")) {
       return "macOS";
     } else if (userAgent.contains("iPhone") || userAgent.contains("iPad") || userAgent.contains("iPod")) {
       return "iOS";
-    } else if (userAgent.contains("Linux")) {
+    } else if (userAgent.contains("X11")) {
       return "Linux";
     } else {
       return null;


### PR DESCRIPTION
#### Responsive styling for the Web sharing UI
 
<img src="https://user-images.githubusercontent.com/39922116/232408579-d8c16fa3-3e83-4739-9021-e3414ac06704.png" width="650" />

<img src="https://user-images.githubusercontent.com/39922116/232408967-f653a364-3c52-45cf-8c0f-719e99bc06da.png" width="650" />

#### So far only the Teal color has been used from Localsend's color palette, but the page could incorporate more from it. Also, the styles could be split to a separate file, if necessary.

Other Changes: 

```javascript
	// Looking for "Win" can match with Windows, Win64 or Win32. 
	if (userAgent.contains("Windows")) {
    if (userAgent.contains("Win")) {
	
	// iOS userAgent also contains Mac OS, example: 
	// Mozilla/5.0 (iPhone13,2; U; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/15E148 Safari/602.1
    } else if (userAgent.contains("Macintosh") || userAgent.contains("Mac OS")) {
    } else if (userAgent.contains("Macintosh")) {

	// Using "X11" ensures it is a Linux desktop and not a potential variant, like Android.
    } else if (userAgent.contains("Linux")) {
    } else if (userAgent.contains("X11"))

``` 
