### PR TITLE
fix: Fallback to "$HOME/Downloads" when default downloads folder is unavailable

### DIFF
--- a/lib/util/native/get_destination_directory.dart
+++ b/lib/util/native/get_destination_directory.dart
@@ -17,10 +17,18 @@ Future<String> getDefaultDestinationDirectory() async {
     case TargetPlatform.windows:
     case TargetPlatform.fuchsia:
       var downloadDir = await path.getDownloadsDirectory();
-      if (defaultTargetPlatform == TargetPlatform.windows) {
-        downloadDir = Directory('${Platform.environment['HOMEPATH']}/Downloads');
-      } else {
-        downloadDir = Directory('${Platform.environment['HOME']}/Downloads');
+      if (downloadDir == null) {
+        if (defaultTargetPlatform == TargetPlatform.windows) {
+          downloadDir = Directory('${Platform.environment['HOMEPATH']}/Downloads');
+          if (!downloadDir.existsSync()) {
+            downloadDir = Directory(Platform.environment['HOMEPATH']!);
+          }
+        } else {
+          downloadDir = Directory('${Platform.environment['HOME']}/Downloads');
+          if (!downloadDir.existsSync()) {
+            downloadDir = Directory(Platform.environment['HOME']!);
+          }
+        }
       }
       return downloadDir.path.replaceAll('\\', '/');
   }

--- a/lib/util/native/get_destination_directory.dart
+++ b/lib/util/native/get_destination_directory.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Directory, Platform;
+
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart' as path;
 import 'package:shared_storage/shared_storage.dart' as shared_storage;
@@ -14,6 +16,12 @@ Future<String> getDefaultDestinationDirectory() async {
     case TargetPlatform.macOS:
     case TargetPlatform.windows:
     case TargetPlatform.fuchsia:
-      return (await path.getDownloadsDirectory())!.path.replaceAll('\\', '/');
+      var downloadDir = await path.getDownloadsDirectory();
+      if (defaultTargetPlatform == TargetPlatform.windows) {
+        downloadDir = Directory('${Platform.environment['HOMEPATH']}/Downloads');
+      } else {
+        downloadDir = Directory('${Platform.environment['HOME']}/Downloads');
+      }
+      return downloadDir.path.replaceAll('\\', '/');
   }
 }


### PR DESCRIPTION
Fixes: #461 

# Bug
When the system does not have the default Downloads folder defined (`XDG_DOWNLOAD_DIR` for Linux, `374DE290-123F-4565-9164-39C4925E467B` folderId in Windows) the application fails to send the files with an 500 response.

# Fix
The PR aims to fix it by manually defaulting to the Downloads folder by absolute path
On Linux by using the `$HOME` variable, which should be defined by default
On Windows by using the `HOMEPATH` variable