### PR TITLE
i18n: Correction for English language

### DIFF
--- a/app/assets/i18n/strings.json
+++ b/app/assets/i18n/strings.json
@@ -96,7 +96,7 @@
       "languageOptions": {
         "system": "System"
       },
-      "saveWindowPlacement": "Quit: Save window placement",
+      "saveWindowPlacement": "Save window position after quit",
       "minimizeToTray": "Minimize to the System Tray/Menu Bar when closing",
       "launchAtStartup": "Autostart after login",
       "launchMinimized": "Autostart: Start hidden",


### PR DESCRIPTION
I should have corrected it earlier when I was fixing it for Ukrainian and Russian languages, but I forgot. Such a parameter name would look more user-friendly.

Also, a question. My English-speaking friend who uses Windows noticed that the parameter quit/exit is named "Quit LocalSend", which meets Apple’s [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines). However, according to the [Windows app development documentation](https://learn.microsoft.com/uk-ua/windows/apps/), Windows apps should use "Exit", as seen in various Windows apps. So, is it possible to use separate translations for the same strings for different platforms?