### PR TITLE
deps: window_manager bump

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1705,10 +1705,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "2b2572442b2a5178642730442dc625ac088244f5827b1f0811371b1b7485eb62"
+      sha256: "9eef00e393e7f9308309ce9a8b2398c9ee3ca78b50c96e8b4f9873945693ac88"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.3.5"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   uuid: 3.0.7
   wakelock: 0.6.2
   wechat_assets_picker: 8.5.0
-  window_manager: 0.3.2
+  window_manager: ^0.3.5
 
 dev_dependencies:
   build_runner: 2.4.5


### PR DESCRIPTION
Some important fixes were made: 

* On-close event handler is fixed
* setMinimumSize and setMaximumSize is fixed on macOS, although not yet on Linux.