### PR TITLE
Distribution: Update .deb / Add .rpm scripts

### DIFF
--- a/app/linux/packaging/deb/make_config.yaml
+++ b/app/linux/packaging/deb/make_config.yaml
@@ -8,7 +8,7 @@ co_authors:
     email: gb.lima.dev@gmail.com
 priority: optional
 section: x11
-installed_size: 8859
+installed_size: 30600
 essential: false
 icon: assets/img/logo-512.png
 
@@ -16,9 +16,10 @@ pre_dependencies:
   - libc6 (>= 2.31)
 
 dependencies:
-  - libappindicator3-1
-  - libayatana-appindicator3-1
+  - libappindicator3-1 | libayatana-appindicator3-1
+  - gir1.2-appindicator3-0.1 | gir1.2-ayatanaappindicator3-0.1
   - libayatana-ido3-0.4-0
+  - xdg-user-dirs
 
 postinstall_scripts:
   - echo "Installed Localsend successfully"

--- a/app/linux/packaging/rpm/make_config.yaml
+++ b/app/linux/packaging/rpm/make_config.yaml
@@ -1,0 +1,28 @@
+display_name: LocalSend
+packager: Tienisto
+packagerEmail: dev.tien.donam@gmail.com
+url: https://localsend.org
+buildArch: x86_64
+license: MIT
+
+icon: assets/img/logo-512.png
+
+requires:
+  - libappindicator
+  - xdg-user-dirs
+
+keywords:
+  - Sharing
+  - LAN
+  - Files
+
+generic_name: An open source cross-platform alternative to AirDrop
+summary: Share files easily with LocalSend
+group: Applications/Utilities
+
+categories:
+  - GTK
+  - FileTransfer
+  - Utility
+
+startup_notify: true


### PR DESCRIPTION
While this PR adds the RPM script, the best way to add it into the CI should be something to consider. Building it as is on a Debian will make it dependent on Debian specific libs, that cannot be found in Fedora land, so it may be necessary to build the app on a fedora container of storts to make it work out of the box properly.