### PR TITLE
[Distribution] Added debian package configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+/dist/
 
 # Symbolication related
 app.*.symbols

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -1,0 +1,39 @@
+display_name: LocalSend
+package_name: localsend
+maintainer:
+  name: Tienisto
+  email: dev.tien.donam@gmail.com
+co_authors:
+  - name: TheGB0077
+    email: gb.lima.dev@gmail.com
+priority: optional
+section: x11
+installed_size: 8859
+essential: false
+icon: assets/img/logo-512.png
+
+pre_dependencies:
+  - libc6 (>= 2.31)
+
+dependencies:
+  - libappindicator3-1
+  - libayatana-appindicator3-1
+  - libayatana-ido3-0.4-0
+
+postinstall_scripts:
+  - echo "Installed Localsend successfully"
+postuninstall_scripts:
+  - echo "Sorry to see you go :("
+
+keywords:
+  - Sharing
+  - LAN
+  - Files
+
+generic_name: Localsend
+
+categories:
+  - GTK
+  - FileTransfer
+
+startup_notify: true

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -30,7 +30,7 @@ keywords:
   - LAN
   - Files
 
-generic_name: Localsend
+generic_name: An open source cross-platform alternative to AirDrop
 
 categories:
   - GTK


### PR DESCRIPTION
Changes in "For distributors":

Build the executable in Debian 11 ( recommended )

Install flutter distributor

```
dart pub global activate flutter_distributor
``` 
Configure .pub-cache on PATH

```
echo 'export PATH="$PATH:$HOME/.pub-cache/bin"' >> ~/.bashrc
``` 

Generate the .deb package

```
flutter_distributor package --platform linux --targets deb
``` 
