### PR TITLE
Fix issue 1382: File info dialog overflow

### DIFF
--- a/app/lib/widget/dialogs/file_info_dialog.dart
+++ b/app/lib/widget/dialogs/file_info_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/receive_history_entry.dart';
 import 'package:localsend_app/util/file_size_helper.dart';

--- a/app/lib/widget/dialogs/file_info_dialog.dart
+++ b/app/lib/widget/dialogs/file_info_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/receive_history_entry.dart';
 import 'package:localsend_app/util/file_size_helper.dart';
@@ -13,49 +14,52 @@ class FileInfoDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text(t.dialogs.fileInfo.title),
-      content: Table(
-        columnWidths: const {
-          0: IntrinsicColumnWidth(),
-          1: IntrinsicColumnWidth(),
-          2: IntrinsicColumnWidth(),
-        },
-        children: [
-          TableRow(
-            children: [
-              Text(t.dialogs.fileInfo.fileName, maxLines: 1),
-              const SizedBox(width: 10),
-              SelectableText(entry.fileName),
-            ],
-          ),
-          TableRow(
-            children: [
-              Text(t.dialogs.fileInfo.path),
-              const SizedBox(width: 10),
-              SelectableText(entry.savedToGallery ? t.progressPage.savedToGallery : (entry.path ?? '')),
-            ],
-          ),
-          TableRow(
-            children: [
-              Text(t.dialogs.fileInfo.size),
-              const SizedBox(width: 10),
-              SelectableText(entry.fileSize.asReadableFileSize),
-            ],
-          ),
-          TableRow(
-            children: [
-              Text(t.dialogs.fileInfo.sender),
-              const SizedBox(width: 10),
-              SelectableText(entry.senderAlias),
-            ],
-          ),
-          TableRow(
-            children: [
-              Text(t.dialogs.fileInfo.time),
-              const SizedBox(width: 10),
-              SelectableText(entry.timestampString),
-            ],
-          ),
-        ],
+      content: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Table(
+          columnWidths: const {
+            0: IntrinsicColumnWidth(),
+            1: IntrinsicColumnWidth(),
+            2: IntrinsicColumnWidth(),
+          },
+          children: [
+            TableRow(
+              children: [
+                Text(t.dialogs.fileInfo.fileName, maxLines: 1),
+                const SizedBox(width: 10),
+                SelectableText(entry.fileName),
+              ],
+            ),
+            TableRow(
+              children: [
+                Text(t.dialogs.fileInfo.path),
+                const SizedBox(width: 10),
+                SelectableText(entry.savedToGallery ? t.progressPage.savedToGallery : (entry.path ?? '')),
+              ],
+            ),
+            TableRow(
+              children: [
+                Text(t.dialogs.fileInfo.size),
+                const SizedBox(width: 10),
+                SelectableText(entry.fileSize.asReadableFileSize),
+              ],
+            ),
+            TableRow(
+              children: [
+                Text(t.dialogs.fileInfo.sender),
+                const SizedBox(width: 10),
+                SelectableText(entry.senderAlias),
+              ],
+            ),
+            TableRow(
+              children: [
+                Text(t.dialogs.fileInfo.time),
+                const SizedBox(width: 10),
+                SelectableText(entry.timestampString),
+              ],
+            ),
+          ],
+        ),
       ),
       actions: [
         TextButton(


### PR DESCRIPTION
Fixes issue #1382 

As discussed and demonstrated in the issue, the text in the FileInfoDialog widget was prone to overflowing and clipping the text content if it was too long.

![overflow](https://private-user-images.githubusercontent.com/114521419/334160285-39f6c895-d7c5-45f4-b5bb-5d74b338aab8.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTcyNDYyMDQsIm5iZiI6MTcxNzI0NTkwNCwicGF0aCI6Ii8xMTQ1MjE0MTkvMzM0MTYwMjg1LTM5ZjZjODk1LWQ3YzUtNDVmNC1iNWJiLTVkNzRiMzM4YWFiOC5qcGc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNjAxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDYwMVQxMjQ1MDRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0xYjZlMGQ2Yzk3ZDliMzVjZjNlZmE4MWY1MDM3ZmY5MTBlNzRhMWVlYTQyNTExM2ZkNmQyNmJhNjA5NmNhZGYxJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.eLVu869ACn_mD6dYFcMGT103NzLYNcSBrXQbPhXbUzo)

This PR fixes that by wrapping the Table in a SingleChildScrollView as demonstrated in this screen recording:

[TextOverflow.webm](https://github.com/localsend/localsend/assets/38408878/256d29e1-5b18-4f28-a847-79d7ac82ea3c)
