### PR TITLE
feat: always receive trusted

### DIFF
--- a/app/assets/i18n/strings.i18n.json
+++ b/app/assets/i18n/strings.i18n.json
@@ -105,6 +105,11 @@
     "receive": {
       "title": "Receive",
       "quickSave": "@:general.quickSave",
+      "quickSaveType": {
+        "disabled": "Disabled",
+        "enabledForTrusted": "Only favorite devices",
+        "enabled": "Enabled for all"
+      },
       "autoFinish": "Auto Finish",
       "destination": "Destination",
       "downloads": "(Downloads)",

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -19,7 +19,7 @@ class SettingsState with SettingsStateMappable {
   final String? destination; // null = default
   final bool saveToGallery; // only Android, iOS
   final bool saveToHistory;
-  final bool quickSave; // automatically accept file requests
+  final QuickSaveType quickSaveType; // whether to automatically accept file requests
   final bool autoFinish; // automatically finish sessions
   final bool minimizeToTray; // minimize to tray instead of exiting the app
   final bool launchAtStartup; // Tracks if the option is enabled on Linux
@@ -43,7 +43,7 @@ class SettingsState with SettingsStateMappable {
     required this.destination,
     required this.saveToGallery,
     required this.saveToHistory,
-    required this.quickSave,
+    required this.quickSaveType,
     required this.autoFinish,
     required this.minimizeToTray,
     required this.launchAtStartup,

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -41,8 +41,8 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
   static const Field<SettingsState, bool> _f$saveToGallery = Field('saveToGallery', _$saveToGallery);
   static bool _$saveToHistory(SettingsState v) => v.saveToHistory;
   static const Field<SettingsState, bool> _f$saveToHistory = Field('saveToHistory', _$saveToHistory);
-  static bool _$quickSave(SettingsState v) => v.quickSave;
-  static const Field<SettingsState, bool> _f$quickSave = Field('quickSave', _$quickSave);
+  static QuickSaveType _$quickSaveType(SettingsState v) => v.quickSaveType;
+  static const Field<SettingsState, QuickSaveType> _f$quickSaveType = Field('quickSaveType', _$quickSaveType);
   static bool _$autoFinish(SettingsState v) => v.autoFinish;
   static const Field<SettingsState, bool> _f$autoFinish = Field('autoFinish', _$autoFinish);
   static bool _$minimizeToTray(SettingsState v) => v.minimizeToTray;
@@ -78,7 +78,7 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #destination: _f$destination,
     #saveToGallery: _f$saveToGallery,
     #saveToHistory: _f$saveToHistory,
-    #quickSave: _f$quickSave,
+    #quickSaveType: _f$quickSaveType,
     #autoFinish: _f$autoFinish,
     #minimizeToTray: _f$minimizeToTray,
     #launchAtStartup: _f$launchAtStartup,
@@ -104,7 +104,7 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
         destination: data.dec(_f$destination),
         saveToGallery: data.dec(_f$saveToGallery),
         saveToHistory: data.dec(_f$saveToHistory),
-        quickSave: data.dec(_f$quickSave),
+        quickSaveType: data.dec(_f$quickSaveType),
         autoFinish: data.dec(_f$autoFinish),
         minimizeToTray: data.dec(_f$minimizeToTray),
         launchAtStartup: data.dec(_f$launchAtStartup),
@@ -174,7 +174,7 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out> implem
       String? destination,
       bool? saveToGallery,
       bool? saveToHistory,
-      bool? quickSave,
+      QuickSaveType? quickSaveType,
       bool? autoFinish,
       bool? minimizeToTray,
       bool? launchAtStartup,
@@ -207,7 +207,7 @@ class _SettingsStateCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Setting
           Object? destination = $none,
           bool? saveToGallery,
           bool? saveToHistory,
-          bool? quickSave,
+          QuickSaveType? quickSaveType,
           bool? autoFinish,
           bool? minimizeToTray,
           bool? launchAtStartup,
@@ -230,7 +230,7 @@ class _SettingsStateCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Setting
         if (destination != $none) #destination: destination,
         if (saveToGallery != null) #saveToGallery: saveToGallery,
         if (saveToHistory != null) #saveToHistory: saveToHistory,
-        if (quickSave != null) #quickSave: quickSave,
+        if (quickSaveType != null) #quickSaveType: quickSaveType,
         if (autoFinish != null) #autoFinish: autoFinish,
         if (minimizeToTray != null) #minimizeToTray: minimizeToTray,
         if (launchAtStartup != null) #launchAtStartup: launchAtStartup,
@@ -255,7 +255,7 @@ class _SettingsStateCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Setting
       destination: data.get(#destination, or: $value.destination),
       saveToGallery: data.get(#saveToGallery, or: $value.saveToGallery),
       saveToHistory: data.get(#saveToHistory, or: $value.saveToHistory),
-      quickSave: data.get(#quickSave, or: $value.quickSave),
+      quickSaveType: data.get(#quickSaveType, or: $value.quickSaveType),
       autoFinish: data.get(#autoFinish, or: $value.autoFinish),
       minimizeToTray: data.get(#minimizeToTray, or: $value.minimizeToTray),
       launchAtStartup: data.get(#launchAtStartup, or: $value.launchAtStartup),

--- a/app/lib/pages/tabs/receive_tab.dart
+++ b/app/lib/pages/tabs/receive_tab.dart
@@ -1,3 +1,4 @@
+import 'package:common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/pages/home_page.dart';
@@ -7,6 +8,7 @@ import 'package:localsend_app/provider/animation_provider.dart';
 import 'package:localsend_app/provider/ui/home_tab_provider.dart';
 import 'package:localsend_app/util/ip_helper.dart';
 import 'package:localsend_app/widget/animations/initial_fade_transition.dart';
+import 'package:localsend_app/widget/custom_dropdown_button.dart';
 import 'package:localsend_app/widget/custom_icon_button.dart';
 import 'package:localsend_app/widget/local_send_logo.dart';
 import 'package:localsend_app/widget/responsive_list_view.dart';
@@ -73,22 +75,26 @@ class ReceiveTab extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(top: 10),
                     child: Center(
-                      child: vm.quickSaveSettings
-                          ? ElevatedButton(
-                              style: ElevatedButton.styleFrom(
-                                backgroundColor: Theme.of(context).colorScheme.primary,
-                                foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                              ),
-                              onPressed: () async => vm.onSetQuickSave(context, false),
-                              child: Text('${t.general.quickSave}: ${t.general.on}'),
-                            )
-                          : TextButton(
-                              style: TextButton.styleFrom(
-                                foregroundColor: Colors.grey,
-                              ),
-                              onPressed: () async => vm.onSetQuickSave(context, true),
-                              child: Text('${t.general.quickSave}: ${t.general.off}'),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Text(t.settingsTab.receive.quickSave),
+                          ),
+                          Expanded(
+                            child: CustomDropdownButton<QuickSaveType>(
+                              value: vm.quickSaveSettings,
+                              items: QuickSaveType.values.map((type) {
+                                return DropdownMenuItem(
+                                  value: type,
+                                  alignment: Alignment.center,
+                                  child: Text(type.humanName, textAlign: TextAlign.center),
+                                );
+                              }).toList(),
+                              onChanged: (type) async => await vm.onSetQuickSave(context, type),
                             ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                   const SizedBox(height: 15),
@@ -181,5 +187,15 @@ class ReceiveTab extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+extension on QuickSaveType {
+  String get humanName {
+    return switch (this) {
+      QuickSaveType.disabled => t.settingsTab.receive.quickSaveType.disabled,
+      QuickSaveType.enabledForTrusted => t.settingsTab.receive.quickSaveType.enabledForTrusted,
+      QuickSaveType.enabled => t.settingsTab.receive.quickSaveType.enabled,
+    };
   }
 }

--- a/app/lib/pages/tabs/receive_tab_vm.dart
+++ b/app/lib/pages/tabs/receive_tab_vm.dart
@@ -1,3 +1,4 @@
+import 'package:common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/model/state/server/server_state.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
@@ -16,13 +17,13 @@ final _showHistoryButtonProvider = StateProvider<bool>((ref) => true, debugLabel
 
 class ReceiveTabVm {
   final String aliasSettings;
-  final bool quickSaveSettings;
+  final QuickSaveType quickSaveSettings;
   final ServerState? serverState;
   final List<String> localIps;
   final bool showAdvanced;
   final bool showHistoryButton;
   final Future<void> Function() toggleAdvanced;
-  final Future<void> Function(BuildContext context, bool enable) onSetQuickSave;
+  final Future<void> Function(BuildContext context, QuickSaveType enable) onSetQuickSave;
 
   const ReceiveTabVm({
     required this.aliasSettings,
@@ -37,7 +38,7 @@ class ReceiveTabVm {
 }
 
 final receiveTabVmProvider = ViewProvider((ref) {
-  final (alias, quickSave) = ref.watch(settingsProvider.select((s) => (s.alias, s.quickSave)));
+  final (alias, quickSaveType) = ref.watch(settingsProvider.select((s) => (s.alias, s.quickSaveType)));
   final networkInfo = ref.watch(localIpProvider).localIps;
   final serverState = ref.watch(serverProvider);
   final showAdvanced = ref.watch(_showAdvancedProvider);
@@ -45,7 +46,7 @@ final receiveTabVmProvider = ViewProvider((ref) {
 
   return ReceiveTabVm(
     aliasSettings: alias,
-    quickSaveSettings: quickSave,
+    quickSaveSettings: quickSaveType,
     serverState: serverState,
     localIps: networkInfo,
     showAdvanced: showAdvanced,
@@ -60,9 +61,9 @@ final receiveTabVmProvider = ViewProvider((ref) {
         ref.notifier(_showHistoryButtonProvider).setState((_) => false);
       }
     },
-    onSetQuickSave: (context, enable) async {
-      await ref.notifier(settingsProvider).setQuickSave(enable);
-      if (enable && context.mounted) {
+    onSetQuickSave: (context, quickSaveType) async {
+      await ref.notifier(settingsProvider).setQuickSave(quickSaveType);
+      if (quickSaveType == QuickSaveType.enabled && context.mounted) {
         await QuickSaveNotice.open(context);
       }
     },

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -169,16 +169,24 @@ class SettingsTab extends StatelessWidget {
             _SettingsSection(
               title: t.settingsTab.receive.title,
               children: [
-                _BooleanEntry(
+                _SettingsEntry(
                   label: t.settingsTab.receive.quickSave,
-                  value: vm.settings.quickSave,
-                  onChanged: (b) async {
-                    final old = vm.settings.quickSave;
-                    await ref.notifier(settingsProvider).setQuickSave(b);
-                    if (!old && b && context.mounted) {
-                      await QuickSaveNotice.open(context);
-                    }
-                  },
+                  child: CustomDropdownButton<QuickSaveType>(
+                    value: vm.settings.quickSaveType,
+                    items: QuickSaveType.values.map((quickSaveType) {
+                      return DropdownMenuItem(
+                        value: quickSaveType,
+                        alignment: Alignment.center,
+                        child: Text(quickSaveType.humanName, textAlign: TextAlign.center),
+                      );
+                    }).toList(),
+                    onChanged: (quickSaveType) async {
+                      await ref.notifier(settingsProvider).setQuickSave(quickSaveType);
+                      if (quickSaveType == QuickSaveType.enabled && context.mounted) {
+                        await QuickSaveNotice.open(context);
+                      }
+                    },
+                  ),
                 ),
                 if (checkPlatformWithFileSystem())
                   _SettingsEntry(
@@ -650,6 +658,16 @@ extension on ColorMode {
       ColorMode.localsend => t.appName,
       ColorMode.oled => t.settingsTab.general.colorOptions.oled,
       ColorMode.yaru => 'Yaru',
+    };
+  }
+}
+
+extension on QuickSaveType {
+  String get humanName {
+    return switch (this) {
+      QuickSaveType.disabled => t.settingsTab.receive.quickSaveType.disabled,
+      QuickSaveType.enabledForTrusted => t.settingsTab.receive.quickSaveType.enabledForTrusted,
+      QuickSaveType.enabled => t.settingsTab.receive.quickSaveType.enabled,
     };
   }
 }

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -55,7 +55,7 @@ const _multicastGroupKey = 'ls_multicast_group';
 const _destinationKey = 'ls_destination';
 const _saveToGallery = 'ls_save_to_gallery';
 const _saveToHistory = 'ls_save_to_history';
-const _quickSave = 'ls_quick_save';
+const _quickSaveType = 'ls_quick_save_type';
 const _autoFinish = 'ls_auto_finish';
 const _minimizeToTray = 'ls_minimize_to_tray';
 const _launchAtStartup = 'ls_launch_at_startup';
@@ -276,12 +276,12 @@ class PersistenceService {
     await _prefs.setBool(_saveToHistory, saveToHistory);
   }
 
-  bool isQuickSave() {
-    return _prefs.getBool(_quickSave) ?? false;
+  QuickSaveType getQuickSaveType() {
+    return QuickSaveType.values.firstWhereOrNull((m) => m.name == _prefs.getString(_quickSaveType)) ?? QuickSaveType.disabled;
   }
 
-  Future<void> setQuickSave(bool quickSave) async {
-    await _prefs.setBool(_quickSave, quickSave);
+  Future<void> setQuickSaveType(QuickSaveType quickSaveType) async {
+    await _prefs.setString(_quickSaveType, quickSaveType.name);
   }
 
   bool isAutoFinish() {

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -28,7 +28,7 @@ class SettingsService extends PureNotifier<SettingsState> {
         destination: _persistence.getDestination(),
         saveToGallery: _persistence.isSaveToGallery(),
         saveToHistory: _persistence.isSaveToHistory(),
-        quickSave: _persistence.isQuickSave(),
+        quickSaveType: _persistence.getQuickSaveType(),
         autoFinish: _persistence.isAutoFinish(),
         minimizeToTray: _persistence.isMinimizeToTray(),
         launchAtStartup: _persistence.isLaunchAtStartup(),
@@ -105,10 +105,10 @@ class SettingsService extends PureNotifier<SettingsState> {
     );
   }
 
-  Future<void> setQuickSave(bool quickSave) async {
-    await _persistence.setQuickSave(quickSave);
+  Future<void> setQuickSave(QuickSaveType quickSaveType) async {
+    await _persistence.setQuickSaveType(quickSaveType);
     state = state.copyWith(
-      quickSave: quickSave,
+      quickSaveType: quickSaveType,
     );
   }
 

--- a/common/lib/common.dart
+++ b/common/lib/common.dart
@@ -10,5 +10,6 @@ export 'package:common/src/model/dto/receive_request_response_dto.dart';
 export 'package:common/src/model/dto/register_dto.dart';
 export 'package:common/src/model/file_status.dart';
 export 'package:common/src/model/file_type.dart';
+export 'package:common/src/model/quick_save_type.dart';
 export 'package:common/src/model/session_status.dart';
 export 'package:common/src/model/stored_security_context.dart';

--- a/common/lib/src/model/quick_save_type.dart
+++ b/common/lib/src/model/quick_save_type.dart
@@ -1,0 +1,5 @@
+enum QuickSaveType {
+  disabled,
+  enabledForTrusted,
+  enabled,
+}


### PR DESCRIPTION
Hello. I implemented a feature to enable quick save only for 'trusted' devices. Currently it just check if the sender is in the favorite device list and doesn't have it's own list (it's enough for me). Please take a look.

Related issue https://github.com/localsend/localsend/issues/861