### PR TITLE
feat: ios app - make documents files visible to the Finder/AppleDevices app

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -121,5 +121,11 @@
             </array>
         </dict>
     </array>
+
+    <!-- Make documents files visible to the Finder/AppleDevices app -->
+    <key>UIFileSharingEnabled</key>
+    <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
This PR can make ios app's documents files visible to the Finder/AppleDevices app.

This allows users to transfer files in the LocalSend documents directory between Mac/Win and iOS devices .

Finder (Mac)
![mac](https://github.com/localsend/localsend/assets/37923060/697a6284-af3d-485d-a04c-5cef26f23128)

AppleDevices (Windows)
<img width="914" alt="win" src="https://github.com/localsend/localsend/assets/37923060/6ac3c0a0-4374-442e-ac28-baf7ff42483a">
