### PR TITLE
Add Button to quickly clear selection

### DIFF
--- a/app/lib/pages/tabs/send_tab.dart
+++ b/app/lib/pages/tabs/send_tab.dart
@@ -11,6 +11,7 @@ import 'package:localsend_app/provider/network/nearby_devices_provider.dart';
 import 'package:localsend_app/provider/network/scan_facade.dart';
 import 'package:localsend_app/provider/network/send_provider.dart';
 import 'package:localsend_app/provider/progress_provider.dart';
+import 'package:localsend_app/provider/selection/selected_sending_files_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/theme.dart';
 import 'package:localsend_app/util/file_size_helper.dart';
@@ -88,9 +89,26 @@ class SendTab extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        t.sendTab.selection.title,
-                        style: Theme.of(context).textTheme.titleMedium,
+                      Row(
+                        children: [
+                          Text(
+                            t.sendTab.selection.title,
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const Spacer(),
+                          CustomIconButton(
+                            onPressed: () {
+                              ref
+                                .redux(selectedSendingFilesProvider)
+                                .dispatch(ClearSelectionAction());
+                              context.popUntilRoot();
+                            },
+                            child: Icon(
+                              Icons.close,
+                              color: Theme.of(context).colorScheme.secondary
+                            ),
+                          ),
+                        ],
                       ),
                       const SizedBox(height: 5),
                       Text(t.sendTab.selection.files(files: vm.selectedFiles.length)),

--- a/app/lib/pages/tabs/send_tab.dart
+++ b/app/lib/pages/tabs/send_tab.dart
@@ -101,7 +101,6 @@ class SendTab extends StatelessWidget {
                               ref
                                 .redux(selectedSendingFilesProvider)
                                 .dispatch(ClearSelectionAction());
-                              context.popUntilRoot();
                             },
                             child: Icon(
                               Icons.close,


### PR DESCRIPTION
### Solves issue #1091 

As mentioned in the linked issue, this PR adds a new button on the `send_tab` element of the "Send Page". This button clears the current file selection. The reason behind this is to reduce the UX friction for that action.

See video:
https://github.com/localsend/localsend/assets/38408878/0f05dd53-e055-4a96-b5ba-65d4903b6a36