### PR TITLE
Added feature for macOS: command+w to close the window without quiting the app

### DIFF
--- a/app/lib/widget/watcher/shortcut_watcher.dart
+++ b/app/lib/widget/watcher/shortcut_watcher.dart
@@ -22,22 +22,16 @@ class ShortcutWatcher extends StatelessWidget {
 
         // Add Control+Q binding for Linux
         // https://github.com/localsend/localsend/issues/194
-        if (checkPlatform([TargetPlatform.linux]))
-          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyQ):
-              _ExitAppIntent(),
+        if (checkPlatform([TargetPlatform.linux])) LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyQ): _ExitAppIntent(),
+        // Add Command+W to close the window for macOS
+        if (checkPlatform([TargetPlatform.macOS])) LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyW): _CloseWindowIntent(),
 
         LogicalKeySet(LogicalKeyboardKey.escape): _PopPageIntent(),
 
         // Control+V and Command+V
-        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV):
-            _PasteIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV):
-            _PasteIntent(),
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV): _PasteIntent(),
+        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV): _PasteIntent(),
 
-        // Add Command+W to close the window for macOS
-        if (checkPlatform([TargetPlatform.macOS]))
-          LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyW):
-              _CloseWindowIntent(),
       },
       child: Actions(
         actions: {

--- a/app/lib/widget/watcher/shortcut_watcher.dart
+++ b/app/lib/widget/watcher/shortcut_watcher.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:localsend_app/util/native/file_picker.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
+import 'package:localsend_app/widget/watcher/window_watcher.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
 
@@ -21,22 +22,40 @@ class ShortcutWatcher extends StatelessWidget {
 
         // Add Control+Q binding for Linux
         // https://github.com/localsend/localsend/issues/194
-        if (checkPlatform([TargetPlatform.linux])) LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyQ): _ExitAppIntent(),
+        if (checkPlatform([TargetPlatform.linux]))
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyQ):
+              _ExitAppIntent(),
 
         LogicalKeySet(LogicalKeyboardKey.escape): _PopPageIntent(),
 
         // Control+V and Command+V
-        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV): _PasteIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV): _PasteIntent(),
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV):
+            _PasteIntent(),
+        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV):
+            _PasteIntent(),
+
+        // Add Command+W to close the window for macOS
+        if (checkPlatform([TargetPlatform.macOS]))
+          LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyW):
+              _CloseWindowIntent(),
       },
       child: Actions(
         actions: {
           _ExitAppIntent: CallbackAction(onInvoke: (_) => exit(0)),
-          _PopPageIntent: CallbackAction(onInvoke: (_) async => Navigator.of(Routerino.context).maybePop()),
+          _PopPageIntent: CallbackAction(
+              onInvoke: (_) async =>
+                  Navigator.of(Routerino.context).maybePop()),
           _PasteIntent: CallbackAction(onInvoke: (_) async {
-            await context.ref.dispatchAsync(PickFileAction(option: FilePickerOption.clipboard, context: context));
+            await context.ref.dispatchAsync(PickFileAction(
+                option: FilePickerOption.clipboard, context: context));
             return null;
           }),
+          _CloseWindowIntent: CallbackAction<_CloseWindowIntent>(
+            onInvoke: (_) async {
+              await WindowWatcher.closeWindow(context);
+              return null;
+            },
+          ),
         },
         child: child,
       ),
@@ -49,3 +68,5 @@ class _ExitAppIntent extends Intent {}
 class _PopPageIntent extends Intent {}
 
 class _PasteIntent extends Intent {}
+
+class _CloseWindowIntent extends Intent {}

--- a/app/lib/widget/watcher/window_watcher.dart
+++ b/app/lib/widget/watcher/window_watcher.dart
@@ -22,6 +22,11 @@ class WindowWatcher extends StatefulWidget {
 
   @override
   State<WindowWatcher> createState() => _WindowWatcherState();
+
+  static Future<void> closeWindow(BuildContext context) async {
+    final state = context.findAncestorStateOfType<_WindowWatcherState>();
+    await state?.onWindowClose();
+  }
 }
 
 class _WindowWatcherState extends State<WindowWatcher> with WindowListener, Refena {


### PR DESCRIPTION
With these changes, macOS users can now comfortably use Command+W to close the window while preserving the app in the menubar, just like with other apps. I think this improves the consistency of user experience.

This is my first-ever pull request, so please bear with me if there are any issues, whether in the process of creating this PR or in the code itself ^^