### PR TITLE
feat: drastically improve GPU usage by optimizing the spin animation

### DIFF
--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.0 (2023-)
+
+- feat: drastically improve GPU usage by optimizing the spin animation (@Tienisto)
+
 ## 1.11.1 (2023-09-04)
 
 - feat: hide color setting when dynamic colors are not supported (@Tienisto)

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -8,6 +8,7 @@ import 'package:localsend_app/pages/tabs/receive_tab.dart';
 import 'package:localsend_app/pages/tabs/send_tab.dart';
 import 'package:localsend_app/pages/tabs/settings_tab.dart';
 import 'package:localsend_app/provider/selection/selected_sending_files_provider.dart';
+import 'package:localsend_app/provider/ui/home_tab_provider.dart';
 import 'package:localsend_app/theme.dart';
 import 'package:localsend_app/widget/responsive_builder.dart';
 import 'package:riverpie_flutter/riverpie_flutter.dart';
@@ -63,14 +64,17 @@ class _HomePageState extends State<HomePage> with Riverpie {
     _pageController = PageController(initialPage: widget.initialTab.index);
     _currentTab = widget.initialTab;
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
+    ensureRef((ref) async {
+      ref.redux(homeTabProvider).dispatch(SetHomeTabAction(widget.initialTab));
       await postInit(context, ref, widget.appStart, _goToPage);
     });
   }
 
   void _goToPage(int index) {
+    final tab = HomeTab.values[index];
+    ref.redux(homeTabProvider).dispatch(SetHomeTabAction(tab));
     setState(() {
-      _currentTab = HomeTab.values[index];
+      _currentTab = tab;
       _pageController.jumpToPage(_currentTab.index);
     });
   }

--- a/lib/pages/tabs/receive_tab.dart
+++ b/lib/pages/tabs/receive_tab.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
+import 'package:localsend_app/pages/home_page.dart';
 import 'package:localsend_app/pages/receive_history_page.dart';
 import 'package:localsend_app/provider/animation_provider.dart';
 import 'package:localsend_app/provider/network/server/server_provider.dart';
 import 'package:localsend_app/provider/network_info_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/provider/ui/home_tab_provider.dart';
 import 'package:localsend_app/util/ip_helper.dart';
 import 'package:localsend_app/util/sleep.dart';
 import 'package:localsend_app/widget/animations/initial_fade_transition.dart';
@@ -37,7 +39,6 @@ class _ReceiveTagState extends State<ReceiveTab> with AutomaticKeepAliveClientMi
     final settings = ref.watch(settingsProvider);
     final networkInfo = ref.watch(networkStateProvider);
     final serverState = ref.watch(serverProvider);
-    final animations = ref.watch(animationProvider);
 
     return Stack(
       children: [
@@ -53,33 +54,36 @@ class _ReceiveTagState extends State<ReceiveTab> with AutomaticKeepAliveClientMi
                     child: Column(
                       children: [
                         Expanded(
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Center(
-                              child: Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  InitialFadeTransition(
-                                    duration: const Duration(milliseconds: 300),
-                                    delay: const Duration(milliseconds: 200),
-                                    child: RotatingWidget(
-                                      duration: const Duration(seconds: 15),
-                                      spinning: serverState != null && animations,
-                                      child: const LocalSendLogo(withText: false),
-                                    ),
-                                  ),
-                                  Text(serverState?.alias ?? settings.alias, style: const TextStyle(fontSize: 48)),
-                                  InitialFadeTransition(
-                                    duration: const Duration(milliseconds: 300),
-                                    delay: const Duration(milliseconds: 500),
-                                    child: Text(
-                                      serverState == null ? t.general.offline : networkInfo.localIps.map((ip) => '#${ip.visualId}').toSet().join(' '),
-                                      style: const TextStyle(fontSize: 24),
-                                    ),
-                                  ),
-                                ],
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              InitialFadeTransition(
+                                duration: const Duration(milliseconds: 300),
+                                delay: const Duration(milliseconds: 200),
+                                child: Consumer(builder: (context, ref) {
+                                  final animations = ref.watch(animationProvider);
+                                  final activeTab = ref.watch(homeTabProvider);
+                                  return RotatingWidget(
+                                    duration: const Duration(seconds: 15),
+                                    spinning: serverState != null && animations && activeTab == HomeTab.receive,
+                                    child: const LocalSendLogo(withText: false),
+                                  );
+                                }),
                               ),
-                            ),
+                              FittedBox(
+                                fit: BoxFit.scaleDown,
+                                child: Text(serverState?.alias ?? settings.alias, style: const TextStyle(fontSize: 48)),
+                              ),
+                              InitialFadeTransition(
+                                duration: const Duration(milliseconds: 300),
+                                delay: const Duration(milliseconds: 500),
+                                child: Text(
+                                  serverState == null ? t.general.offline : networkInfo.localIps.map((ip) => '#${ip.visualId}').toSet().join(' '),
+                                  style: const TextStyle(fontSize: 24),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],

--- a/lib/provider/ui/home_tab_provider.dart
+++ b/lib/provider/ui/home_tab_provider.dart
@@ -1,0 +1,20 @@
+import 'package:localsend_app/pages/home_page.dart';
+import 'package:riverpie_flutter/riverpie_flutter.dart';
+
+/// This provider is used so that tabs know if they are currently visible.
+/// The [HomePage] is responsible for setting the current tab.
+final homeTabProvider = ReduxProvider<HomeTabNotifier, HomeTab>((ref) => HomeTabNotifier());
+
+class HomeTabNotifier extends ReduxNotifier<HomeTab> {
+  @override
+  HomeTab init() => HomeTab.receive;
+}
+
+class SetHomeTabAction extends ReduxAction<HomeTabNotifier, HomeTab> {
+  final HomeTab tab;
+
+  SetHomeTabAction(this.tab);
+
+  @override
+  HomeTab reduce() => tab;
+}


### PR DESCRIPTION
The current spin animation (the logo above the alias) consumes a lot of resources.
This PR implements a more performant approach.

Closes #510
Closes #535 

![gpu](https://github.com/localsend/localsend/assets/38380847/e648b27a-2484-4595-84a3-9ea7e471194f)
