### PR TITLE
docs: use ** instead of ####

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ You can help translating this app to other languages!
    3. Run app via `flutter run`
 4. Open a pull request
 
-#### _Take note:_ Fields decorated with `@` are not meant to be translated, they are not used in the app in any way, being merely informative text about the file or to give context to the translator.
+**_Take note:_ Fields decorated with `@` are not meant to be translated, they are not used in the app in any way, being merely informative text about the file or to give context to the translator.**
 
 ## Contributing Guidelines
 


### PR DESCRIPTION
`#` stands for headline, so the note should not be bolded with `#`, but with `**` instead.