### PR TITLE
feat: enable minify for android

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -70,6 +70,8 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+            minifyEnabled true
+            shrinkResources true
         }
     }
 }


### PR DESCRIPTION
![image](https://github.com/localsend/localsend/assets/51242302/f0ff8971-80f3-4d62-a57f-03d3658f5301)

localsend has never enabled this feature, resulting in android packages being larger than almost all other platforms
![image](https://github.com/localsend/localsend/assets/51242302/77ba2032-93ae-457b-b09e-5e4069aae060)
