### PR TITLE
README: Reword and re-style "Getting Started" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,17 @@ For more information on the LocalSend Protocol, see the [documentation](https://
 
 To compile LocalSend from the source code, follow these steps:
 
-1. Install [Flutter](https://flutter.dev).
-2. Clone the LocalSend repository.
-3. Run `cd app` to enter the app directory.
-4. Run `flutter pub get` to download dependencies.
-5. Run `flutter run` to start the app.
+1. Install Flutter [directly](https://flutter.dev) or using [fvm](https://fvm.app) (see [version required](.fvm/fvm_config.json))
+2. Clone the `LocalSend` repository
+3. Run `cd app` to enter the app directory
+4. Run `flutter pub get` to download dependencies
+5. Run `flutter run` to start the app
 
-The issue may be caused by a mismatch between the required Flutter version and the installed Flutter version.
-
-LocalSend uses [fvm](https://fvm.app) to manage the project Flutter version (specified in [.fvm/fvm_config.json](.fvm/fvm_config.json)). After you install it, run `fvm flutter` instead of `flutter`.
+> [!NOTE]
+> LocalSend currently requires an older Flutter version (specified in [.fvm/fvm_config.json](.fvm/fvm_config.json))
+> and thus build issues may be caused by a mismatch between the required and the (system-wide) installed Flutter version.  
+> To make development more consistent, LocalSend uses [fvm](https://fvm.app) to manage the project Flutter version.
+> After installing `fvm`, run `fvm flutter` instead of `flutter`.
 
 ## Contributing
 


### PR DESCRIPTION
Push users more heavily towards using `fvm` and get rid of nonsensical previous edits to this section.

Distro-provided flutter versions are almost certainly either too old or too recent for this roject (currently requiring Flutter SDK 3.13, yet e.g. Arch Linux provides an incompatible 3.19 in AUR), leading to unnecessary irritation and confusion when running subsequent `flutter` and `pub` commands.

---

The reason for me creating this PR was time wasted trying to make the `Flutter` version supplied by my distro work with LocalSend and finding out too late it relies on an outdated SDK version

> The issue may be caused ...

What even is that wording? Totally read right past that and assumed it was from a different section. I see https://github.com/localsend/localsend/pull/809 and https://github.com/localsend/localsend/pull/817 as well as https://github.com/localsend/localsend/pull/969 have actively worsened the readability of this section; it might be sensible to reject such garbage github-profile-inflating edits in the future.