### PR TITLE
i18n: Update missing translation for Ukrainian and Russian language (uk-UK; ru-Ru)

### DIFF
--- a/app/assets/i18n/_missing_translations_ru.json
+++ b/app/assets/i18n/_missing_translations_ru.json
@@ -4,11 +4,11 @@
     "After editing this file, you can run 'dart run slang apply --locale=ru' to quickly apply the newly added translations."
   ],
   "general": {
-    "noItemInClipboard": "No item in Clipboard"
+    "noItemInClipboard": "Буфер обмена пуст"
   },
   "sendTab": {
     "picker": {
-      "clipboard": "Clipboard"
+      "clipboard": "Буфер обмена"
     }
   },
   "settingsTab": {

--- a/app/assets/i18n/_missing_translations_uk.json
+++ b/app/assets/i18n/_missing_translations_uk.json
@@ -4,11 +4,11 @@
     "After editing this file, you can run 'dart run slang apply --locale=uk' to quickly apply the newly added translations."
   ],
   "general": {
-    "noItemInClipboard": "No item in Clipboard"
+    "noItemInClipboard": "Буфер обміну порожній"
   },
   "sendTab": {
     "picker": {
-      "clipboard": "Clipboard"
+      "clipboard": "Буфер обміну"
     }
   },
   "settingsTab": {


### PR DESCRIPTION
OLED has no suitable equivalents in either Ukrainian or Russian, as it is an abbreviation, so everyone uses OLED.