### PR TITLE
fix: Close file stream properly

### DIFF
--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -282,7 +282,7 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
               'Content-Type': file.file.lookupMime(),
             },
           ),
-          data: file.path != null ? File(file.path!).openRead() : Stream.fromIterable([file.bytes!]),
+          data: file.path != null ? File(file.path!).openRead().asBroadcastStream() : file.bytes!,
           onSendProgress: (curr, total) {
             if (stopwatch.elapsedMilliseconds >= 100) {
               stopwatch.reset();

--- a/app/lib/provider/network/server/controller/send_controller.dart
+++ b/app/lib/provider/network/server/controller/send_controller.dart
@@ -199,7 +199,7 @@ class SendController {
       } else {
         return Response(
           200,
-          body: File(file.path!).openRead(),
+          body: File(file.path!).openRead().asBroadcastStream(),
           headers: headers,
         );
       }

--- a/app/lib/provider/network/server/controller/send_controller.dart
+++ b/app/lib/provider/network/server/controller/send_controller.dart
@@ -48,8 +48,7 @@ class SendController {
         return server.responseAsset(403, Assets.web.error403);
       }
 
-      return server.responseAsset(
-          200, Assets.web.main, 'text/javascript; charset=utf-8');
+      return server.responseAsset(200, Assets.web.main, 'text/javascript; charset=utf-8');
     });
 
     router.get('/i18n.json', (Request request) async {
@@ -78,11 +77,8 @@ class SendController {
       final requestSessionId = request.url.queryParameters['sessionId'];
       if (requestSessionId != null) {
         // Check if the user already has permission
-        final session =
-            server.getState().webSendState?.sessions[requestSessionId];
-        if (session != null &&
-            session.responseHandler == null &&
-            session.ip == request.ip) {
+        final session = server.getState().webSendState?.sessions[requestSessionId];
+        if (session != null && session.responseHandler == null && session.ip == request.ip) {
           final deviceInfo = server.ref.read(deviceInfoProvider);
           return server.responseJson(200,
               body: ReceiveRequestResponseDto(
@@ -96,8 +92,7 @@ class SendController {
                 ),
                 sessionId: session.sessionId,
                 files: {
-                  for (final entry in state.webSendState!.files.entries)
-                    entry.key: entry.value.file,
+                  for (final entry in state.webSendState!.files.entries) entry.key: entry.value.file,
                 },
               ).toJson());
         }
@@ -121,8 +116,7 @@ class SendController {
         ),
       );
 
-      final accepted = state.webSendState?.autoAccept == true ||
-          await streamController.stream.first;
+      final accepted = state.webSendState?.autoAccept == true || await streamController.stream.first;
       if (!accepted) {
         // user rejected the file transfer
         server.setState(
@@ -130,8 +124,7 @@ class SendController {
             webSendState: oldState.webSendState!.copyWith(
               sessions: {
                 for (final entry in oldState.webSendState!.sessions.entries)
-                  if (entry.key != sessionId)
-                    entry.key: entry.value, // remove session
+                  if (entry.key != sessionId) entry.key: entry.value, // remove session
               },
             ),
           ),
@@ -145,8 +138,7 @@ class SendController {
             sessionId: sessionId,
             update: (oldSession) {
               return oldSession.copyWith(
-                responseHandler:
-                    null, // this indicates that the session is active
+                responseHandler: null, // this indicates that the session is active
               );
             },
           ),
@@ -165,8 +157,7 @@ class SendController {
             ),
             sessionId: sessionId,
             files: {
-              for (final entry in state.webSendState!.files.entries)
-                entry.key: entry.value.file,
+              for (final entry in state.webSendState!.files.entries) entry.key: entry.value.file,
             },
           ).toJson());
     });
@@ -178,9 +169,7 @@ class SendController {
       }
 
       final session = server.getState().webSendState?.sessions[sessionId];
-      if (session == null ||
-          session.responseHandler != null ||
-          session.ip != request.ip) {
+      if (session == null || session.responseHandler != null || session.ip != request.ip) {
         return server.responseJson(403, message: 'Invalid sessionId.');
       }
 
@@ -194,12 +183,10 @@ class SendController {
         return server.responseJson(403, message: 'Invalid fileId.');
       }
 
-      final fileName = file.file.fileName
-          .replaceAll('/', '-'); // File name may be inside directories
+      final fileName = file.file.fileName.replaceAll('/', '-'); // File name may be inside directories
       final headers = {
         'content-type': 'application/octet-stream',
-        'content-disposition':
-            'attachment; filename="${Uri.encodeComponent(fileName)}"',
+        'content-disposition': 'attachment; filename="${Uri.encodeComponent(fileName)}"',
         'content-length': '${file.file.size}',
       };
 
@@ -233,10 +220,8 @@ class SendController {
               size: file.size,
               fileType: file.fileType,
               hash: null,
-              preview: files.first.fileType == FileType.text &&
-                      files.first.bytes != null
-                  ? utf8.decode(files.first
-                      .bytes!) // send simple message by embedding it into the preview
+              preview: files.first.fileType == FileType.text && files.first.bytes != null
+                  ? utf8.decode(files.first.bytes!) // send simple message by embedding it into the preview
                   : null,
               legacy: false,
             ),
@@ -265,8 +250,7 @@ class SendController {
   }
 
   void _respondRequest(String sessionId, bool accepted) {
-    final controller =
-        server.getState().webSendState?.sessions[sessionId]?.responseHandler;
+    final controller = server.getState().webSendState?.sessions[sessionId]?.responseHandler;
     if (controller == null) {
       return;
     }

--- a/app/lib/provider/network/server/controller/send_controller.dart
+++ b/app/lib/provider/network/server/controller/send_controller.dart
@@ -48,7 +48,8 @@ class SendController {
         return server.responseAsset(403, Assets.web.error403);
       }
 
-      return server.responseAsset(200, Assets.web.main, 'text/javascript; charset=utf-8');
+      return server.responseAsset(
+          200, Assets.web.main, 'text/javascript; charset=utf-8');
     });
 
     router.get('/i18n.json', (Request request) async {
@@ -77,8 +78,11 @@ class SendController {
       final requestSessionId = request.url.queryParameters['sessionId'];
       if (requestSessionId != null) {
         // Check if the user already has permission
-        final session = server.getState().webSendState?.sessions[requestSessionId];
-        if (session != null && session.responseHandler == null && session.ip == request.ip) {
+        final session =
+            server.getState().webSendState?.sessions[requestSessionId];
+        if (session != null &&
+            session.responseHandler == null &&
+            session.ip == request.ip) {
           final deviceInfo = server.ref.read(deviceInfoProvider);
           return server.responseJson(200,
               body: ReceiveRequestResponseDto(
@@ -92,7 +96,8 @@ class SendController {
                 ),
                 sessionId: session.sessionId,
                 files: {
-                  for (final entry in state.webSendState!.files.entries) entry.key: entry.value.file,
+                  for (final entry in state.webSendState!.files.entries)
+                    entry.key: entry.value.file,
                 },
               ).toJson());
         }
@@ -116,7 +121,8 @@ class SendController {
         ),
       );
 
-      final accepted = state.webSendState?.autoAccept == true || await streamController.stream.first;
+      final accepted = state.webSendState?.autoAccept == true ||
+          await streamController.stream.first;
       if (!accepted) {
         // user rejected the file transfer
         server.setState(
@@ -124,7 +130,8 @@ class SendController {
             webSendState: oldState.webSendState!.copyWith(
               sessions: {
                 for (final entry in oldState.webSendState!.sessions.entries)
-                  if (entry.key != sessionId) entry.key: entry.value, // remove session
+                  if (entry.key != sessionId)
+                    entry.key: entry.value, // remove session
               },
             ),
           ),
@@ -138,7 +145,8 @@ class SendController {
             sessionId: sessionId,
             update: (oldSession) {
               return oldSession.copyWith(
-                responseHandler: null, // this indicates that the session is active
+                responseHandler:
+                    null, // this indicates that the session is active
               );
             },
           ),
@@ -157,7 +165,8 @@ class SendController {
             ),
             sessionId: sessionId,
             files: {
-              for (final entry in state.webSendState!.files.entries) entry.key: entry.value.file,
+              for (final entry in state.webSendState!.files.entries)
+                entry.key: entry.value.file,
             },
           ).toJson());
     });
@@ -169,7 +178,9 @@ class SendController {
       }
 
       final session = server.getState().webSendState?.sessions[sessionId];
-      if (session == null || session.responseHandler != null || session.ip != request.ip) {
+      if (session == null ||
+          session.responseHandler != null ||
+          session.ip != request.ip) {
         return server.responseJson(403, message: 'Invalid sessionId.');
       }
 
@@ -183,10 +194,12 @@ class SendController {
         return server.responseJson(403, message: 'Invalid fileId.');
       }
 
-      final fileName = file.file.fileName.replaceAll('/', '-'); // File name may be inside directories
+      final fileName = file.file.fileName
+          .replaceAll('/', '-'); // File name may be inside directories
       final headers = {
         'content-type': 'application/octet-stream',
-        'content-disposition': 'attachment; filename="${Uri.encodeComponent(fileName)}"',
+        'content-disposition':
+            'attachment; filename="${Uri.encodeComponent(fileName)}"',
         'content-length': '${file.file.size}',
       };
 
@@ -220,8 +233,10 @@ class SendController {
               size: file.size,
               fileType: file.fileType,
               hash: null,
-              preview: files.first.fileType == FileType.text && files.first.bytes != null
-                  ? utf8.decode(files.first.bytes!) // send simple message by embedding it into the preview
+              preview: files.first.fileType == FileType.text &&
+                      files.first.bytes != null
+                  ? utf8.decode(files.first
+                      .bytes!) // send simple message by embedding it into the preview
                   : null,
               legacy: false,
             ),
@@ -250,7 +265,8 @@ class SendController {
   }
 
   void _respondRequest(String sessionId, bool accepted) {
-    final controller = server.getState().webSendState?.sessions[sessionId]?.responseHandler;
+    final controller =
+        server.getState().webSendState?.sessions[sessionId]?.responseHandler;
     if (controller == null) {
       return;
     }


### PR DESCRIPTION
Fixes #1062, fixes #1000

Since the broadcast stream cancels itself when there are no current subscribers, it can properly release file handles even if the read stream is interrupted.

I have tested it on my Windows PC and it works as expected and it should work fine on other machines.

Reference: [Stream.asBroadcastStream()](https://api.flutter.dev/flutter/dart-async/Stream/asBroadcastStream.html)