### PR TITLE
i18n: Update Polish translation

### DIFF
--- a/app/assets/i18n/_missing_translations_pl.json
+++ b/app/assets/i18n/_missing_translations_pl.json
@@ -32,7 +32,7 @@
     "favoriteEditDialog": {
       "titleAdd": "Dodaj do ulubionych",
       "titleEdit": "Dostosuj",
-      "name": "Nazwa",
+      "name": "Alias",
       "auto": "(auto)",
       "ip": "Adres IP",
       "port": "Port"

--- a/app/assets/i18n/_missing_translations_pl.json
+++ b/app/assets/i18n/_missing_translations_pl.json
@@ -4,12 +4,12 @@
     "After editing this file, you can run 'dart run slang apply --locale=pl' to quickly apply the newly added translations."
   ],
   "general": {
-    "delete": "Delete",
-    "noItemInClipboard": "No item in Clipboard"
+    "delete": "Usuń",
+    "noItemInClipboard": "Schowek jest pusty"
   },
   "sendTab": {
     "picker": {
-      "clipboard": "Paste"
+      "clipboard": "Wklej"
     }
   },
   "settingsTab": {
@@ -21,25 +21,25 @@
   },
   "dialogs": {
     "favoriteDialog": {
-      "title": "Favorites",
-      "noFavorites": "No favorites devices yet.",
-      "addFavorite": "Add"
+      "title": "Ulubione",
+      "noFavorites": "Brak ulubionych urządzeń.",
+      "addFavorite": "Dodaj"
     },
     "favoriteDeleteDialog": {
-      "title": "Delete from favorites",
-      "content": "Do you really want to delete from favorites \"{name}\"?"
+      "title": "Usuń z ulubionych",
+      "content": "Czy na pewno chcesz usunąć z ulubionych \"{name}\"?"
     },
     "favoriteEditDialog": {
-      "titleAdd": "Add to favorites",
-      "titleEdit": "Adjustment",
-      "name": "Alias",
+      "titleAdd": "Dodaj do ulubionych",
+      "titleEdit": "Dostosuj",
+      "name": "Nazwa",
       "auto": "(auto)",
-      "ip": "IP Address",
+      "ip": "Adres IP",
       "port": "Port"
     },
     "historyClearDialog": {
-      "title": "Clear history",
-      "content": "Do you really want to delete the entire history?"
+      "title": "Wyczyść historię",
+      "content": "Czy na pewno chcesz usunąć całą historię?"
     }
   }
 }

--- a/app/assets/i18n/strings_pl.i18n.json
+++ b/app/assets/i18n/strings_pl.i18n.json
@@ -78,7 +78,7 @@
     "title": "Ustawienia",
     "general": {
       "title": "Ogólne",
-      "brightness": "Jasność",
+      "brightness": "Motyw",
       "brightnessOptions": {
         "system": "System",
         "dark": "Ciemny",


### PR DESCRIPTION
I updated _missing_translations_pl.json and changed "Jasność" to "Motyw", which is a more accurate translation of "Theme"