### PR TITLE
Receive options dropdown resized

### DIFF
--- a/lib/pages/receive_options_page.dart
+++ b/lib/pages/receive_options_page.dart
@@ -62,7 +62,7 @@ class ReceiveOptionsPage extends ConsumerWidget {
                 Row(
                   children: [
                     SizedBox(
-                      width: 100,
+                      width: 125,
                       child: CustomDropdownButton<bool>(
                         value: receiveSession.saveToGallery,
                         items: [false, true].map((b) {

--- a/lib/pages/receive_options_page.dart
+++ b/lib/pages/receive_options_page.dart
@@ -62,7 +62,7 @@ class ReceiveOptionsPage extends ConsumerWidget {
                 Row(
                   children: [
                     SizedBox(
-                      width: 125,
+                      width: 100 + (t.general.off.length * 2),
                       child: CustomDropdownButton<bool>(
                         value: receiveSession.saveToGallery,
                         items: [false, true].map((b) {


### PR DESCRIPTION
#### Change to better accommodate longer lenghts of text

![image](https://user-images.githubusercontent.com/39922116/232737183-cccc90dd-5eed-4af3-a9db-016a7c05bc79.png)

![image](https://user-images.githubusercontent.com/39922116/232737245-a32894fc-0d20-487c-8509-b14ab3fcfd73.png)

#### Used the ` t.general.off.length ` because it looks to be the consistently lengthier across languages 