### PR TITLE
Linux: Use tray_manager instead of system_tray; remove system_tray

### DIFF
--- a/app/lib/util/native/tray_helper.dart
+++ b/app/lib/util/native/tray_helper.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:localsend_app/gen/assets.gen.dart';
 import 'package:localsend_app/gen/strings.g.dart';
@@ -6,7 +5,6 @@ import 'package:localsend_app/provider/animation_provider.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:logging/logging.dart';
 import 'package:refena_flutter/refena_flutter.dart';
-import 'package:system_tray/system_tray.dart';
 import 'package:tray_manager/tray_manager.dart' as tm;
 import 'package:window_manager/window_manager.dart';
 

--- a/app/lib/util/native/tray_helper.dart
+++ b/app/lib/util/native/tray_helper.dart
@@ -21,63 +21,35 @@ Future<void> initTray() async {
   if (!checkPlatformHasTray()) {
     return;
   }
-  if (!checkPlatform([TargetPlatform.linux])) {
-    try {
-      if (checkPlatform([TargetPlatform.windows])) {
-        await tm.trayManager.setIcon(
-          Assets.img.logo,
-        );
-      } else if (checkPlatform([TargetPlatform.macOS])) {
-        await tm.trayManager.setIcon(Assets.img.logo32Black.path, isTemplate: true);
-      } else {
-        await tm.trayManager.setIcon(Assets.img.logo32.path);
-      }
-
-      final items = [
-        tm.MenuItem(
-          key: TrayEntry.open.name,
-          label: t.tray.open,
-        ),
-        tm.MenuItem(
-          key: TrayEntry.close.name,
-          label: t.tray.close,
-        ),
-      ];
-      await tm.trayManager.setContextMenu(tm.Menu(items: items));
-      await tm.trayManager.setToolTip(t.appName);
-    } catch (e) {
-      _logger.warning('Failed to init tray', e);
+  try {
+    if (checkPlatform([TargetPlatform.windows])) {
+      await tm.trayManager.setIcon(Assets.img.logo);
+    } else if (checkPlatform([TargetPlatform.macOS])) {
+      await tm.trayManager.setIcon(Assets.img.logo32Black.path, isTemplate: true);
+    } else if (checkPlatform([TargetPlatform.linux])) {
+      await tm.trayManager.setIcon(Assets.img.logo32White.path);
+    } else {
+      await tm.trayManager.setIcon(Assets.img.logo32.path);
     }
-  } else {
-    // The Linux tray display is handled by systemTray instead
-    final SystemTray systemTray = SystemTray();
 
-    await systemTray.initSystemTray(
-      title: t.appName,
-      iconPath: Assets.img.logo32White.path,
-    );
-
-    final Menu menu = Menu();
-    await menu.buildFrom([
-      MenuItemLabel(
+    final items = [
+      tm.MenuItem(
+        key: TrayEntry.open.name,
         label: t.tray.open,
-        onClicked: (menuItem) async {
-          await windowManager.show();
-          await windowManager.focus();
-        },
       ),
-      MenuItemLabel(label: t.tray.close, onClicked: (menuItem) => exit(0)),
-    ]);
-
-    await systemTray.setContextMenu(menu);
-
-    systemTray.registerSystemTrayEventHandler((eventName) {
-      if (eventName == kSystemTrayEventClick) {
-        systemTray.popUpContextMenu();
-      } else if (eventName == kSystemTrayEventRightClick) {
-        WindowManager.instance.show();
-      }
-    });
+      tm.MenuItem(
+        key: TrayEntry.close.name,
+        label: t.tray.close,
+      ),
+    ];
+    await tm.trayManager.setContextMenu(tm.Menu(items: items));
+    // No Linux implementation for setToolTip available as of tray_manager 0.2.2
+    // https://pub.dev/packages/tray_manager#api
+    if (!checkPlatform([TargetPlatform.linux])) {
+      await tm.trayManager.setToolTip(t.appName);
+    }
+  } catch (e) {
+    _logger.warning('Failed to init tray', e);
   }
 }
 

--- a/app/linux/flutter/generated_plugin_registrant.cc
+++ b/app/linux/flutter/generated_plugin_registrant.cc
@@ -12,7 +12,6 @@
 #include <gtk/gtk_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
-#include <system_tray/system_tray_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -36,9 +35,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
-  g_autoptr(FlPluginRegistrar) system_tray_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "SystemTrayPlugin");
-  system_tray_plugin_register_with_registrar(system_tray_registrar);
   g_autoptr(FlPluginRegistrar) tray_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "TrayManagerPlugin");
   tray_manager_plugin_register_with_registrar(tray_manager_registrar);

--- a/app/linux/flutter/generated_plugin_registrant.cc
+++ b/app/linux/flutter/generated_plugin_registrant.cc
@@ -13,6 +13,7 @@
 #include <pasteboard/pasteboard_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <system_tray/system_tray_plugin.h>
+#include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -38,6 +39,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) system_tray_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "SystemTrayPlugin");
   system_tray_plugin_register_with_registrar(system_tray_registrar);
+  g_autoptr(FlPluginRegistrar) tray_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "TrayManagerPlugin");
+  tray_manager_plugin_register_with_registrar(tray_manager_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -9,7 +9,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   gtk
   pasteboard
   screen_retriever
-  system_tray
   tray_manager
   url_launcher_linux
   window_manager

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -10,6 +10,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   pasteboard
   screen_retriever
   system_tray
+  tray_manager
   url_launcher_linux
   window_manager
 )

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import dynamic_color
 import file_selector_macos
 import gal
 import in_app_purchase_storekit
+import macos_dock_progress
 import network_info_plus
 import package_info_plus
 import pasteboard
@@ -34,6 +35,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
+  MacosDockProgressPlugin.register(with: registry.registrar(forPlugin: "MacosDockProgressPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -20,7 +20,6 @@ import path_provider_foundation
 import photo_manager
 import screen_retriever
 import shared_preferences_foundation
-import system_tray
 import tray_manager
 import url_launcher_macos
 import video_player_avfoundation
@@ -43,7 +42,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  SystemTrayPlugin.register(with: registry.registrar(forPlugin: "SystemTrayPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1509,12 +1509,11 @@ packages:
   tray_manager:
     dependency: "direct main"
     description:
-      path: "."
-      ref: b37f5e088e0f02c45a684ae41e9d2da2d5c596db
-      resolved-ref: b37f5e088e0f02c45a684ae41e9d2da2d5c596db
-      url: "https://github.com/Tienisto/tray_manager.git"
-    source: git
-    version: "0.2.0"
+      name: tray_manager
+      sha256: e0ac9a88b2700f366b8629b97e8663b6ef450a2f169560a685dc167bfe9c9c29
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   type_plus:
     dependency: transitive
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -812,6 +812,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macos_dock_progress:
+    dependency: "direct main"
+    description:
+      name: macos_dock_progress
+      sha256: "4dfd32c3117903944d9069ec2b22054e5226180cea57ad94b5908436609eb884"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   markdown:
     dependency: transitive
     description:
@@ -1738,6 +1746,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.8"
+  windows_taskbar:
+    dependency: "direct main"
+    description:
+      name: windows_taskbar
+      sha256: "204edfdb280a7053febdf50fc9b49b3c007255bd8a83c082d10c174ec6548f33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   xdg_directories:
     dependency: transitive
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1458,14 +1458,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  system_tray:
-    dependency: "direct main"
-    description:
-      name: system_tray
-      sha256: "40444e5de8ed907822a98694fd031b8accc3cb3c0baa547634ce76189cf3d9cf"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
   term_glyph:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -61,7 +61,6 @@ dependencies:
   slang: 3.29.0
   slang_flutter: 3.29.0
   system_settings: 2.1.0
-  system_tray: 2.0.3
   tray_manager: 0.2.2
   url_launcher: 6.2.4
   uuid: 3.0.7

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -62,12 +62,7 @@ dependencies:
   slang_flutter: 3.29.0
   system_settings: 2.1.0
   system_tray: 2.0.3
-  tray_manager:
-    # https://github.com/leanflutter/tray_manager/issues/30
-    # The Linux tray manager is disabled for now
-    git:
-      url: https://github.com/Tienisto/tray_manager.git
-      ref: b37f5e088e0f02c45a684ae41e9d2da2d5c596db
+  tray_manager: 0.2.2
   url_launcher: 6.2.4
   uuid: 3.0.7
   wakelock_plus: 1.1.4

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -14,7 +14,6 @@
 #include <pasteboard/pasteboard_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
-#include <system_tray/system_tray_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
@@ -37,8 +36,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenRetrieverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
-  SystemTrayPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("SystemTrayPlugin"));
   TrayManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("TrayManagerPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -18,6 +18,7 @@
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
+#include <windows_taskbar/windows_taskbar_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
@@ -44,4 +45,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
+  WindowsTaskbarPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowsTaskbarPlugin"));
 }

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -11,7 +11,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   pasteboard
   permission_handler_windows
   screen_retriever
-  system_tray
   tray_manager
   url_launcher_windows
   window_manager

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -15,6 +15,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   tray_manager
   url_launcher_windows
   window_manager
+  windows_taskbar
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Using [tray_manager](https://pub.dev/packages/tray_manager) for Linux as well allows ditching of the unreliable and seemingly less-than-well maintained flutter library [system_tray](https://pub.dev/packages/system_tray) and unifies desktop tray handling across platforms.

At the same time, use upstream `tray_manager` instead of a forked repo (which was stuck on 0.2 and did not contain e.g. leanflutter/tray_manager#38 ). This additionally enables building on Linux again since Tienisto's forked repo used to disable the Linux plugin: Tienisto/tray_manager@b37f5e0. This also works around issues with newer libayatana-appindicator versions: leanflutter/tray_manager#38

Caveats discussed previously still apply: https://github.com/localsend/localsend/pull/404

Mainly:
- Flutter versions installed using `snap` having incompatible `GLib`: https://github.com/leanflutter/tray_manager/issues/30 and https://github.com/leanflutter/tray_manager/issues/28.
  Note that the incompatibility should have existed with both `system_tray` as well as `tray_manager`, the latter being a slightly more maintained fork (?) but utilizing very similar build macros
- Reliance on `libayatana-*` packages

As for @TheGB0077 saying:

> (I tried to make the tray manager work for Linux but it didn't work still)

I'm not quite sure what the issue was, but it seems to work okay now. The only thing to keep note of for me was to guard the call to `setToolTip()` since it would throw a `MissingPluginException` on Linux, but this was noted in the API docs of `tray_manager`.


For reference, potentially relevant prior discussions/commits: 
- https://github.com/localsend/localsend/commit/53b1899aec3ab2e74681c908274c8dd7e387e99d
- https://github.com/localsend/localsend/issues/409
- https://github.com/localsend/localsend/issues/651

### Issues?

I have only tested this on an up-to-date Arch Linux system and cannot speak to the viability of `tray_manager` for other (older) distros.

It seems that the `AppImage` and `Flatpak` distributors as well as Debian-based systems _might_ not be fully compatible with _anything_ recent, but I cannot see how re-enabling `tray_manager` on Linux would surface any additional errors that weren't previously being thrown by `system_tray`.

My setup:
```
libappindicator-gtk3 12.10.0.r298-3
libayatana-appindicator 0.5.93-1
libayatana-indicator 0.9.4-1
libcanberra 1:0.30+r2+gc0620e4-3
```
With `flutter` installed through `fvm`:
```
$ fvm flutter --version
Flutter 3.13.9 • channel stable • https://github.com/flutter/flutter.git
Framework • revision d211f42860 (5 months ago) • 2023-10-25 13:42:25 -0700
Engine • revision 0545f8705d
Tools • Dart 3.1.5 • DevTools 2.25.0
```