### PR TITLE
feat: use Escape key to quit about and changelog page

### DIFF
--- a/lib/pages/about_page.dart
+++ b/lib/pages/about_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/pages/debug/debug_page.dart';
+import 'package:localsend_app/util/shortcut_warpper.dart';
 import 'package:localsend_app/widget/local_send_logo.dart';
 import 'package:localsend_app/widget/responsive_list_view.dart';
 import 'package:routerino/routerino.dart';
@@ -26,66 +27,71 @@ class AboutPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(t.aboutPage.title),
-      ),
-      body: ResponsiveListView(
-        padding: const EdgeInsets.symmetric(horizontal: 15),
-        children: [
-          const SizedBox(height: 20),
-          const LocalSendLogo(withText: true),
-          Text(
-            '© ${DateTime.now().year} Tien Do Nam',
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 10),
-          Center(
-            child: TextButton(
-              onPressed: () async {
-                await launchUrl(Uri.parse('https://localsend.org'));
-              },
-              child: const Text('localsend.org'),
+    return ShortcutWrapper(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(t.aboutPage.title),
+        ),
+        body: ResponsiveListView(
+          padding: const EdgeInsets.symmetric(horizontal: 15),
+          children: [
+            const SizedBox(height: 20),
+            const LocalSendLogo(withText: true),
+            Text(
+              '© ${DateTime.now().year} Tien Do Nam',
+              textAlign: TextAlign.center,
             ),
-          ),
-          Text(_body),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              TextButton(
+            const SizedBox(height: 10),
+            Center(
+              child: TextButton(
                 onPressed: () async {
                   await launchUrl(Uri.parse('https://localsend.org'));
                 },
-                child: const Text('Homepage'),
+                child: const Text('localsend.org'),
               ),
-              TextButton(
-                onPressed: () async {
-                  await launchUrl(Uri.parse('https://github.com/localsend/localsend'), mode: LaunchMode.externalApplication);
-                },
-                child: const Text('Source Code (Github)'),
-              ),
-              TextButton(
-                onPressed: () async {
-                  await launchUrl(Uri.parse('https://opensource.org/licenses/MIT'));
-                },
-                child: const Text('MIT License'),
-              ),
-              TextButton(
-                onPressed: () async {
-                  await context.push(() => const LicensePage());
-                },
-                child: const Text('License Notices'),
-              ),
-              TextButton(
-                onPressed: () async {
-                  await context.push(() => const DebugPage());
-                },
-                child: const Text('Debugging'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 50),
-        ],
+            ),
+            Text(_body),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextButton(
+                  onPressed: () async {
+                    await launchUrl(Uri.parse('https://localsend.org'));
+                  },
+                  child: const Text('Homepage'),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    await launchUrl(
+                        Uri.parse('https://github.com/localsend/localsend'),
+                        mode: LaunchMode.externalApplication);
+                  },
+                  child: const Text('Source Code (Github)'),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    await launchUrl(
+                        Uri.parse('https://opensource.org/licenses/MIT'));
+                  },
+                  child: const Text('MIT License'),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    await context.push(() => const LicensePage());
+                  },
+                  child: const Text('License Notices'),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    await context.push(() => const DebugPage());
+                  },
+                  child: const Text('Debugging'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 50),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/changelog_page.dart
+++ b/lib/pages/changelog_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:localsend_app/gen/assets.gen.dart';
 import 'package:localsend_app/gen/strings.g.dart';
+import 'package:localsend_app/util/shortcut_warpper.dart';
 import 'package:localsend_app/util/ui/nav_bar_padding.dart';
 
 class ChangelogPage extends StatelessWidget {
@@ -10,26 +11,29 @@ class ChangelogPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(t.changelogPage.title),
-      ),
-      body: FutureBuilder(
-        future: rootBundle.loadString(Assets.changelog), // ignore: discarded_futures
-        builder: (context, data) {
-          if (!data.hasData) {
-            return Container();
-          }
-          return Markdown(
-            padding: EdgeInsets.only(
-              left: 15,
-              right: 15,
-              top: 15,
-              bottom: 15 + getNavBarPadding(context),
-            ),
-            data: data.data!,
-          );
-        },
+    return ShortcutWrapper(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(t.changelogPage.title),
+        ),
+        body: FutureBuilder(
+          future: rootBundle
+              .loadString(Assets.changelog), // ignore: discarded_futures
+          builder: (context, data) {
+            if (!data.hasData) {
+              return Container();
+            }
+            return Markdown(
+              padding: EdgeInsets.only(
+                left: 15,
+                right: 15,
+                top: 15,
+                bottom: 15 + getNavBarPadding(context),
+              ),
+              data: data.data!,
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/util/shortcut_warpper.dart
+++ b/lib/util/shortcut_warpper.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class ShortcutWrapper extends StatelessWidget {
+  final Widget child;
+  final Map<LogicalKeySet, Intent> additionalShortcuts;
+
+  ShortcutWrapper({
+    required this.child,
+    this.additionalShortcuts = const {},
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final shortcuts = {
+      LogicalKeySet(LogicalKeyboardKey.escape): ActivateIntent(),
+      ...additionalShortcuts,
+    };
+
+    return Shortcuts(
+      shortcuts: shortcuts,
+      child: Actions(
+        actions: {
+          ActivateIntent: CallbackAction<ActivateIntent>(
+            onInvoke: (ActivateIntent intent) => Navigator.pop(context),
+          ),
+        },
+        child: Focus(
+          autofocus: true,
+          child: child,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This change only affects two pages: about and changelog.

After use press Escape key on their keyboard will back to previous page. 

I add a `ShortcutWrapper` for the `Scaffold` component of these two pages to achieve this.