### PR TITLE
I18n/tr

### DIFF
--- a/app/assets/i18n/_missing_translations_tr.json
+++ b/app/assets/i18n/_missing_translations_tr.json
@@ -2,36 +2,5 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <tr>.",
     "After editing this file, you can run 'dart run slang apply --locale=tr' to quickly apply the newly added translations."
-  ],
-  "settingsTab": {
-    "other": {
-      "title": "Other",
-      "support": "Support LocalSend",
-      "donate": "Donate",
-      "privacyPolicy": "Privacy Policy",
-      "termsOfUse": "Terms of Use"
-    }
-  },
-  "aboutPage": {
-    "description": [
-      "LocalSend is a free, open-source app that allows you to securely share files and messages with nearby devices over your local network without needing an internet connection.",
-      "This app is available on Android, iOS, macOS, Windows and Linux. You can find all download options on the official homepage."
-    ],
-    "author": "Author",
-    "contributors": "Contributors",
-    "translators": "Translators"
-  },
-  "donationPage": {
-    "title": "Donate",
-    "info": "LocalSend is free, open source and without any ads. If you like the app, you can support the development with a donation.",
-    "donate": "Donate {amount}",
-    "thanks": "Thank you very much!",
-    "restore": "Restore purchase"
-  },
-  "dialogs": {
-    "historyClearDialog": {
-      "title": "Clear history",
-      "content": "Do you really want to delete the entire history?"
-    }
-  }
+  ]
 }

--- a/app/assets/i18n/strings_tr.i18n.json
+++ b/app/assets/i18n/strings_tr.i18n.json
@@ -123,7 +123,14 @@
       "multicastGroup": "Çoklu yayın",
       "multicastGroupWarning": "Özel çoklu yayın adresini kullandığınız için diğer cihazlar tarafından algılanamayabilirsiniz.(varsayılan: {defaultMulticast})"
     },
-    "advancedSettings": "Gelişmiş ayarlar"
+    "advancedSettings": "Gelişmiş ayarlar",
+    "other": {
+      "title": "Diğer",
+      "support": "LocalSend'i destekle",
+      "donate": "Bağış yap",
+      "privacyPolicy": "Gizlilik politikası",
+      "termsOfUse": "Kullanım koşulları"
+    }
   },
   "troubleshootPage": {
     "title": "Sorun Giderme",
@@ -213,7 +220,21 @@
     "pendingRequests": "Bekleyen istekler: {n}"
   },
   "aboutPage": {
-    "title": "LocalSend hakkında"
+    "title": "LocalSend hakkında",
+    "description": [
+      "LocalSend, internet bağlantısına ihtiyaç duymadan yerel ağınız üzerinden yakınınızdaki cihazlarla dosya ve mesajlarınızı güvenli bir şekilde paylaşmanıza olanak tanıyan özgür ve açık kaynaklı bir uygulamadır.",
+      "Bu uygulama Android, iOS, macOS, Windows ve Linux'ta mevcuttur. Tüm indirme seçeneklerini resmi ana sayfada bulabilirsiniz."
+    ],
+    "author": "Yazar",
+    "contributors": "Katkıda bulunanlar",
+    "translators": "Çevirmenler"
+  },
+  "donationPage": {
+    "title": "Bağış yap",
+    "info": "LocalSend ücretsiz, açık kaynaklı ve reklamsız bir uygulamadır. Eğer uygulamayı beğendiyseniz, bağış yaparak uygulamanın gelişimine katkıda bulunabilirsiniz.",
+    "donate": "Bağışta bulun {amount}",
+    "thanks": "Çok teşekkür ederim!",
+    "restore": "Satın alınanları geri yükle"
   },
   "changelogPage": {
     "title": "Değişiklik günlüğü"
@@ -317,6 +338,10 @@
       "single": "Dosyaları bir alıcıya gönderir. Seçim, bitmiş dosya aktarımından sonra temizlenir.",
       "multiple": "Dosyaları birden çok alıcıya gönderir. Seçim temizlenmeyecektir.",
       "link": "LocalSend yüklü olmayan alıcılar, tarayıcılarındaki bağlantıyı açarak seçilen dosyaları indirebilir."
+    },
+    "historyClearDialog": {
+      "title": "Geçmişi temizle",
+      "content": "Gerçekten tüm geçmişi silmek istiyor musunuz?"
     }
   },
   "tray": {

--- a/app/lib/pages/about/translators.dart
+++ b/app/lib/pages/about/translators.dart
@@ -20,6 +20,7 @@ const _translators = <AppLocale, List<String>>{
   AppLocale.km: ['Chandara H. Wei (@nidexingg)'],
   AppLocale.ko: ['@mgmix'],
   AppLocale.ptBr: ['Gabriel Lima (@TheGB0077)'],
+  AppLocale.tr: ['Mert Şişmanoğlu (@mertssmnoglu)'],
   AppLocale.ru: ['Sergiy (@sergd88)'],
   AppLocale.uk: ['Sergiy (@sergd88)'],
   AppLocale.vi: ['@faea726'],


### PR DESCRIPTION
# Changes

- Add missing turkish :tr: translations  
- Remove translated lines from `_missing_translations_tr.json` file

Currently, localsend seems to fully support Turkish language.

## Question
Can I add my username to tr section in [translators.dart](https://github.com/localsend/localsend/blob/main/app/lib/pages/about/translators.dart) ?

