### PR TITLE
i18n: Updates for missing translations for Ukrainian and Russian. Also, a minor correction for English

### DIFF
--- a/app/assets/i18n/_missing_translations_ru.json
+++ b/app/assets/i18n/_missing_translations_ru.json
@@ -4,7 +4,7 @@
     "After editing this file, you can run 'dart run slang apply --locale=ru' to quickly apply the newly added translations."
   ],
   "general": {
-    "quickSaveFromFavorites": "Quick Save for \"Favorites\""
+    "quickSaveFromFavorites": "Быстрое сохранение для \"Избранных\""
   },
   "settingsTab": {
     "receive": {
@@ -14,7 +14,7 @@
   "dialogs": {
     "quickSaveFromFavoritesNotice": {
       "title": "@:general.quickSaveFromFavorites",
-      "content": "File requests are automatically accepted from devices in your contact list."
+      "content": "Запросы на получение файлов теперь принимаются автоматически от устройств из вашего списка избранных."
     }
   }
 }

--- a/app/assets/i18n/_missing_translations_uk.json
+++ b/app/assets/i18n/_missing_translations_uk.json
@@ -4,7 +4,7 @@
     "After editing this file, you can run 'dart run slang apply --locale=uk' to quickly apply the newly added translations."
   ],
   "general": {
-    "quickSaveFromFavorites": "Quick Save for \"Favorites\""
+    "quickSaveFromFavorites": "Швидке збереження для \"Улюблених\""
   },
   "settingsTab": {
     "receive": {
@@ -14,7 +14,7 @@
   "dialogs": {
     "quickSaveFromFavoritesNotice": {
       "title": "@:general.quickSaveFromFavorites",
-      "content": "File requests are automatically accepted from devices in your contact list."
+      "content": "Запити на отримання файлів відтепер приймаються автоматично від пристроїв з вашого списку улюблених."
     }
   }
 }

--- a/app/assets/i18n/strings.json
+++ b/app/assets/i18n/strings.json
@@ -427,11 +427,11 @@
     },
     "quickSaveNotice": {
       "title": "@:general.quickSave",
-      "content": "File requests are automatically accepted. Be aware that everyone on the local network can send you files."
+      "content": "File requests are now accepted automatically. Be aware that everyone on the local network can send you files."
     },
     "quickSaveFromFavoritesNotice": {
       "title": "@:general.quickSaveFromFavorites",
-      "content": "File requests are automatically accepted from devices in your contact list."
+      "content": "File requests are now accepted automatically from devices in your favorites list."
     },
     "pin": {
       "title": "Enter PIN"


### PR DESCRIPTION
Since there is no contact list but rather a favorites list, I think it should specify "favorites list" to avoid confusing users (changes for the English).