### PR TITLE
i18n/tr Translated missing turkish words

### DIFF
--- a/app/assets/i18n/_missing_translations_tr.json
+++ b/app/assets/i18n/_missing_translations_tr.json
@@ -2,10 +2,5 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <tr>.",
     "After editing this file, you can run 'dart run slang apply --locale=tr' to quickly apply the newly added translations."
-  ],
-  "settingsTab": {
-    "receive": {
-      "autoFinish": "Auto Finish"
-    }
-  }
+  ]
 }

--- a/app/assets/i18n/strings_tr.i18n.json
+++ b/app/assets/i18n/strings_tr.i18n.json
@@ -108,7 +108,8 @@
       "destination": "Hedef klasör",
       "downloads": "(İndirilenler)",
       "saveToGallery": "Medyayı galeriye kaydet",
-      "saveToHistory": "Geçmişe kaydet"
+      "saveToHistory": "Geçmişe kaydet",
+      "autoFinish": "Otomatik bitir"
     },
     "network": {
       "title": "Ağ",


### PR DESCRIPTION
The last missing translation added to the i18n tr documentation. 
Looks like localsend is fully compatible with Turkish ( :tr: ) language.