### PR TITLE
fix: use correct portable settings file when started via autostart

### DIFF
--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -4,6 +4,7 @@
 - feat(windows): use bigger icon for the installer (@Tienisto)
 - fix: memory leak when receiving files, properly receive files that exceed available RAM (@Tienisto)
 - fix(android): save files outside of Download folder (@Tienisto)
+- fix(windows): use correct portable settings file when started via autostart (@Tienisto)
 - fix(windows): make installer work on arm64 (@Tienisto)
 
 ## 1.15.1 (2024-07-18)

--- a/app/lib/util/shared_preferences/shared_preferences_portable.dart
+++ b/app/lib/util/shared_preferences/shared_preferences_portable.dart
@@ -1,8 +1,18 @@
+import 'dart:io';
+
 import 'package:localsend_app/util/shared_preferences/shared_preferences_file.dart';
+import 'package:path/path.dart' as path;
 
 /// Custom implementation of SharedPreferencesStorePlatform
 /// that uses a file named settings.json located next to the executable.
 /// This is used to for portable mode.
 class SharedPreferencesPortable extends SharedPreferencesFile {
-  SharedPreferencesPortable() : super(filePath: 'settings.json', beautify: true);
+  SharedPreferencesPortable() : super(filePath: _getSettingsPathFromExecutable(), beautify: true);
+}
+
+/// Returns the absolute path to the settings.json file next to the executable.
+String _getSettingsPathFromExecutable() {
+  final executablePath = Platform.resolvedExecutable;
+  final executableParentPath = File(executablePath).parent.path;
+  return path.join(executableParentPath, 'settings.json');
 }


### PR DESCRIPTION
Closes #1561 