### PR TITLE
Update Winget Releaser job to latest tag

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: LocalSend.LocalSend
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Action has moved from `vedantmgoyal2009/winget-releaser@v2` to `vedantmgoyal9/winget-releaser@main`. This should fix the recent workflow failures.