### PR TITLE
refactor: use ip as request session

### DIFF
--- a/app/lib/provider/network/server/controller/send_controller.dart
+++ b/app/lib/provider/network/server/controller/send_controller.dart
@@ -103,7 +103,7 @@ class SendController {
       }
 
       final streamController = StreamController<bool>();
-      final sessionId = _uuid.v4();
+      final sessionId = request.ip;
       server.setState(
         (oldState) => oldState!.copyWith(
           webSendState: oldState.webSendState!.copyWith(


### PR DESCRIPTION
fix #1124 

use remote ip as every request session, has no more seession will be created on refresh browser