### PR TITLE
Update make_config.yaml

### DIFF
--- a/app/linux/packaging/deb/make_config.yaml
+++ b/app/linux/packaging/deb/make_config.yaml
@@ -35,5 +35,6 @@ generic_name: An open source cross-platform alternative to AirDrop
 categories:
   - GTK
   - FileTransfer
+  - Utility
 
 startup_notify: true


### PR DESCRIPTION
In the KDE Plasma desktop environment, apps installed using `.deb` file are classified as `Lost & Found` . After adding `Utility` to `categories`, the app will be classified as `Utilities` .