### PR TITLE
Update strings.i18n.json Tray -> Menu Bar

### DIFF
--- a/assets/i18n/strings.i18n.json
+++ b/assets/i18n/strings.i18n.json
@@ -93,7 +93,7 @@
         "system": "System"
       },
       "saveWindowPlacement": "Quit: Save window placement",
-      "minimizeToTray": "Quit: Minimize to tray",
+      "minimizeToTray": "Quit: Minimize to Menu Bar",
       "launchAtStartup": "Autostart after login",
       "launchMinimized": "Autostart: Start hidden",
       "animations": "Animations"


### PR DESCRIPTION
Small request: 

On MacOS, the bar that runs along the top of the computer is referred to by Apple as the Menu Bar.[1] I was slightly confused upon seeing "tray" and thought is was the dock, like this guy.[2]

It seems that updating this might impact all settings, if so, please tell me, and I'll see if I can make it Mac specific.

[1]: https://support.apple.com/en-ca/guide/mac-help/mchlp1446/mac
[2]: https://apple.stackexchange.com/questions/101074/move-desktop-item-to-system-tray-dock

