### PR TITLE
fix: possible race condition leading to zero files

### DIFF
--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - feat: hide color setting when dynamic colors are not supported (@Tienisto)
 - feat(linux): use white icon for the linux tray (@GaryElshaw, @Tienisto)
+- fix: possible race condition leading to zero total files (@Tienisto)
 - fix(android): navigation bar color on Android 9 and earlier (@Tienisto)
 - fix(android): add `requestLegacyExternalStorage` again (that was removed in 1.11.0) (@Tienisto)
 - fix(linux): do not use zenity dependency anymore for file picker (@Tienisto)


### PR DESCRIPTION
The progress indicator is wrong sometimes because its total size/count value is calculated once by looking for files with tokens.

The calculation happens initially assuming that no files has been sent yet (because each receive request will set the token `null`).

On very fast networks, the request is already received leading to an invalid amount of files with tokens.

The solution is to look for the `status == skipped` condition because this should never change.