### PR TITLE
i18n: Update missing ko locale

### DIFF
--- a/assets/i18n/_missing_translations_ko.json
+++ b/assets/i18n/_missing_translations_ko.json
@@ -4,159 +4,159 @@
     "After editing this file, you can run 'flutter pub run slang apply --locale=ko' to quickly apply the newly added translations."
   ],
   "general": {
-    "accepted": "Accepted"
+    "accepted": "수락됨"
   },
   "sendTab": {
     "picker": {
-      "folder": "Folder",
-      "app": "App"
+      "folder": "폴더",
+      "app": "앱"
     },
-    "sendMode": "Send mode",
+    "sendMode": "전송 모드",
     "sendModes": {
-      "single": "Single recipient",
-      "multiple": "Multiple recipients",
-      "link": "Share via link"
+      "single": "단일 수신자",
+      "multiple": "다중 수신자",
+      "link": "링크로 공유하기"
     },
-    "sendModeHelp": "Explanation"
+    "sendModeHelp": "설명"
   },
   "settingsTab": {
     "general": {
-      "saveWindowPlacement": "Quit: Save window placement"
+      "saveWindowPlacement": "종료: 화면 위치 저장하기"
     },
     "receive": {
-      "downloads": "(Downloads)"
+      "downloads": "(다운로드 폴더)"
     },
     "network": {
-      "multicastGroup": "Multicast",
-      "multicastGroupWarning": "You might not be detected by other devices because you are using a custom multicast address. (default: {defaultMulticast})"
+      "multicastGroup": "멀티캐스트",
+      "multicastGroupWarning": "사용자 지정 멀티캐스트 주소를 사용하고 있기 때문에 다른 기기에서 감지되지 않을 수 있습니다. (기본값: {defaultMulticast})"
     }
   },
   "troubleshootPage": {
-    "title": "Troubleshoot",
-    "subTitle": "This app does not work as expected? Here you can find common solutions.",
-    "solution": "Solution:",
-    "fixButton": "Fix automatically",
+    "title": "문제해결",
+    "subTitle": "이 앱이 예상대로 작동하지 않나요? 여기에서 일반적인 해결 방법을 찾을 수 있습니다.",
+    "solution": "해결방법:",
+    "fixButton": "자동으로 수정하기",
     "firewall": {
-      "symptom": "This app can send files to other devices but other devices cannot send files to this device.",
-      "solution": "This is most likely a firewall issue. You can solve this by allowing incoming connections (UDP and TCP) on port {port}.",
-      "openFirewall": "Open Firewall"
+      "symptom": "이 앱은 다른 기기로 파일을 보낼 수 있지만, 다른 기기에서 이 기기로 파일을 보낼 수 없습니다.",
+      "solution": "방화벽 설정 때문일 가능성이 높습니다. {port} 포트로 들어오는 연결(UDP 및 TCP)을 허용하여 이 문제를 해결할 수 있습니다.",
+      "openFirewall": "방화벽 열기"
     },
     "noConnection": {
-      "symptom": "Both devices cannot discover each other nor can they share files.",
-      "solution": "The problem exists on both sides? Then you need to make sure that both devices are in the same wifi network and share the same configuration (port, multicast address, encryption). The wifi may not allow communication between participants. In this case, this option must be enabled on the router."
+      "symptom": "두 기기 모두 서로를 검색하거나 파일을 공유할 수 없습니다.",
+      "solution": "양쪽 모두에 문제가 있나요? 두 기기가 동일한 Wi-Fi 네트워크에 연결되어 있고 동일한 구성 (포트, 멀티캐스트 주소, 암호화)를 공유하는지 확인해야 합니다. Wi-Fi가 참가자 간 통신을 허용하지 않을 수도 있습니다. 이 경우 라우터에서 해당 옵션을 활성화해야 합니다."
     }
   },
   "receiveHistoryPage": {
-    "title": "History",
-    "openFolder": "Open folder",
-    "deleteHistory": "Delete history",
-    "empty": "The history is empty.",
+    "title": "전송 기록",
+    "openFolder": "폴더 열기",
+    "deleteHistory": "기록 삭제",
+    "empty": "전송 기록이 비어 있습니다.",
     "entryActions": {
-      "open": "Open file",
-      "info": "Information",
-      "deleteFromHistory": "Delete from history"
+      "open": "파일 열기",
+      "info": "정보",
+      "deleteFromHistory": "기록에서 삭제"
     }
   },
   "apkPickerPage": {
-    "title": "Apps (APK)",
-    "excludeSystemApps": "Exclude system apps",
-    "excludeAppsWithoutLaunchIntent": "Exclude non-launchable apps",
-    "apps": "{n} Apps"
+    "title": "앱 (APK)",
+    "excludeSystemApps": "시스템 앱 제외",
+    "excludeAppsWithoutLaunchIntent": "실행할 수 없는 앱 제외",
+    "apps": "{n} 개의 앱"
   },
   "receiveOptionsPage": {
     "saveToGallery": "@:settingsTab.receive.saveToGallery",
-    "saveToGalleryOff": "Turned off automatically because there are directories."
+    "saveToGalleryOff": "디렉토리가 있어 자동으로 꺼집니다."
   },
   "sendPage": {
-    "busy": "The recipient is busy with another request."
+    "busy": "수신자가 다른 요청으로 바쁩니다."
   },
   "webSharePage": {
-    "title": "Share via link",
-    "loading": "Starting server...",
-    "stopping": "Stopping server...",
-    "error": "An error occurred while starting the server.",
-    "hint": "Keep in mind that the connection is unencrypted. You should only use this method if the recipient has not LocalSend installed.",
+    "title": "링크로 공유하기",
+    "loading": "서버 시작 중...",
+    "stopping": "서버 중지 중...",
+    "error": "서버 시작 중 오류가 발생했습니다.",
+    "hint": "연결이 암호화되지 않는다는 점에 주의해주세요. 이 방법은 수신자가 LocalSend를 설치하지 않은 경우에만 사용해야 합니다.",
     "openLink": {
-      "one": "Open this link in the browser:",
-      "other": "Open one of these links in the browser:"
+      "one": "이 링크를 브라우저에서 열기:",
+      "other": "이 중 하나의 링크를 브라우저에서 열기:"
     },
-    "requests": "Requests",
-    "noRequests": "No requests yet.",
-    "pendingRequests": "Pending requests: {n}"
+    "requests": "요청",
+    "noRequests": "아직 요청이 없습니다.",
+    "pendingRequests": "대기중인 요청: {n}"
   },
   "dialogs": {
     "addressInput": {
-      "recentlyUsed": "Recently used: "
+      "recentlyUsed": "최근 사용된 주소: "
     },
     "cannotOpenFile": {
-      "title": "Cannot open file",
-      "content": "Could not open \"{file}\". Has this file been moved, renamed or deleted?"
+      "title": "파일을 열 수 없음",
+      "content": "\"{file}\"을 열 수 없습니다. 파일이 이동, 이름 변경 또는 삭제 되었는지 확인해주세요."
     },
     "errorDialog": {
       "title": "@:general.error"
     },
     "fileInfo": {
-      "title": "File information",
-      "fileName": "File name:",
-      "path": "Path:",
-      "size": "Size:",
-      "sender": "Sender:",
-      "time": "Time:"
+      "title": "파일 정보",
+      "fileName": "파일 이름:",
+      "path": "경로:",
+      "size": "크기:",
+      "sender": "보낸 사람:",
+      "time": "시간:"
     },
     "localNetworkUnauthorized": {
-      "title": "No permission",
-      "description": "LocalSend can't find other devices without having the permission to scan the local network. Please grant this permission in the settings.",
-      "gotoSettings": "Settings"
+      "title": "권한 없음",
+      "description": "로컬 네트워크를 스캔할 권한이 없어 LocalSend가 다른 기기를 찾을 수 없습니다. 설정에서 권한을 부여해주세요.",
+      "gotoSettings": "설정"
     },
     "notAvailableOnPlatform": {
-      "title": "Not available",
-      "content": "This feature is only available on:"
+      "title": "사용 불가",
+      "content": "이 기능은 다음 플랫폼에서만 사용 가능합니다:"
     },
     "qr": {
-      "title": "QR Code"
+      "title": "QR 코드"
     },
     "sendModeHelp": {
-      "title": "Send modes",
-      "single": "Sends files to one recipient. Selection will be cleared after finished file transfer.",
-      "multiple": "Sends files to multiple recipients. Selection will not be cleared.",
-      "link": "Recipients who do not have LocalSend installed can download the selected files by opening the link in their browser."
+      "title": "전송 모드",
+      "single": "파일을 한 명의 수신자에게 보냅니다. 파일 전송이 완료되면 선택이 지워집니다.",
+      "multiple": "파일을 여러 명의 수신자에게 보냅니다. 선택이 지워지지 않습니다.",
+      "link": "LocalSend를 설치하지 않은 수신자는 브라우저에서 링크를 열어 선택한 파일을 다운로드할 수 있습니다."
     }
   },
   "web": {
     "waiting": "@:sendPage.waiting",
-    "rejected": "Rejected",
-    "files": "Files",
-    "fileName": "File name",
-    "size": "Size"
+    "rejected": "거부됨",
+    "files": "파일",
+    "fileName": "파일 이름",
+    "size": "크기"
   },
   "assetPicker": {
-    "confirm": "Confirm",
-    "cancel": "Cancel",
-    "edit": "Edit",
+    "confirm": "확인",
+    "cancel": "취소",
+    "edit": "편집",
     "gifIndicator": "GIF",
-    "loadFailed": "Load failed",
-    "original": "Origin",
-    "preview": "Preview",
-    "select": "Select",
-    "emptyList": "Empty list",
-    "unSupportedAssetType": "Unsupported file type.",
-    "unableToAccessAll": "Unable to access all files on the device",
-    "viewingLimitedAssetsTip": "Only view files and albums accessible to the app.",
-    "changeAccessibleLimitedAssets": "Click to update accessible files",
-    "accessAllTip": "App can only access some files on the device. Go to system settings and allow the app to access all media on the device.",
-    "goToSystemSettings": "Go to system settings",
-    "accessLimitedAssets": "Continue with limited access",
-    "accessiblePathName": "Accessible files",
-    "sTypeAudioLabel": "Audio",
-    "sTypeImageLabel": "Image",
-    "sTypeVideoLabel": "Video",
-    "sTypeOtherLabel": "Other media",
-    "sActionPlayHint": "play",
-    "sActionPreviewHint": "preview",
-    "sActionSelectHint": "select",
-    "sActionSwitchPathLabel": "change path",
-    "sActionUseCameraHint": "use camera",
-    "sNameDurationLabel": "duration",
-    "sUnitAssetCountLabel": "count"
+    "loadFailed": "로드 실패",
+    "original": "원본",
+    "preview": "미리보기",
+    "select": "선택",
+    "emptyList": "목록이 비어있음",
+    "unSupportedAssetType": "지원하지 않는 파일 유형입니다.",
+    "unableToAccessAll": "기기의 모든 파일에 접근할 수 없습니다.",
+    "viewingLimitedAssetsTip": "앱에서 접근 가능한 파일과 앨범만 볼 수 있습니다.",
+    "changeAccessibleLimitedAssets": "접근 가능한 파일을 업데이트하려면 클릭하세요.",
+    "accessAllTip": "앱은 기기의 일부 파일에만 접근할 수 있습니다. 시스템 설정으로 이동하여 앱이 기기의 모든 미디어에 액세스할 수 있도록 허용하세요.",
+    "goToSystemSettings": "시스템 설정으로 이동",
+    "accessLimitedAssets": "제한된 접근으로 계속하기",
+    "accessiblePathName": "접근 가능한 파일",
+    "sTypeAudioLabel": "오디오",
+    "sTypeImageLabel": "이미지",
+    "sTypeVideoLabel": "비디오",
+    "sTypeOtherLabel": "기타 미디어",
+    "sActionPlayHint": "재생",
+    "sActionPreviewHint": "미리보기",
+    "sActionSelectHint": "선택",
+    "sActionSwitchPathLabel": "경로 변경",
+    "sActionUseCameraHint": "카메라 사용",
+    "sNameDurationLabel": "길이",
+    "sUnitAssetCountLabel": "개수"
   }
 }

--- a/assets/i18n/strings_ko.i18n.json
+++ b/assets/i18n/strings_ko.i18n.json
@@ -3,6 +3,7 @@
   "appName": "LocalSend",
   "general": {
     "accept": "수락",
+    "accepted": "수락됨",
     "add": "추가",
     "advanced": "상세",
     "cancel": "취소",
@@ -54,13 +55,22 @@
     },
     "picker": {
       "file": "파일",
+      "folder": "폴더",
       "media": "미디어",
-      "text": "텍스트"
+      "text": "텍스트",
+      "app": "앱"
     },
     "shareIntentInfo": "휴대전화의 '공유' 기능을 사용하면 보다 편리하게 파일을 선택할 수 있습니다",
     "nearbyDevices": "근처의 기기",
     "thisDevice": "이 기기",
     "scan": "기기를 검색하는 중",
+    "sendMode": "전송 모드",
+    "sendModes": {
+      "single": "단일 수신자",
+      "multiple": "다중 수신자",
+      "link": "링크로 공유하기"
+    },
+    "sendModeHelp": "설명",
     "help": "보낼 기기가 같은 Wi-Fi 네트워크에 연결되었는지 확인해주세요",
     "placeItems": "드롭해서 공유"
   },
@@ -78,6 +88,7 @@
       "languageOptions": {
         "system": "시스템"
       },
+      "saveWindowPlacement": "종료: 화면 위치 저장하기",
       "minimizeToTray": "종료 시 시스템 트레이로 최소화",
       "launchAtStartup": "로그인 시 자동으로 시작",
       "launchMinimized": "최소화된 상태로 시작"
@@ -86,6 +97,7 @@
       "title": "수신",
       "quickSave": "@:general.quickSave",
       "destination": "저장 위치",
+      "downloads": "(다운로드 폴더)",
       "saveToGallery": "미디어를 갤러리에 저장"
     },
     "network": {
@@ -95,8 +107,42 @@
       "alias": "별명",
       "port": "포트",
       "portWarning": "커스텀 포트를 사용하면 이 디바이스가 다른 장치에서 감지되지 않을 수 있습니다. (기본값: {defaultPort})",
-      "encryption": "암호화"
+      "encryption": "암호화",
+      "multicastGroup": "멀티캐스트",
+      "multicastGroupWarning": "사용자 지정 멀티캐스트 주소를 사용하고 있기 때문에 다른 기기에서 감지되지 않을 수 있습니다. (기본값: {defaultMulticast})"
     }
+  },
+  "troubleshootPage": {
+    "title": "문제해결",
+    "subTitle": "이 앱이 예상대로 작동하지 않나요? 여기에서 일반적인 해결 방법을 찾을 수 있습니다.",
+    "solution": "해결방법:",
+    "fixButton": "자동으로 수정하기",
+    "firewall": {
+      "symptom": "이 앱은 다른 기기로 파일을 보낼 수 있지만, 다른 기기에서 이 기기로 파일을 보낼 수 없습니다.",
+      "solution": "방화벽 설정 때문일 가능성이 높습니다. {port} 포트로 들어오는 연결(UDP 및 TCP)을 허용하여 이 문제를 해결할 수 있습니다.",
+      "openFirewall": "방화벽 열기"
+    },
+    "noConnection": {
+      "symptom": "두 기기 모두 서로를 검색하거나 파일을 공유할 수 없습니다.",
+      "solution": "양쪽 모두에 문제가 있나요? 두 기기가 동일한 Wi-Fi 네트워크에 연결되어 있고 동일한 구성 (포트, 멀티캐스트 주소, 암호화)를 공유하는지 확인해야 합니다. Wi-Fi가 참가자 간 통신을 허용하지 않을 수도 있습니다. 이 경우 라우터에서 해당 옵션을 활성화해야 합니다."
+    }
+  },
+  "receiveHistoryPage": {
+    "title": "전송 기록",
+    "openFolder": "폴더 열기",
+    "deleteHistory": "기록 삭제",
+    "empty": "전송 기록이 비어 있습니다.",
+    "entryActions": {
+      "open": "파일 열기",
+      "info": "정보",
+      "deleteFromHistory": "기록에서 삭제"
+    }
+  },
+  "apkPickerPage": {
+    "title": "앱 (APK)",
+    "excludeSystemApps": "시스템 앱 제외",
+    "excludeAppsWithoutLaunchIntent": "실행할 수 없는 앱 제외",
+    "apps": "{n} 개의 앱"
   },
   "selectedFilesPage": {
     "deleteAll": "모두 삭제"
@@ -113,11 +159,14 @@
   "receiveOptionsPage": {
     "title": "옵션",
     "destination": "@:settingsTab.receive.destination",
-    "appDirectory": "(LocalSend 폴더)"
+    "appDirectory": "(LocalSend 폴더)",
+    "saveToGallery": "@:settingsTab.receive.saveToGallery",
+    "saveToGalleryOff": "디렉토리가 있어 자동으로 꺼집니다."
   },
   "sendPage": {
     "waiting": "답변을 기다리는 중…",
-    "rejected": "받는 사람이 요청을 거부했습니다"
+    "rejected": "받는 사람이 요청을 거부했습니다",
+    "busy": "수신자가 다른 요청으로 바쁩니다."
   },
   "progressPage": {
     "titleSending": "파일을 보내는 중",
@@ -135,14 +184,25 @@
       "speed": "속도: {speed}/s"
     }
   },
+  "webSharePage": {
+    "title": "링크로 공유하기",
+    "loading": "서버 시작 중...",
+    "stopping": "서버 중지 중...",
+    "error": "서버 시작 중 오류가 발생했습니다.",
+    "hint": "연결이 암호화되지 않는다는 점에 주의해주세요. 이 방법은 수신자가 LocalSend를 설치하지 않은 경우에만 사용해야 합니다.",
+    "openLink": {
+      "one": "이 링크를 브라우저에서 열기:",
+      "other": "이 중 하나의 링크를 브라우저에서 열기:"
+    },
+    "requests": "요청",
+    "noRequests": "아직 요청이 없습니다.",
+    "pendingRequests": "대기중인 요청: {n}"
+  },
   "aboutPage": {
     "title": "LocalSend에 대해"
   },
   "changelogPage": {
     "title": "업데이트 이력"
-  },
-  "aliasGenerator": {
-    "@info": "Inherits from the English version"
   },
   "dialogs": {
     "addFile": {
@@ -152,15 +212,40 @@
     "addressInput": {
       "title": "주소를 입력",
       "hashtag": "해시태그",
-      "ip": "IP 주소"
+      "ip": "IP 주소",
+      "recentlyUsed": "최근 사용된 주소: "
     },
     "cancelSession": {
       "title": "파일 전송을 취소",
       "content": "정말로 파일 전송을 취소할까요?"
     },
+    "cannotOpenFile": {
+      "title": "파일을 열 수 없음",
+      "content": "\"{file}\"을 열 수 없습니다. 파일이 이동, 이름 변경 또는 삭제 되었는지 확인해주세요."
+    },
+    "encryptionDisabledNotice": {
+      "title": "암호화가 비활성화되었습니다",
+      "content": "이제부터 암호화되지 않은 HTTP 프로토콜로 통신이 이루어집니다. HTTPS를 사용하려면 암호화를 다시 활성화해주세요."
+    },
+    "errorDialog": {
+      "title": "@:general.error"
+    },
+    "fileInfo": {
+      "title": "파일 정보",
+      "fileName": "파일 이름:",
+      "path": "경로:",
+      "size": "크기:",
+      "sender": "보낸 사람:",
+      "time": "시간:"
+    },
     "fileNameInput": {
       "title": "파일 이름을 입력하세요",
       "original": "기존 이름: {original}"
+    },
+    "localNetworkUnauthorized": {
+      "title": "권한 없음",
+      "description": "로컬 네트워크를 스캔할 권한이 없어 LocalSend가 다른 기기를 찾을 수 없습니다. 설정에서 권한을 부여해주세요.",
+      "gotoSettings": "설정"
     },
     "messageInput": {
       "title": "메시지를 입력하세요",
@@ -169,6 +254,13 @@
     "noFiles": {
       "title": "파일이 선택되지 않았습니다",
       "content": "적어도 하나 이상의 파일을 선택해주세요"
+    },
+    "notAvailableOnPlatform": {
+      "title": "사용 불가",
+      "content": "이 기능은 다음 플랫폼에서만 사용 가능합니다:"
+    },
+    "qr": {
+      "title": "QR 코드"
     },
     "quickActions": {
       "title": "퀵 액션",
@@ -182,13 +274,55 @@
       "title": "@:general.quickSave",
       "content": "파일 요청이 자동으로 수락됩니다. 로컬 네트워크의 누구나 파일을 보낼 수 있게되므로 주의해 주세요."
     },
-    "encryptionDisabledNotice": {
-      "title": "암호화가 비활성화되었습니다",
-      "content": "이제부터 암호화되지 않은 HTTP 프로토콜로 통신이 이루어집니다. HTTPS를 사용하려면 암호화를 다시 활성화해주세요."
+    "sendModeHelp": {
+      "title": "전송 모드",
+      "single": "파일을 한 명의 수신자에게 보냅니다. 파일 전송이 완료되면 선택이 지워집니다.",
+      "multiple": "파일을 여러 명의 수신자에게 보냅니다. 선택이 지워지지 않습니다.",
+      "link": "LocalSend를 설치하지 않은 수신자는 브라우저에서 링크를 열어 선택한 파일을 다운로드할 수 있습니다."
     }
   },
   "tray": {
     "open": "@:general.open",
     "close": "LocalSend 종료"
+  },
+  "web": {
+    "waiting": "@:sendPage.waiting",
+    "rejected": "거부됨",
+    "files": "파일",
+    "fileName": "파일 이름",
+    "size": "크기"
+  },
+  "assetPicker": {
+    "confirm": "확인",
+    "cancel": "취소",
+    "edit": "편집",
+    "gifIndicator": "GIF",
+    "loadFailed": "로드 실패",
+    "original": "원본",
+    "preview": "미리보기",
+    "select": "선택",
+    "emptyList": "목록이 비어있음",
+    "unSupportedAssetType": "지원하지 않는 파일 유형입니다.",
+    "unableToAccessAll": "기기의 모든 파일에 접근할 수 없습니다.",
+    "viewingLimitedAssetsTip": "앱에서 접근 가능한 파일과 앨범만 볼 수 있습니다.",
+    "changeAccessibleLimitedAssets": "접근 가능한 파일을 업데이트하려면 클릭하세요.",
+    "accessAllTip": "앱은 기기의 일부 파일에만 접근할 수 있습니다. 시스템 설정으로 이동하여 앱이 기기의 모든 미디어에 액세스할 수 있도록 허용하세요.",
+    "goToSystemSettings": "시스템 설정으로 이동",
+    "accessLimitedAssets": "제한된 접근으로 계속하기",
+    "accessiblePathName": "접근 가능한 파일",
+    "sTypeAudioLabel": "오디오",
+    "sTypeImageLabel": "이미지",
+    "sTypeVideoLabel": "비디오",
+    "sTypeOtherLabel": "기타 미디어",
+    "sActionPlayHint": "재생",
+    "sActionPreviewHint": "미리보기",
+    "sActionSelectHint": "선택",
+    "sActionSwitchPathLabel": "경로 변경",
+    "sActionUseCameraHint": "카메라 사용",
+    "sNameDurationLabel": "길이",
+    "sUnitAssetCountLabel": "개수"
+  },
+  "aliasGenerator": {
+    "@info": "Inherits from the English version"
   }
 }


### PR DESCRIPTION
I've finished translating the missing_translations_en file, and execute `slang analyzer --split-missing` locally
it seems to have gone well. (Changes made by analyzer were not committed.)