### PR TITLE
feat(macos): show transfer progress in Dock icon

### DIFF
--- a/app/lib/util/native/macos_channel.dart
+++ b/app/lib/util/native/macos_channel.dart
@@ -18,6 +18,14 @@ Future<void> setupStatusBar() async {
   });
 }
 
+Future<void> updateDockProgress(double progress) async {
+  if (defaultTargetPlatform != TargetPlatform.macOS) {
+    return;
+  }
+
+  await _methodChannel.invokeMethod('updateDockProgress', progress);
+}
+
 // This happens:
 /// - on macOS when text is dropped onto the app Dock icon
 /// - on macOS when text is dropped onto the app menu bar icon

--- a/app/lib/util/native/taskbar_helper.dart
+++ b/app/lib/util/native/taskbar_helper.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:localsend_app/util/native/macos_channel.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
-// import 'package:macos_dock_progress/macos_dock_progress.dart';
 import 'package:windows_taskbar/windows_taskbar.dart';
 
 class TaskbarHelper {
@@ -11,7 +11,7 @@ class TaskbarHelper {
     if (_isWindows) {
       await WindowsTaskbar.setProgressMode(TaskbarProgressMode.noProgress);
     } else if (_isMacos) {
-      // await DockProgress.setProgress(1.0);
+      await updateDockProgress(1.0);
     }
   }
 
@@ -23,7 +23,7 @@ class TaskbarHelper {
       if (_isWindows) {
         await WindowsTaskbar.setProgress(digestedProgress, digestedTotal);
       } else if (_isMacos) {
-        // await DockProgress.setProgress(double.parse((progress / total).toStringAsFixed(3)));
+        await updateDockProgress(progress / total);
       }
     } else {
       if (_isWindows) {

--- a/app/macos/Podfile
+++ b/app/macos/Podfile
@@ -33,6 +33,7 @@ target 'Runner' do
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
   
   pod 'Defaults', '~> 4.2'
+  pod 'DockProgress'
 end
 
 post_install do |installer|

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -7,6 +7,7 @@ PODS:
     - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
+  - DockProgress (3.2.0)
   - dynamic_color (0.0.2):
     - FlutterMacOS
   - file_selector_macos (0.0.1):
@@ -55,6 +56,7 @@ DEPENDENCIES:
   - Defaults (~> 4.2)
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
+  - DockProgress
   - dynamic_color (from `Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
@@ -77,6 +79,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Defaults
+    - DockProgress
     - ReachabilitySwift
 
 EXTERNAL SOURCES:
@@ -128,6 +131,7 @@ SPEC CHECKSUMS:
   Defaults: d785e56c0fb8890dc40351603f05c8e1df1bdd45
   desktop_drop: 69eeff437544aa619c8db7f4481b3a65f7696898
   device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
+  DockProgress: 94765d097d5c54579bf93385b5be71bd6a74fdf6
   dynamic_color: 2eaa27267de1ca20d879fbd6e01259773fb1670f
   file_selector_macos: 54fdab7caa3ac3fc43c9fac4d7d8d231277f8cf2
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
@@ -148,6 +152,6 @@ SPEC CHECKSUMS:
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 
-PODFILE CHECKSUM: 5c6550f5101fcba381ddb97e2135e4cacca4f31f
+PODFILE CHECKSUM: 660eab236b19bb36037d2fc653a1e4ae4c99e9b4
 
 COCOAPODS: 1.15.2

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import FlutterMacOS
 import Defaults
+import DockProgress
 
 @main
 class AppDelegate: FlutterAppDelegate {
@@ -20,6 +21,9 @@ class AppDelegate: FlutterAppDelegate {
         channel?.setMethodCallHandler(handleFlutterCall)
         
         self.setupDockIconTextDropEventListener()
+        
+        let localsendBrandColor = NSColor(red: 0, green: 0.392, blue: 0.353, alpha: 0.8) // #00645a
+        DockProgress.style = .squircle(color: localsendBrandColor)
     }
     
     private func setupPendingItemsObservation() {
@@ -120,6 +124,10 @@ class AppDelegate: FlutterAppDelegate {
         case "setupStatusBar":
             let i18n = call.arguments as! [String: String]
             setupStatusBarItem(i18n: i18n)
+            result(nil)
+        case "updateDockProgress":
+            let progress = call.arguments as! Double
+            DockProgress.progress = progress
             result(nil)
         default:
             result(FlutterMethodNotImplemented)


### PR DESCRIPTION
closes https://github.com/localsend/localsend/issues/1688

![cleanshot_2024-09-08_at_19 33 24_2x](https://github.com/user-attachments/assets/ce88fb49-a734-4fb9-bd22-cb4d03edfeda)

Flutter's Swift Package Manager support is only from Flutter version 3.24, and we are stuck on 3.13, so we lose things like https://github.com/sindresorhus/DockProgress/issues/1 (DockProgress dropped CocoaPods support in v4.0.0)
Once we're free, switch to the latest version of DockProgress using the Swift package manager (same as the Default dependency).