### PR TITLE
Working dependency for Arch

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -27,7 +27,10 @@ AppDir:
       - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security universe
       - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security multiverse
     include:
-      - libc6:amd64
+      - libayatana-appindicator3-1:amd64
+      - librsvg2-common:amd64
+    exclude:
+      - adwaita-icon-theme:*
   files:
     include: []
     exclude:


### PR DESCRIPTION
This is a bit of a mess, I figured it would be easy to move around libayatana-appindicator3-1's dependency tree, but in all truth it is a complete mess.

It bundles the entirety of the gtk3 lib that in turn pulls some obligatory dependencies, but somehow different associated ayatana libs also pull systemd by default that could or not be useful for a headless mode. Not to mention that some few distros don't ship with some version of GTK... so in theory it's practical to have it.

I did try to experiment excluding several dependencies and got to the point of making an AppImage that weighed 54 mB (that worked), but ultimately I decided to just leave adwaita-icon-theme out because the app doesn't implement [https://pub.dev/packages/adwaita](https://pub.dev/packages/adwaita), unfortunately this makes a previously 13 mB into a 56 mB one, although then I believe we can reach maximum compatibility without thinking twice.

Small note: I'm currently afflicted by a nasty cold, so beyond my attempts I decided to not delve deeper into eliminating useless deps, and tbh is likely not worth it : P 