### PR TITLE
feat(macos): add support for text sharing and dropping

### DIFF
--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -183,10 +183,10 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
 
   if (appStart) {
     if (defaultTargetPlatform == TargetPlatform.macOS) {
-      final files = await getPendingFiles();
-      if (files.isNotEmpty) {
+      final pendingFiles = await getPendingFiles();
+      if (pendingFiles.isNotEmpty) {
         await ref.global.dispatchAsync(_HandleAppStartArgumentsAction(
-          args: files,
+          args: pendingFiles,
         ));
       }
 
@@ -195,6 +195,23 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
         ref.global.dispatchAsync(_HandleAppStartArgumentsAction(
           args: files,
         ));
+        ref.redux(homePageControllerProvider).dispatch(ChangeTabAction(HomeTab.send));
+      });
+
+      final pendingStrings = await getPendingStrings();
+      if (pendingStrings.isNotEmpty) {
+        for (final string in pendingStrings) {
+          ref.redux(selectedSendingFilesProvider).dispatch(AddMessageAction(message: string));
+          ref.redux(homePageControllerProvider).dispatch(ChangeTabAction(HomeTab.send));
+        }
+      }
+
+      // handle future dropped strings
+      getPendingStringsStream().listen((pendingStrings) {
+        for (final string in pendingStrings) {
+          ref.redux(selectedSendingFilesProvider).dispatch(AddMessageAction(message: string));
+          ref.redux(homePageControllerProvider).dispatch(ChangeTabAction(HomeTab.send));
+        }
       });
     } else {
       final args = ref.read(appArgumentsProvider);

--- a/app/lib/util/native/macos_channel.dart
+++ b/app/lib/util/native/macos_channel.dart
@@ -56,6 +56,7 @@ Stream<List<String>> getPendingFilesStream() {
 
 /// Returns a list of pending strings from the native swift runner.
 /// This happens:
+/// - on macOS when text is dropped onto the app Dock icon
 /// - on macOS when text is dropped onto the app menu bar icon
 /// - on macOS when text\web link are shared to the app using the share extension (i.e. the system share menu)
 Future<List<String>> getPendingStrings() async {

--- a/app/lib/util/native/macos_channel.dart
+++ b/app/lib/util/native/macos_channel.dart
@@ -53,3 +53,38 @@ Stream<List<String>> getPendingFilesStream() {
 
   return controller.stream.asBroadcastStream();
 }
+
+/// Returns a list of pending strings from the native swift runner.
+/// This happens:
+/// - on macOS when text is dropped onto the app menu bar icon
+/// - on macOS when text\web link are shared to the app using the share extension (i.e. the system share menu)
+Future<List<String>> getPendingStrings() async {
+  if (defaultTargetPlatform != TargetPlatform.macOS) {
+    return <String>[];
+  }
+
+  final strings = await _methodChannel.invokeMethod<List>('getPendingStrings');
+  if (strings == null) {
+    throw PlatformException(
+      code: 'UNKNOWN',
+      message: 'Unable to get strings',
+    );
+  }
+
+  return strings.cast<String>();
+}
+
+Stream<List<String>> getPendingStringsStream() {
+  if (defaultTargetPlatform != TargetPlatform.macOS) {
+    return Stream.value(<String>[]).asBroadcastStream();
+  }
+
+  final controller = StreamController<List<String>>();
+  _methodChannel.setMethodCallHandler((call) async {
+    if (call.method == 'onPendingStrings') {
+      controller.add((call.arguments as List).cast<String>());
+    }
+  });
+
+  return controller.stream.asBroadcastStream();
+}

--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		053DADF62C89486500C3B4DE /* ShareController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053DADF42C89486500C3B4DE /* ShareController.swift */; };
 		053DADFD2C89F83400C3B4DE /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053DADFA2C89F25E00C3B4DE /* Shared.swift */; };
 		053DADFE2C89F83500C3B4DE /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053DADFA2C89F25E00C3B4DE /* Shared.swift */; };
-		0543E87B2C8A93A9004AA8B7 /* FileDropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0543E87A2C8A93A9004AA8B7 /* FileDropView.swift */; };
+		0543E87B2C8A93A9004AA8B7 /* ContentDropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0543E87A2C8A93A9004AA8B7 /* ContentDropView.swift */; };
 		05BAA8D02C8CE248003CFCF1 /* SecurityScopedResourceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05BAA8CF2C8CE248003CFCF1 /* SecurityScopedResourceManager.swift */; };
 		0F663CE30FCD07225E44A808 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F8CCFF0FAB783405F067709 /* Pods_Runner.framework */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
@@ -86,7 +86,7 @@
 		053DADF12C8947A500C3B4DE /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		053DADF42C89486500C3B4DE /* ShareController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareController.swift; sourceTree = "<group>"; };
 		053DADFA2C89F25E00C3B4DE /* Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
-		0543E87A2C8A93A9004AA8B7 /* FileDropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropView.swift; sourceTree = "<group>"; };
+		0543E87A2C8A93A9004AA8B7 /* ContentDropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDropView.swift; sourceTree = "<group>"; };
 		05BAA8CF2C8CE248003CFCF1 /* SecurityScopedResourceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityScopedResourceManager.swift; sourceTree = "<group>"; };
 		2F8CCFF0FAB783405F067709 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
@@ -199,7 +199,7 @@
 			isa = PBXGroup;
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
-				0543E87A2C8A93A9004AA8B7 /* FileDropView.swift */,
+				0543E87A2C8A93A9004AA8B7 /* ContentDropView.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
 				05BAA8CF2C8CE248003CFCF1 /* SecurityScopedResourceManager.swift */,
 				053DADFA2C89F25E00C3B4DE /* Shared.swift */,
@@ -444,7 +444,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0543E87B2C8A93A9004AA8B7 /* FileDropView.swift in Sources */,
+				0543E87B2C8A93A9004AA8B7 /* ContentDropView.swift in Sources */,
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				053DADFD2C89F83400C3B4DE /* Shared.swift in Sources */,
 				05BAA8D02C8CE248003CFCF1 /* SecurityScopedResourceManager.swift in Sources */,

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -20,6 +20,8 @@ class AppDelegate: FlutterAppDelegate {
         channel?.setMethodCallHandler(handle)
         
         self.setupPendingItemsObservation()
+        
+        self.setupDockIconTextDropEventListener()
     }
     
     private func setupPendingItemsObservation() {
@@ -34,6 +36,17 @@ class AppDelegate: FlutterAppDelegate {
             guard !pendingStrings.isEmpty else { return }
             self.sendPendingItemsToFlutter()
         }
+    }
+    
+    private func setupDockIconTextDropEventListener() {
+        let appleEventManager = NSAppleEventManager.shared()
+        
+        appleEventManager.setEventHandler(
+            self,
+            andSelector: #selector(handleOpenContentsEvent(_:withReplyEvent:)),
+            forEventClass: AEEventClass(kCoreEventClass),
+            andEventID: AEEventID(kAEOpenContents)
+        )
     }
     
     private func setupStatusBarItem(i18n: [String: String]) {
@@ -151,4 +164,11 @@ class AppDelegate: FlutterAppDelegate {
         }
     }
     // END: handle opened files
+    
+    /// Handle **text** droped onto the Dock icon
+    @objc func handleOpenContentsEvent(_ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
+        if let string = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue {
+            Defaults[.pendingStrings].append(string)
+        }
+    }
 }

--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -118,5 +118,24 @@
             </array>
         </dict>
     </array>
+
+    <key>NSServices</key>
+    <array>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Send to LocalSend</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>handleTextDropEvent</string>
+            <key>NSPortName</key>
+            <string>LocalSend</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>public.plain-text</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/app/macos/Runner/Shared.swift
+++ b/app/macos/Runner/Shared.swift
@@ -6,6 +6,7 @@ let sharedDefaults = UserDefaults(suiteName: "com.localsend.shared_group")!
 typealias FileBookmarkData = Data
 extension Defaults.Keys {
     static let pendingFiles = Key<[FileBookmarkData]>("pendingFiles", default: [], suite: sharedDefaults)
+    static let pendingStrings = Key<[String]>("pendingStrings", default: [], suite: sharedDefaults)
 }
 
 /**

--- a/app/macos/Runner/Shared.swift
+++ b/app/macos/Runner/Shared.swift
@@ -3,9 +3,9 @@ import Defaults
 
 let sharedDefaults = UserDefaults(suiteName: "com.localsend.shared_group")!
 
-typealias BookmarkData = Data
+typealias FileBookmarkData = Data
 extension Defaults.Keys {
-    static let pendingFiles = Key<[BookmarkData]>("pendingFiles", default: [], suite: sharedDefaults)
+    static let pendingFiles = Key<[FileBookmarkData]>("pendingFiles", default: [], suite: sharedDefaults)
 }
 
 /**
@@ -24,7 +24,7 @@ extension Defaults.Keys {
  
  - Tag: create-bookmark-func
  */
-func createBookmarkForFile(at url: URL) -> BookmarkData? {
+func createBookmarkForFile(at url: URL) -> FileBookmarkData? {
     do {
         let securityScopedBookmark = try (url as NSURL).bookmarkData(
             options: .minimalBookmark,

--- a/app/macos/ShareExtension/Info.plist
+++ b/app/macos/ShareExtension/Info.plist
@@ -13,17 +13,17 @@
 				<key>NSExtensionActivationDictionaryVersion</key>
 				<integer>2</integer>
 				<key>NSExtensionActivationSupportsAttachmentsWithMaxCount</key>
-				<integer>1000</integer>
+				<integer>999</integer>
 				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
-				<integer>1000</integer>
+				<integer>999</integer>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>1000</integer>
+				<integer>999</integer>
 				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
-				<integer>1000</integer>
+				<integer>999</integer>
 				<key>NSExtensionActivationSupportsText</key>
-				<false/>
+				<true/>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>0</integer>
+				<integer>1</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/app/macos/ShareExtension/Utilities.swift
+++ b/app/macos/ShareExtension/Utilities.swift
@@ -9,12 +9,23 @@ extension Sequence where Element: Sequence {
     }
 }
 
+struct TextContent {
+    var title: String?
+    var body: String?
+}
 
 extension NSExtensionContext {
     var inputItemsTyped: [NSExtensionItem] { inputItems as! [NSExtensionItem] }
     
     var attachments: [NSItemProvider] {
         inputItemsTyped.compactMap(\.attachments).flatten()
+    }
+    
+    var textContent: TextContent {
+        TextContent(
+            title: inputItemsTyped.first?.attributedTitle?.string,
+            body: inputItemsTyped.first?.attributedContentText?.string
+        )
     }
 }
 
@@ -38,7 +49,7 @@ extension NSExtensionContext {
     }
 }
 
-
+@MainActor
 extension NSItemProvider {
     func loadItem<T>(ofClass cls: T.Type) async throws -> T where T: NSItemProviderReading {
         try await withCheckedThrowingContinuation { continuation in


### PR DESCRIPTION
Added support for sharing web URLs and texts using macOS Share menu, and added support for drag and drop text onto the menu bar item and the Dock icon

Completion of #1716 and #1739