### PR TITLE
Updated missing translations for Serbian language, latin and cyrilic script

### DIFF
--- a/app/assets/i18n/_missing_translations_sr.json
+++ b/app/assets/i18n/_missing_translations_sr.json
@@ -5,26 +5,26 @@
   ],
   "settingsTab": {
     "general": {
-      "showInContextMenu": "Show LocalSend in context menu"
+      "showInContextMenu": "Prikaži LocalSend u kontekst meniju"
     }
   },
   "receiveHistoryPage": {
     "entryActions": {
-      "showInFolder": "Show in folder"
+      "showInFolder": "Prikaži u folderu"
     }
   },
   "webSharePage": {
-    "requirePin": "Require PIN",
-    "pinHint": "The PIN is \"{pin}\""
+    "requirePin": "Potreban PIN",
+    "pinHint": "PIN je \"{pin}\""
   },
   "dialogs": {
     "pin": {
-      "title": "Enter PIN"
+      "title": "Unesi PIN"
     }
   },
   "web": {
-    "enterPin": "Enter PIN",
-    "invalidPin": "Invalid PIN",
-    "tooManyAttempts": "Too many attempts"
+    "enterPin": "Unesi PIN",
+    "invalidPin": "Neispravan PIN",
+    "tooManyAttempts": "Previše pokušaja"
   }
 }

--- a/app/assets/i18n/_missing_translations_sr_Cyrl.json
+++ b/app/assets/i18n/_missing_translations_sr_Cyrl.json
@@ -5,26 +5,26 @@
   ],
   "settingsTab": {
     "general": {
-      "showInContextMenu": "Show LocalSend in context menu"
+      "showInContextMenu": "Прикажи LocalSend у контекст менију"
     }
   },
   "receiveHistoryPage": {
     "entryActions": {
-      "showInFolder": "Show in folder"
+      "showInFolder": "Прикажи у фолдеру"
     }
   },
   "webSharePage": {
-    "requirePin": "Require PIN",
-    "pinHint": "The PIN is \"{pin}\""
+    "requirePin": "Потребан PIN",
+    "pinHint": "PIN је \"{pin}\""
   },
   "dialogs": {
     "pin": {
-      "title": "Enter PIN"
+      "title": "Унеси PIN"
     }
   },
   "web": {
-    "enterPin": "Enter PIN",
-    "invalidPin": "Invalid PIN",
-    "tooManyAttempts": "Too many attempts"
+    "enterPin": "Унеси PIN",
+    "invalidPin": "Неисправан PIN",
+    "tooManyAttempts": "Превише покушаја"
   }
 }


### PR DESCRIPTION
Strings in app/assets/i18n/_missing_translations_sr.json and app/assets/i18n/_missing_translations_sr_Cyrl.json updated.