### PR TITLE
Update README.md -  Bug -> Grammar bugs in README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For more information on the LocalSend Protocol, see the [documentation](https://
 
 ## Getting Started
 
-To start LocalSend from source code, follow these steps:
+To start LocalSend from the source code, follow these steps:
 
 1. Install [Flutter](https://flutter.dev)
 2. Clone the LocalSend repository
@@ -85,7 +85,7 @@ To start LocalSend from source code, follow these steps:
 
 It may be the case that it doesn't work because of a mismatch between the required Flutter version and the installed Flutter version.
 
-LocalSend uses [fvm](https://fvm.app) to manage the project Flutter version (specified in [.fvm/fvm_config.json](.fvm/fvm_config.json)). After you installed it, run `fvm flutter` instead of `flutter`.
+LocalSend uses [fvm](https://fvm.app) to manage the project Flutter version (specified in [.fvm/fvm_config.json](.fvm/fvm_config.json)). After you install it, run `fvm flutter` instead of `flutter`.
 
 ## Contributing
 


### PR DESCRIPTION
I have spotted two small bug related to grammar in **README.md** inside section "**Getting Started**".

"**To start LocalSend from source code,..**"  should be "**To start LocalSend from the source code,..**"  and also

"**After you installed it,..**"  should be "**After you install it,..**"

Below I have attached a sceenshot of it ,

![Screenshot (85)](https://github.com/localsend/localsend/assets/115995339/0e061e31-5f3d-466d-8f95-8fad4c557b2f)
