### PR TITLE
add duplicate files validation when pick image or files or directory

### DIFF
--- a/app/lib/provider/selection/selected_sending_files_provider.dart
+++ b/app/lib/provider/selection/selected_sending_files_provider.dart
@@ -2,12 +2,11 @@ import 'dart:convert' show utf8;
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/model/file_type.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
 import 'package:localsend_app/util/native/cache_helper.dart';
+import 'package:localsend_app/util/native/cross_file_converters.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:refena_flutter/refena_flutter.dart';
@@ -124,7 +123,7 @@ class AddFilesAction<T> extends AsyncReduxAction<SelectedSendingFilesNotifier, L
       //  https://github.com/fluttercandies/flutter_photo_manager/issues/589
 
       final crossFile = await converter(file);
-      final isAlreadySelect = state.any((element) => p.basename(element.path ?? '') == p.basename(crossFile.path ?? ''));
+      final isAlreadySelect = state.any((element) => element.isSameFile(otherFile: crossFile));
       if (!isAlreadySelect) {
         newFiles.add(crossFile);
       }
@@ -161,7 +160,7 @@ class AddDirectoryAction extends AsyncReduxAction<SelectedSendingFilesNotifier, 
           bytes: null,
         );
 
-        final isAlreadySelect = state.any((element) => p.basename(element.path ?? '') == p.basename(file.path ?? ''));
+        final isAlreadySelect = state.any((element) => element.isSameFile(otherFile: file));
         if (!isAlreadySelect) {
           newFiles.add(file);
         }

--- a/app/lib/provider/selection/selected_sending_files_provider.dart
+++ b/app/lib/provider/selection/selected_sending_files_provider.dart
@@ -2,6 +2,8 @@ import 'dart:convert' show utf8;
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/model/file_type.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
@@ -119,8 +121,13 @@ class AddFilesAction<T> extends AsyncReduxAction<SelectedSendingFilesNotifier, L
     final newFiles = <CrossFile>[];
     for (final file in files) {
       // we do it sequential because there are bugs
-      // https://github.com/fluttercandies/flutter_photo_manager/issues/589
-      newFiles.add(await converter(file));
+      //  https://github.com/fluttercandies/flutter_photo_manager/issues/589
+
+      final crossFile = await converter(file);
+      final isAlreadySelect = state.any((element) => p.basename(element.path ?? '') == p.basename(crossFile.path ?? ''));
+      if (!isAlreadySelect) {
+        newFiles.add(crossFile);
+      }
     }
     return List.unmodifiable([
       ...state,
@@ -153,7 +160,11 @@ class AddDirectoryAction extends AsyncReduxAction<SelectedSendingFilesNotifier, 
           path: entity.path,
           bytes: null,
         );
-        newFiles.add(file);
+
+        final isAlreadySelect = state.any((element) => p.basename(element.path ?? '') == p.basename(file.path ?? ''));
+        if (!isAlreadySelect) {
+          newFiles.add(file);
+        }
       }
     }
 

--- a/app/lib/util/native/cross_file_converters.dart
+++ b/app/lib/util/native/cross_file_converters.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/model/file_type.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
+import 'package:path/path.dart' as p;
 import 'package:share_handler/share_handler.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
@@ -74,5 +75,11 @@ class CrossFileConverters {
       path: app.apkFilePath,
       bytes: null,
     );
+  }
+}
+
+extension CompareFile on CrossFile {
+  bool isSameFile({required CrossFile otherFile}) {
+    return (p.basename(path ?? '') == p.basename(otherFile.path ?? '')) && size == otherFile.size;
   }
 }

--- a/app/lib/util/native/cross_file_converters.dart
+++ b/app/lib/util/native/cross_file_converters.dart
@@ -7,7 +7,6 @@ import 'package:image_picker/image_picker.dart';
 import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/model/file_type.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
-import 'package:path/path.dart' as p;
 import 'package:share_handler/share_handler.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
@@ -80,6 +79,6 @@ class CrossFileConverters {
 
 extension CompareFile on CrossFile {
   bool isSameFile({required CrossFile otherFile}) {
-    return (p.basename(path ?? '') == p.basename(otherFile.path ?? '')) && size == otherFile.size;
+    return (path ?? '') == (otherFile.path ?? '');
   }
 }


### PR DESCRIPTION
linked to #903 

I try to add validation for already selected files from menu options file, media or folder.

# Before 
### MacOs
https://github.com/localsend/localsend/assets/7869219/843a0615-a9de-4d90-9c89-6ebc39572872

### Android
https://github.com/localsend/localsend/assets/7869219/7ef7ccd1-b6e3-4ec7-8794-b790eb104439


# After 
### MacOs
https://github.com/localsend/localsend/assets/7869219/1c17290e-a86c-44a0-bcf3-1c81348727fd


### Android
https://github.com/localsend/localsend/assets/7869219/ec4923ee-7900-4834-a5f4-0e9bf3687755

