### PR TITLE
Update italian translation

### DIFF
--- a/app/assets/i18n/strings_it.json
+++ b/app/assets/i18n/strings_it.json
@@ -13,7 +13,7 @@
     "copy": "Copia",
     "copiedToClipboard": "Copiato negli Appunti",
     "decline": "Rifiuta",
-    "done": "Eseguito",
+    "done": "Fatto",
     "delete": "Cancella",
     "edit": "Modifica",
     "error": "Errore",


### PR DESCRIPTION
I propose to change the Italian translation of the English word "Done" from "Eseguito" to "Fatto".

The current "Eseguito" is like "Executed", which in my opinion creates confusion as Italians are not used to this word in this context and for a button with the function to close the download section after receiving data.