### PR TITLE
fix: file picker options padding in RTL lang

### DIFF
--- a/app/lib/widget/horizontal_clip_list_view.dart
+++ b/app/lib/widget/horizontal_clip_list_view.dart
@@ -46,7 +46,7 @@ class HorizontalClipListView extends StatelessWidget {
                           child: children[i],
                         )
                       : Padding(
-                          padding: EdgeInsets.only(right: childPadding),
+                          padding: EdgeInsetsDirectional.only(end: childPadding),
                           child: SizedBox(
                             width: childWidth,
                             child: children[i],


### PR DESCRIPTION
before:
![CleanShot 2024-09-04 at 16 50 50@2x](https://github.com/user-attachments/assets/99fb9da9-26c0-4cab-9558-2cf62581a241)
after:
![CleanShot 2024-09-04 at 16 46 03@2x](https://github.com/user-attachments/assets/9623fdf4-f8f4-49cf-b796-8b6a588da6c8)
