### PR TITLE
Update _missing_translations_fr.json

### DIFF
--- a/app/assets/i18n/_missing_translations_fr.json
+++ b/app/assets/i18n/_missing_translations_fr.json
@@ -5,26 +5,26 @@
   ],
   "settingsTab": {
     "general": {
-      "showInContextMenu": "Show LocalSend in context menu"
+      "showInContextMenu": "Montrer LocalSend dans le menu contextuel"
     }
   },
   "receiveHistoryPage": {
     "entryActions": {
-      "showInFolder": "Show in folder"
+      "showInFolder": "Ouvrir le dossier"
     }
   },
   "webSharePage": {
-    "requirePin": "Require PIN",
-    "pinHint": "The PIN is \"{pin}\""
+    "requirePin": "Code PIN nécessaire",
+    "pinHint": "Le code PIN est \"{pin}\""
   },
   "dialogs": {
     "pin": {
-      "title": "Enter PIN"
+      "title": "Entrez le code PIN"
     }
   },
   "web": {
-    "enterPin": "Enter PIN",
-    "invalidPin": "Invalid PIN",
-    "tooManyAttempts": "Too many attempts"
+    "enterPin": "Entrez le code PIN",
+    "invalidPin": "Code PIN Invalide",
+    "tooManyAttempts": "Trop d'essais infructueux"
   }
 }


### PR DESCRIPTION
Saw that there's a release soon in https://github.com/localsend/localsend/issues/345#issuecomment-2221875935

Translation differences:
- Unsure if "menu contextuel" is the best fit as i've pretty much never seen it used like that, but can't find anything better for now.
- Changed meaning from "show in folder" to "open the folder" since "show in folder" is pretty unnatural in french
- Added "code" before pin because it sounds better
- changed meaning from "too many attemps" to "too many bad attempts"