### PR TITLE
fix: Chinese translate problem 共享 -> 分享

### DIFF
--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,7 +16,7 @@
 [github]: https://github.com/localsend/localsend
 [codeberg]: https://codeberg.org/localsend/localsend
 
-LocalSend 是一个自由、开源的应用程序，允许你在本地网络上安全地与附近设备共享文件和消息，无需互联网连接。
+LocalSend 是一个自由、开源的应用程序，允许你在本地网络上安全地与附近设备分享文件和消息，无需互联网连接。
 
 - [关于](#关于)
 - [截图](#截图)

--- a/app/assets/i18n/strings_zh-CN.i18n.json
+++ b/app/assets/i18n/strings_zh-CN.i18n.json
@@ -229,7 +229,7 @@
   "aboutPage": {
     "title": "关于 LocalSend",
     "description": [
-      "LocalSend 是一款免费的开源应用程序，可让您通过本地网络与附近的设备安全地共享文件和信息，而无需互联网连接。",
+      "LocalSend 是一款免费的开源应用程序，可让您通过本地网络与附近的设备安全地分享文件和信息，而无需互联网连接。",
       "本程序可在 Android、iOS、macOS、Windows 和 Linux 上使用。您可以在官方主页找到所有下载选项。"
     ],
     "author": "作者",

--- a/app/assets/i18n/strings_zh-TW.i18n.json
+++ b/app/assets/i18n/strings_zh-TW.i18n.json
@@ -228,7 +228,7 @@
   "aboutPage": {
     "title": "關於 LocalSend",
     "description": [
-      "LocalSend 是一款免費的開源應用程式，可讓您透過區域網路與鄰近的裝置安全的共享檔案和訊息，無需網際網路連線。",
+      "LocalSend 是一款免費的開源應用程式，可讓您透過區域網路與鄰近的裝置安全的分享檔案和訊息，無需網際網路連線。",
       "此應用程式可在 Android、iOS、macOS、Windows 和 Linux 上使用。 您可以在官網首頁上找到所有下載選項。"
     ],
     "author": "作者",

--- a/app/lib/gen/strings_zh_CN.g.dart
+++ b/app/lib/gen/strings_zh_CN.g.dart
@@ -285,7 +285,7 @@ class _StringsAboutPageZhCn extends _StringsAboutPageEn {
 	// Translations
 	@override String get title => '关于 LocalSend';
 	@override List<String> get description => [
-		'LocalSend 是一款免费的开源应用程序，可让您通过本地网络与附近的设备安全地共享文件和信息，而无需互联网连接。',
+		'LocalSend 是一款免费的开源应用程序，可让您通过本地网络与附近的设备安全地分享文件和信息，而无需互联网连接。',
 		'本程序可在 Android、iOS、macOS、Windows 和 Linux 上使用。您可以在官方主页找到所有下载选项。',
 	];
 	@override String get author => '作者';

--- a/app/lib/gen/strings_zh_TW.g.dart
+++ b/app/lib/gen/strings_zh_TW.g.dart
@@ -284,7 +284,7 @@ class _StringsAboutPageZhTw extends _StringsAboutPageEn {
 	// Translations
 	@override String get title => '關於 LocalSend';
 	@override List<String> get description => [
-		'LocalSend 是一款免費的開源應用程式，可讓您透過區域網路與鄰近的裝置安全的共享檔案和訊息，無需網際網路連線。',
+		'LocalSend 是一款免費的開源應用程式，可讓您透過區域網路與鄰近的裝置安全的分享檔案和訊息，無需網際網路連線。',
 		'此應用程式可在 Android、iOS、macOS、Windows 和 Linux 上使用。 您可以在官網首頁上找到所有下載選項。',
 	];
 	@override String get author => '作者';


### PR DESCRIPTION
# Same as this PR of website 

[https://github.com/localsend/website/pull/70](https://github.com/localsend/website/pull/70)

* * *

## Improve Chinese Translation: Change "共享" to "分享"

**Description:**
This pull request aims to improve the Chinese translation of LocalSend by changing the term "共享" to "分享."

**Rationale:**
In Chinese, the terms "共享" and "分享" both refer to the act of sharing, but they have slightly different connotations and usage contexts:

1. **共享 (Gòngxiǎng):**
   - Typically used in formal or technical contexts.
   - Implies mutual access or usage, often with an emphasis on collective benefit. Commonly used for resources, services, or infrastructure.
   - Example: "共享经济" (sharing economy), "共享单车" (bike-sharing).

2. **分享 (Fēnxiǎng):**
   - More commonly used in everyday language.
   - Focuses on the act of giving and receiving, emphasizing the personal and voluntary aspect of sharing. Often used for content, experiences, or personal items.
   - Example: "分享照片" (sharing photos), "分享经验" (sharing experiences).

Given the context of LocalSend, which is about sending files to nearby devices in a way that users can relate to on a personal level, "分享" is a more appropriate and user-friendly term. It aligns better with the casual and user-centric nature of the application.

**Updated Translation:**
"LocalSend：将文件分享给附近的设备。免费、开源、跨平台。"

Thank you for considering this improvement. I believe this change will enhance the clarity and relatability of the Chinese translation for LocalSend users.