### PR TITLE
refactor: simplified `methodChannelInitialized` awaiting

### DIFF
--- a/app/lib/util/native/macos_channel.dart
+++ b/app/lib/util/native/macos_channel.dart
@@ -18,14 +18,22 @@ Future<void> setupStatusBar() async {
   });
 }
 
+// This happens:
+/// - on macOS when text is dropped onto the app Dock icon
+/// - on macOS when text is dropped onto the app menu bar icon
+/// - on macOS when text\web link are shared to the app using the share extension (i.e. the system share menu)
 final _pendingFilesStreamController = StreamController<List<String>>.broadcast();
 Stream<List<String>> get pendingFilesStream => _pendingFilesStreamController.stream;
 
+/// This happens:
+/// - on macOS when text is dropped onto the app Dock icon
+/// - on macOS when text is dropped onto the app menu bar icon
+/// - on macOS when text\web link are shared to the app using the share extension (i.e. the system share menu)
 final _pendingStringsStreamController = StreamController<List<String>>.broadcast();
 Stream<List<String>> get pendingStringsStream => _pendingStringsStreamController.stream;
 
 /// Sets up the method call handler.
-/// Any call from native code is dropped until this method is called.
+/// Any call from swift native code is dropped until this method is called.
 Future<void> setupMethodCallHandler() async {
   _methodChannel.setMethodCallHandler((call) async {
     switch (call.method) {


### PR DESCRIPTION
refactor of https://github.com/localsend/localsend/commit/cf48c539fdf36902329f450a8513ace25e9ec7f2

The main point is that the `Defaults.observe` callback is called not only for future changes, but is called first for the initial value.