### PR TITLE
Rename NixOS to Nixpkgs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Git based distribution:
 | [Homebrew][]   | [Homebrew Repo][]   | [@Tienisto][], Github Actions                      |
 | [Flathub][]    | [Flathub Repo][]    | [@proletarius101][], [@Tienisto][], Github Actions |
 | [AUR][]        | [AUR Repo][]        | [@Nixuge][]                                        |
-| [NixOS][]      | [NixOS Repo][]      | [@sikmir][], [@linsui][]                           |
+| [Nixpkgs][]    | [Nixpkgs Repo][]    | [@sikmir][], [@linsui][]                           |
 | [F-Droid][]    | [F-Droid Repo][]    | [@linsui][], [@Tienisto][], [F-Droid CI][]         |
 
 [winget]: https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/LocalSend/LocalSend

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is recommended to download the app either from an app store or from a package
 |--------------------------|-------------------------|--------------------|----------------|---------------|------------|
 | [Winget][]               | [App Store][]           | [Flathub][]        | [Play Store][] | [App Store][] | [Amazon][] |
 | [Scoop][]                | [Homebrew][]            | [AUR][]            | [F-Droid][]    |               |            |
-| [Chocolatey][]           | [DMG Installer][latest] | [NixOS][]          | [APK][latest]  |               |            |
+| [Chocolatey][]           | [DMG Installer][latest] | [Nixpkgs][]        | [APK][latest]  |               |            |
 | [MSIX Installer][latest] |                         | [TAR][latest]      |                |               |            |
 | [EXE Installer][latest]  |                         | [DEB][latest]      |                |               |            |
 | [Portable ZIP][latest]   |                         | [AppImage][latest] |                |               |            |
@@ -65,7 +65,7 @@ Read more about [distribution channels][].
 [homebrew]: https://github.com/localsend/homebrew-localsend
 [flathub]: https://flathub.org/apps/details/org.localsend.localsend_app
 [aur]: https://aur.archlinux.org/packages/localsend-bin
-[nixos]: https://search.nixos.org/packages?show=localsend
+[nixpkgs]: https://search.nixos.org/packages?show=localsend
 [latest]: https://github.com/localsend/localsend/releases/latest
 [distribution channels]: https://github.com/localsend/localsend/blob/main/CONTRIBUTING.md#distribution
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -51,7 +51,7 @@ LocalSend 是一个跨平台应用程序，使用 REST API 和 HTTPS 加密实�
 |--------------------------|-------------------------|--------------------|----------------|---------------|------------|
 | [Winget][]               | [App Store][]           | [Flathub][]        | [Play Store][] | [App Store][] | [Amazon][] |
 | [Scoop][]                | [Homebrew][]            | [AUR][]            | [F-Droid][]    |               |            |
-| [Chocolatey][]           | [DMG Installer][latest] | [NixOS][]          | [APK][latest]  |               |            |
+| [Chocolatey][]           | [DMG Installer][latest] | [Nixpkgs][]        | [APK][latest]  |               |            |
 | [MSIX Installer][latest] |                         | [TAR][latest]      |                |               |            |
 | [EXE Installer][latest]  |                         | [DEB][latest]      |                |               |            |
 | [Portable ZIP][latest]   |                         | [AppImage][latest] |                |               |            |
@@ -70,7 +70,7 @@ LocalSend 是一个跨平台应用程序，使用 REST API 和 HTTPS 加密实�
 [homebrew]: https://github.com/localsend/homebrew-localsend
 [flathub]: https://flathub.org/apps/details/org.localsend.localsend_app
 [aur]: https://aur.archlinux.org/packages/localsend-bin
-[nixos]: https://search.nixos.org/packages?show=localsend
+[nixpkgs]: https://search.nixos.org/packages?show=localsend
 [latest]: https://github.com/localsend/localsend/releases/latest
 [发行渠道]: https://github.com/localsend/localsend/blob/main/CONTRIBUTING.md#distribution
 


### PR DESCRIPTION
-> Addresses issue #1258 

As stated in the mentioned issue, the Nix package manager isn't tied specifically to NixOS. This PR simply relabeled all mentions of NixOS.