### PR TITLE
i18n: el added missing translations

### DIFF
--- a/app/assets/i18n/_missing_translations_el.json
+++ b/app/assets/i18n/_missing_translations_el.json
@@ -2,14 +2,5 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <el>.",
     "After editing this file, you can run 'dart run slang apply --locale=el' to quickly apply the newly added translations."
-  ],
-  "settingsTab": {
-    "send": {
-      "title": "Send",
-      "shareViaLinkAutoAccept": "Share via link: Auto accept"
-    }
-  },
-  "webSharePage": {
-    "autoAccept": "Automatically accept requests"
-  }
+  ]
 }

--- a/app/assets/i18n/strings_el.i18n.json
+++ b/app/assets/i18n/strings_el.i18n.json
@@ -111,6 +111,10 @@
       "saveToHistory": "Αποθήκευση στο ιστορικό",
 	  "autoFinish": "Αυτόματη ολοκλήρωση"
     },
+    "send": {
+      "title": "Αποστολή",
+      "shareViaLinkAutoAccept": "Κοινοποίηση μέσω συνδέσμου: Αυτόματη αποδοχή"
+    }
     "network": {
       "title": "Δίκτυο",
       "needRestart": "Κάντε επανεκκίνηση του διακομιστή για να εφαρμοστούν οι ρυθμίσεις!",
@@ -219,6 +223,7 @@
     "encryption": "@:settingsTab.network.encryption",
     "encryptionHint": "Το LocalSend χρησιμοποιεί αυτο-υπογεγραμμένο πιστοποιητικό. Χρειάζεται να το αποθεχτείτε στον φυλλομετρητή.",
     "pendingRequests": "Αναμονή αιτημάτων: {n}"
+    "autoAccept": "Αυτόματη αποδοχή αιτημάτων"
   },
   "aboutPage": {
     "title": "Σχετικά με το LocalSend",


### PR DESCRIPTION
missing el (greek) translations, translated and added to strings_el.i18n.json