### PR TITLE
feat: linux tray enabled

### DIFF
--- a/lib/pages/tabs/settings_tab.dart
+++ b/lib/pages/tabs/settings_tab.dart
@@ -109,7 +109,7 @@ class _SettingsTabState extends ConsumerState<SettingsTab> {
                   await ref.read(settingsProvider.notifier).setSaveWindowPlacement(b);
                 },
               ),
-              if (checkPlatform([TargetPlatform.windows, TargetPlatform.macOS])) ...[
+              if (checkPlatformHasTray()) ...[
                 _BooleanEntry(
                   label: t.settingsTab.general.minimizeToTray,
                   value: settings.minimizeToTray,

--- a/lib/util/native/platform_check.dart
+++ b/lib/util/native/platform_check.dart
@@ -17,7 +17,6 @@ bool checkPlatformIsDesktop() {
 }
 
 /// This platform supports tray
-/// On linux, this is currently not supported
 bool checkPlatformHasTray() {
   return checkPlatform([TargetPlatform.windows, TargetPlatform.macOS, TargetPlatform.linux]);
 }

--- a/lib/util/native/platform_check.dart
+++ b/lib/util/native/platform_check.dart
@@ -19,7 +19,7 @@ bool checkPlatformIsDesktop() {
 /// This platform supports tray
 /// On linux, this is currently not supported
 bool checkPlatformHasTray() {
-  return checkPlatform([TargetPlatform.windows, TargetPlatform.macOS]);
+  return checkPlatform([TargetPlatform.windows, TargetPlatform.macOS, TargetPlatform.linux]);
 }
 
 /// This platform can receive share intents

--- a/lib/util/native/tray_helper.dart
+++ b/lib/util/native/tray_helper.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:localsend_app/gen/assets.gen.dart';
 import 'package:localsend_app/gen/strings.g.dart';
@@ -43,6 +44,7 @@ Future<void> initTray() async {
       print(e);
     }
   } else {
+    // The Linux tray display is handled by systemTray instead
     final SystemTray systemTray = SystemTray();
 
     await systemTray.initSystemTray(
@@ -56,7 +58,7 @@ Future<void> initTray() async {
         await windowManager.show();
         await windowManager.focus();
     }),
-      MenuItemLabel(label: t.tray.close, onClicked: (menuItem) => windowManager.destroy()),
+      MenuItemLabel(label: t.tray.close, onClicked: (menuItem) => exit(0)),
     ]);
 
     await systemTray.setContextMenu(menu);

--- a/lib/util/native/tray_helper.dart
+++ b/lib/util/native/tray_helper.dart
@@ -2,7 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:localsend_app/gen/assets.gen.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
-import 'package:tray_manager/tray_manager.dart';
+import 'package:system_tray/system_tray.dart';
+import 'package:tray_manager/tray_manager.dart' as tm;
 import 'package:window_manager/window_manager.dart';
 
 enum TrayEntry {
@@ -14,31 +15,59 @@ Future<void> initTray() async {
   if (!checkPlatformHasTray()) {
     return;
   }
-  try {
-    if (checkPlatform([TargetPlatform.windows])) {
-      await trayManager.setIcon(
-        Assets.img.logo32Ico,
-      );
-    } else if (checkPlatform([TargetPlatform.macOS])) {
-      await trayManager.setIcon(Assets.img.logo32BlackWhite.path, isTemplate: true);
-    } else {
-      await trayManager.setIcon(Assets.img.logo32Png.path);
-    }
+  if (!checkPlatform([TargetPlatform.linux])) {
+    try {
+      if (checkPlatform([TargetPlatform.windows])) {
+        await tm.trayManager.setIcon(
+          Assets.img.logo32Ico,
+        );
+      } else if (checkPlatform([TargetPlatform.macOS])) {
+        await tm.trayManager.setIcon(Assets.img.logo32BlackWhite.path, isTemplate: true);
+      } else {
+        await tm.trayManager.setIcon(Assets.img.logo32Png.path);
+      }
 
-    final items = [
-      MenuItem(
-        key: TrayEntry.open.name,
-        label: t.tray.open,
-      ),
-      MenuItem(
-        key: TrayEntry.close.name,
-        label: t.tray.close,
-      ),
-    ];
-    await trayManager.setContextMenu(Menu(items: items));
-    await trayManager.setToolTip(t.appName);
-  } catch (e) {
-    print(e);
+      final items = [
+        tm.MenuItem(
+          key: TrayEntry.open.name,
+          label: t.tray.open,
+        ),
+        tm.MenuItem(
+          key: TrayEntry.close.name,
+          label: t.tray.close,
+        ),
+      ];
+      await tm.trayManager.setContextMenu(tm.Menu(items: items));
+      await tm.trayManager.setToolTip(t.appName);
+    } catch (e) {
+      print(e);
+    }
+  } else {
+    final SystemTray systemTray = SystemTray();
+
+    await systemTray.initSystemTray(
+      title: t.appName,
+      iconPath: Assets.img.logo32Png.path,
+    );
+
+    final Menu menu = Menu();
+    await menu.buildFrom([
+      MenuItemLabel(label: t.tray.open, onClicked: (menuItem) async {
+        await windowManager.show();
+        await windowManager.focus();
+    }),
+      MenuItemLabel(label: t.tray.close, onClicked: (menuItem) => windowManager.destroy()),
+    ]);
+
+    await systemTray.setContextMenu(menu);
+
+    systemTray.registerSystemTrayEventHandler((eventName) {
+      if (eventName == kSystemTrayEventClick) {
+        systemTray.popUpContextMenu();
+      } else if (eventName == kSystemTrayEventRightClick) {
+        WindowManager.instance.show();
+      }
+    });
   }
 }
 
@@ -53,6 +82,7 @@ Future<void> hideToTray() async {
 
 Future<void> showFromTray() async {
   await windowManager.show();
+  await windowManager.focus();
   if (checkPlatform([TargetPlatform.macOS])) {
     // This will crash on Windows
     // https://github.com/localsend/localsend/issues/32

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.10)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
+#include <system_tray/system_tray_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -18,6 +19,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
+  g_autoptr(FlPluginRegistrar) system_tray_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SystemTrayPlugin");
+  system_tray_plugin_register_with_registrar(system_tray_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   screen_retriever
+  system_tray
   url_launcher_linux
   window_manager
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import path_provider_foundation
 import photo_manager
 import screen_retriever
 import shared_preferences_foundation
+import system_tray
 import tray_manager
 import url_launcher_macos
 import wakelock_macos
@@ -29,6 +30,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SystemTrayPlugin.register(with: registry.registrar(forPlugin: "SystemTrayPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1318,6 +1318,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  system_tray:
+    dependency: "direct main"
+    description:
+      name: system_tray
+      sha256: "40444e5de8ed907822a98694fd031b8accc3cb3c0baa547634ce76189cf3d9cf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   slang: 3.16.1
   slang_flutter: 3.16.0
   system_settings: ^2.1.0
+  system_tray: ^2.0.3
   tray_manager:
     # https://github.com/leanflutter/tray_manager/issues/30
     # The Linux tray manager is disabled for now

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <network_info_plus/network_info_plus_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
+#include <system_tray/system_tray_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
@@ -26,6 +27,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenRetrieverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
+  SystemTrayPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SystemTrayPlugin"));
   TrayManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("TrayManagerPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   network_info_plus
   permission_handler_windows
   screen_retriever
+  system_tray
   tray_manager
   url_launcher_windows
   window_manager


### PR DESCRIPTION
This change needs some careful considerations...

Unfortunately to incorporate this into the codebase the Linux workflow changes to some degree:

- First of all Flutter has to be installed manually, the snap version has packages included that are not compatible, so we'll need to replace it:  (see https://github.com/leanflutter/tray_manager/issues/28#issuecomment-1308688667)
- The PATH variable will need to be set for flutter and is most reliably set by changing ~/.bashrc manually
- Extra dependencies: lib32stdc++-12-dev, libayatana-appindicator3-dev and the package [system_tray](https://pub.dev/packages/system_tray) 
(I tried to make the tray manager work for Linux but it didn't work still)
- flutter clean will likely be necessary before trying to run the app again

Some extra troubleshooting might be necessary, but those are the steps I took.
