### PR TITLE
i18n: Correction for English language

### DIFF
--- a/app/assets/i18n/strings.json
+++ b/app/assets/i18n/strings.json
@@ -344,8 +344,8 @@
       "recentlyUsed": "Recently used: "
     },
     "cancelSession": {
-      "title": "Cancel file transfer",
-      "content": "Do you really want to cancel the file transfer?"
+      "title": "Cancel files transfer",
+      "content": "Do you really want to cancel the files transfer?"
     },
     "cannotOpenFile": {
       "title": "Cannot open file",


### PR DESCRIPTION
In all similar cases, the translation uses "files transfer" in the plural form rather than "file transfer." That's why I decided to correct it.