### PR TITLE
Add filename sanitization

### DIFF
--- a/app/assets/i18n/strings.i18n.json
+++ b/app/assets/i18n/strings.i18n.json
@@ -424,6 +424,10 @@
       "link": "Recipients who do not have LocalSend installed can download the selected files by opening the link in their browser."
     }
   },
+  "sanitization": {
+    "empty": "Filename cannot be empty",
+    "invalid": "Filename contains invalid characters"
+  },
   "tray": {
     "@info": "Apple Guidelines are very strict about the 'close' wording.",
     "open": "@:general.open",

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 37
-/// Strings: 10707 (289 per locale)
+/// Strings: 10709 (289 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -51,6 +51,7 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 	late final _StringsChangelogPageEn changelogPage = _StringsChangelogPageEn._(_root);
 	late final _StringsAliasGeneratorEn aliasGenerator = _StringsAliasGeneratorEn._(_root);
 	late final _StringsDialogsEn dialogs = _StringsDialogsEn._(_root);
+	late final _StringsSanitizationEn sanitization = _StringsSanitizationEn._(_root);
 	late final _StringsTrayEn tray = _StringsTrayEn._(_root);
 	late final _StringsWebEn web = _StringsWebEn._(_root);
 	late final _StringsAssetPickerEn assetPicker = _StringsAssetPickerEn._(_root);
@@ -430,6 +431,17 @@ class _StringsDialogsEn {
 	late final _StringsDialogsQuickActionsEn quickActions = _StringsDialogsQuickActionsEn._(_root);
 	late final _StringsDialogsQuickSaveNoticeEn quickSaveNotice = _StringsDialogsQuickSaveNoticeEn._(_root);
 	late final _StringsDialogsSendModeHelpEn sendModeHelp = _StringsDialogsSendModeHelpEn._(_root);
+}
+
+// Path: sanitization
+class _StringsSanitizationEn {
+	_StringsSanitizationEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	String get empty => 'Filename cannot be empty';
+	String get invalid => 'Filename contains invalid characters';
 }
 
 // Path: tray

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -26,6 +26,7 @@ import 'package:localsend_app/util/native/file_saver.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:routerino/routerino.dart';
 import 'package:shelf/shelf.dart';
@@ -398,11 +399,13 @@ class ReceiveController {
         fileName: receivingFile.desiredName!,
       );
 
+      final finalName = p.basename(destinationPath);
+
       _logger.info('Saving ${receivingFile.file.fileName} to $destinationPath');
 
       await saveFile(
         destinationPath: destinationPath,
-        name: receivingFile.desiredName!,
+        name: finalName,
         saveToGallery: saveToGallery,
         isImage: fileType == FileType.image,
         stream: request.read(),

--- a/app/lib/util/native/file_saver.dart
+++ b/app/lib/util/native/file_saver.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:gal/gal.dart';
+import 'package:legalize/legalize.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -111,7 +112,7 @@ Future<void> _saveFile({
 
 /// If there is a file with the same name, then it appends a number to its file name
 Future<String> digestFilePathAndPrepareDirectory({required String parentDirectory, required String fileName}) async {
-  final actualFileName = p.basename(fileName);
+  final actualFileName = legalizeFilename(p.basename(fileName), os: Platform.operatingSystem);
   final fileNameParts = p.split(fileName);
   final dir = p.joinAll([parentDirectory, ...fileNameParts.take(fileNameParts.length - 1)]);
 

--- a/app/lib/widget/dialogs/file_name_input_dialog.dart
+++ b/app/lib/widget/dialogs/file_name_input_dialog.dart
@@ -33,14 +33,14 @@ class _FileNameInputDialogState extends State<FileNameInputDialog> {
   bool _validate(String input) {
     if (_textController.text.isEmpty) {
       setState(() {
-        _errorMessage = 'You must enter a file name.';
+        _errorMessage = t.sanitization.empty;
       });
       return false;
     }
 
     if (!isValidFilename(input, os: Platform.operatingSystem)) {
       setState(() {
-        _errorMessage = 'Filename contains invalid characters.';
+        _errorMessage = t.sanitization.invalid;
       });
       return false;
     }

--- a/app/lib/widget/dialogs/file_name_input_dialog.dart
+++ b/app/lib/widget/dialogs/file_name_input_dialog.dart
@@ -1,7 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
+import 'package:localsend_app/theme.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
 import 'package:routerino/routerino.dart';
+import 'package:legalize/legalize.dart';
 
 class FileNameInputDialog extends StatefulWidget {
   final String originalName;
@@ -18,6 +22,7 @@ class FileNameInputDialog extends StatefulWidget {
 
 class _FileNameInputDialogState extends State<FileNameInputDialog> {
   final _textController = TextEditingController();
+  String _errorMessage = '';
 
   @override
   void initState() {
@@ -25,9 +30,38 @@ class _FileNameInputDialogState extends State<FileNameInputDialog> {
     _textController.text = widget.initialName;
   }
 
+  bool _validate(String input) {
+    if (_textController.text.isEmpty) {
+      setState(() {
+        _errorMessage = 'You must enter a file name.';
+      });
+      return false;
+    }
+
+    if (!isValidFilename(input, os: Platform.operatingSystem)) {
+      setState(() {
+        _errorMessage = 'Filename contains invalid characters.';
+      });
+      return false;
+    }
+
+    if (_errorMessage.isNotEmpty) {
+      setState(() {
+        _errorMessage = '';
+      });
+    }
+
+    return true;
+  }
+
   void _submit() {
     if (mounted) {
       String input = _textController.text.trim();
+
+      if (!_validate(_textController.text)) {
+        return;
+      }
+
       if (!input.contains('.') && widget.originalName.contains('.')) {
         // user forgot extension, we fix it
         input = input.withExtension(widget.originalName.extension);
@@ -49,8 +83,18 @@ class _FileNameInputDialogState extends State<FileNameInputDialog> {
           TextFormField(
             controller: _textController,
             autofocus: true,
+            onChanged: (value) => _validate(value.trim()),
             onFieldSubmitted: (_) => _submit,
           ),
+          const SizedBox(height: 5),
+          Visibility(
+              visible: _errorMessage.isNotEmpty,
+              child: Text(
+                _errorMessage,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.warning,
+                ),
+              )),
         ],
       ),
       actions: [

--- a/app/lib/widget/dialogs/file_name_input_dialog.dart
+++ b/app/lib/widget/dialogs/file_name_input_dialog.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:legalize/legalize.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/theme.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
 import 'package:routerino/routerino.dart';
-import 'package:legalize/legalize.dart';
 
 class FileNameInputDialog extends StatefulWidget {
   final String originalName;

--- a/app/lib/widget/dialogs/quick_actions_dialog.dart
+++ b/app/lib/widget/dialogs/quick_actions_dialog.dart
@@ -1,6 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:legalize/legalize.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/provider/selection/selected_receiving_files_provider.dart';
+import 'package:localsend_app/theme.dart';
 import 'package:localsend_app/widget/labeled_checkbox.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
@@ -38,6 +42,26 @@ class _QuickActionsDialogState extends State<QuickActionsDialog> with Refena {
   // random
   final _randomUuid = const Uuid().v4();
 
+  // sanity check
+  bool _isValid = true;
+
+  bool _validate(String input) {
+    if (!isValidFilename(input, os: Platform.operatingSystem) && input.isNotEmpty) {
+      setState(() {
+        _isValid = false;
+      });
+      return false;
+    }
+
+    if (!_isValid) {
+      setState(() {
+        _isValid = true;
+      });
+    }
+
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -74,11 +98,19 @@ class _QuickActionsDialogState extends State<QuickActionsDialog> with Refena {
             TextField(
               autofocus: true,
               onChanged: (s) {
+                _validate(s);
                 setState(() {
                   _prefix = s;
                 });
               },
             ),
+            const SizedBox(height: 5),
+            Visibility(
+                visible: !_isValid,
+                child: Text(
+                  'Filename contains invalid characters',
+                  style: TextStyle(color: Theme.of(context).colorScheme.warning),
+                )),
             const SizedBox(height: 10),
             LabeledCheckbox(
               label: t.dialogs.quickActions.padZero,
@@ -118,6 +150,9 @@ class _QuickActionsDialogState extends State<QuickActionsDialog> with Refena {
           onPressed: () {
             switch (_action) {
               case _QuickAction.counter:
+                if (!_isValid) {
+                  return;
+                }
                 ref.notifier(selectedReceivingFilesProvider).applyCounter(
                       prefix: _prefix,
                       padZero: _padZero,

--- a/app/lib/widget/dialogs/quick_actions_dialog.dart
+++ b/app/lib/widget/dialogs/quick_actions_dialog.dart
@@ -108,7 +108,7 @@ class _QuickActionsDialogState extends State<QuickActionsDialog> with Refena {
             Visibility(
                 visible: !_isValid,
                 child: Text(
-                  'Filename contains invalid characters',
+                  t.sanitization.invalid,
                   style: TextStyle(color: Theme.of(context).colorScheme.warning),
                 )),
             const SizedBox(height: 10),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   in_app_purchase: 3.1.13 # [FOSS_REMOVE]
   intl: ^0.18.0 # allow newer versions, so it can compile with newer Flutter versions
   launch_at_startup: 0.2.2
+  legalize: ^1.2.0
   logging: 1.2.0
   macos_dock_progress: ^1.0.0
   mime: 1.0.4

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   in_app_purchase: 3.1.13 # [FOSS_REMOVE]
   intl: ^0.18.0 # allow newer versions, so it can compile with newer Flutter versions
   launch_at_startup: 0.2.2
-  legalize: ^1.2.0
+  legalize: ^1.2.1
   logging: 1.2.0
   macos_dock_progress: ^1.0.0
   mime: 1.0.4

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   in_app_purchase: 3.1.13 # [FOSS_REMOVE]
   intl: ^0.18.0 # allow newer versions, so it can compile with newer Flutter versions
   launch_at_startup: 0.2.2
-  legalize: ^1.2.1
+  legalize: ^1.2.2
   logging: 1.2.0
   macos_dock_progress: ^1.0.0
   mime: 1.0.4


### PR DESCRIPTION
-> Fixes issue #1063 #1180 #1101  (And possibly more but I couldn't find)

## Description
As discussed in issue #1063 there currently is an error if a file is sent on a device with a different system of the sender. This is due to different character limitations in files' names depending on Operating systems and partitions. For example:

On my Linux computer I can create the file `<cool>.txt` and send it to my other linux computer without issue. But if I try to send it to my Windows computer or to my Android phone, LocalSend will fail to save the file and fail the transfer with error code 500. This is because `<>` are **illegal characters** on Windows and FAT32 devices (Android).

This PR fixes that issue by providing a sanitization step before saving a file. Like here:

```dart
Future<String> digestFilePathAndPrepareDirectory({required String parentDirectory, required String fileName}) async {
  final actualFileName = legalizeFilename(p.basename(fileName), os: Platform.operatingSystem); // <- here
  final fileNameParts = p.split(fileName);
  .....
```

The sanitization is handled by the [legalize](https://pub.dev/packages/legalize) library that I made for the occasion. So if any issues like this open up, they can be addressed upstream [here](https://github.com/Caesarovich/legalize/issues) instead. I'd be glad if users could test it across the many different OS they possess, I couldn't test it directly on all the possible different systems.

## Changes

- Now includes the `legalize: 1.2.1` dependency
- Filename sanitization in the `digestFilePathAndPrepareDirectory` function
- Filename check for the `FileNameInputDialog` and `QuickActionsDialog` widgets
