### PR TITLE
Removed deprecated code from Theme.dart

### DIFF
--- a/app/lib/config/theme.dart
+++ b/app/lib/config/theme.dart
@@ -49,7 +49,7 @@ ThemeData getTheme(ColorMode colorMode, Brightness brightness, DynamicColors? dy
     useMaterial3: true,
     navigationBarTheme: colorScheme.brightness == Brightness.dark
         ? NavigationBarThemeData(
-            iconTheme: MaterialStateProperty.all(const IconThemeData(color: Colors.white)),
+            iconTheme: WidgetStateProperty.all(const IconThemeData(color: Colors.white)),
           )
         : null,
     inputDecorationTheme: InputDecorationTheme(
@@ -165,7 +165,7 @@ ThemeData _getYaruTheme(Brightness brightness) {
   return baseTheme.copyWith(
     navigationBarTheme: colorScheme.brightness == Brightness.dark
         ? NavigationBarThemeData(
-            iconTheme: MaterialStateProperty.all(const IconThemeData(color: Colors.white)),
+            iconTheme: WidgetStateProperty.all(const IconThemeData(color: Colors.white)),
           )
         : null,
     inputDecorationTheme: InputDecorationTheme(


### PR DESCRIPTION
This PR removes deprecated code from Theme.dart.
Replaces MaterialStateProperty with WidgetStateProperty.