### PR TITLE
Add Flox to installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ It is recommended to download the app either from an app store or from a package
 | [Winget][]              | [App Store][]           | [Flathub][]        | [Play Store][] | [App Store][] | [Amazon][] |
 | [Scoop][]               | [Homebrew][]            | [Nixpkgs][]        | [F-Droid][]    |               |            |
 | [Chocolatey][]          | [DMG Installer][latest] | [Snap][]           | [APK][latest]  |               |            |
-| [EXE Installer][latest] |                         | [AUR][]            |                |               |            |
+| [EXE Installer][latest] | [Flox][]                | [AUR][]            |                |               |            |
 | [Portable ZIP][latest]  |                         | [TAR][latest]      |                |               |            |
 |                         |                         | [DEB][latest]      |                |               |            |
 |                         |                         | [AppImage][latest] |                |               |            |
+|                         |                         | [Flox][]           |                |               |            |
 
 Read more about [distribution channels][].
 
@@ -70,6 +71,7 @@ Read more about [distribution channels][].
 [aur]: https://aur.archlinux.org/packages/localsend-bin
 [latest]: https://github.com/localsend/localsend/releases/latest
 [distribution channels]: https://github.com/localsend/localsend/blob/main/CONTRIBUTING.md#distribution
+[flox]: https://flox.dev
 
 ## Setup
 


### PR DESCRIPTION
I've test out installing localsend with Flox, and it worked.
It currently doesn't have a webpage where you can view the package, but these are the commands I ran to make it work.

```console
$ flox init
✨ Created environment 'tmp.jAEYbDjIqo' (aarch64-darwin)

Next:
  $ flox search <package>    <- Search for a package
  $ flox install <package>   <- Install a package into an environment
  $ flox activate            <- Enter the environment
  $ flox edit                <- Add environment variables and shell hooks

$ flox install localsend
✅ 'localsend' installed to environment 'tmp.jAEYbDjIqo'
$ flox activate
✅ You are now using the environment 'tmp.jAEYbDjIqo'.
To stop using this environment, type 'exit'

flox [tmp.jAEYbDjIqo] $ localsend
flutter: dynamic_color: Accent color detected.
...
```