### PR TITLE
Fixed a grammatic error in Swedish Translation

### DIFF
--- a/app/assets/i18n/strings_sv.i18n.json
+++ b/app/assets/i18n/strings_sv.i18n.json
@@ -24,7 +24,7 @@
     "offline": "Offline",
     "on": "På",
     "online": "Online",
-    "open": "Öppen",
+    "open": "Öppna",
     "queue": "Kö",
     "quickSave": "Snabbspara",
     "renamed": "Bytt namn",


### PR DESCRIPTION
"Öppen" means (thing) is already open while "Öppna" means to open (thing).