### PR TITLE
fix: move advanced setting entries below advanced setting checkbox

### DIFF
--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -30,7 +30,8 @@ import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-final _isMacOSSandboxed = defaultTargetPlatform == TargetPlatform.macOS && Platform.environment['APP_SANDBOX_CONTAINER_ID'] != null;
+final _isMacOSSandboxed = defaultTargetPlatform == TargetPlatform.macOS &&
+    Platform.environment['APP_SANDBOX_CONTAINER_ID'] != null;
 
 class SettingsTab extends StatelessWidget {
   const SettingsTab();
@@ -46,7 +47,9 @@ class SettingsTab extends StatelessWidget {
           children: [
             Padding(
               padding: const EdgeInsets.only(left: 8),
-              child: Text(t.settingsTab.title, style: Theme.of(context).textTheme.titleLarge, textAlign: TextAlign.center),
+              child: Text(t.settingsTab.title,
+                  style: Theme.of(context).textTheme.titleLarge,
+                  textAlign: TextAlign.center),
             ),
             const SizedBox(height: 30),
             _SettingsSection(
@@ -82,7 +85,8 @@ class SettingsTab extends StatelessWidget {
                 ),
                 _ButtonEntry(
                   label: t.settingsTab.general.language,
-                  buttonLabel: vm.settings.locale?.humanName ?? t.settingsTab.general.languageOptions.system,
+                  buttonLabel: vm.settings.locale?.humanName ??
+                      t.settingsTab.general.languageOptions.system,
                   onTap: () => vm.onTapLanguage(context),
                 ),
                 if (checkPlatformIsDesktop()) ...[
@@ -94,7 +98,9 @@ class SettingsTab extends StatelessWidget {
                           : t.settingsTab.general.saveWindowPlacement,
                       value: vm.settings.saveWindowPlacement,
                       onChanged: (b) async {
-                        await ref.notifier(settingsProvider).setSaveWindowPlacement(b);
+                        await ref
+                            .notifier(settingsProvider)
+                            .setSaveWindowPlacement(b);
                       },
                     ),
                   if (checkPlatformHasTray()) ...[
@@ -102,7 +108,9 @@ class SettingsTab extends StatelessWidget {
                       label: t.settingsTab.general.minimizeToTray,
                       value: vm.settings.minimizeToTray,
                       onChanged: (b) async {
-                        await ref.notifier(settingsProvider).setMinimizeToTray(b);
+                        await ref
+                            .notifier(settingsProvider)
+                            .setMinimizeToTray(b);
                       },
                     ),
                   ],
@@ -122,12 +130,14 @@ class SettingsTab extends StatelessWidget {
                         child: _BooleanEntry(
                           label: t.settingsTab.general.launchMinimized,
                           value: vm.autoStartLaunchHidden,
-                          onChanged: (_) => vm.onToggleAutoStartLaunchHidden(context),
+                          onChanged: (_) =>
+                              vm.onToggleAutoStartLaunchHidden(context),
                         ),
                       ),
                     ),
                   ],
-                  if (vm.advanced && checkPlatform([TargetPlatform.windows])) ...[
+                  if (vm.advanced &&
+                      checkPlatform([TargetPlatform.windows])) ...[
                     _BooleanEntry(
                       label: t.settingsTab.general.showInContextMenu,
                       value: vm.showInContextMenu,
@@ -163,7 +173,9 @@ class SettingsTab extends StatelessWidget {
                   value: vm.settings.quickSaveFromFavorites,
                   onChanged: (b) async {
                     final old = vm.settings.quickSaveFromFavorites;
-                    await ref.notifier(settingsProvider).setQuickSaveFromFavorites(b);
+                    await ref
+                        .notifier(settingsProvider)
+                        .setQuickSaveFromFavorites(b);
                     if (!old && b && context.mounted) {
                       await QuickSaveFromFavoritesNotice.open(context);
                     }
@@ -186,7 +198,9 @@ class SettingsTab extends StatelessWidget {
                       );
 
                       if (newPin != null && newPin.isNotEmpty) {
-                        await ref.notifier(settingsProvider).setReceivePin(newPin);
+                        await ref
+                            .notifier(settingsProvider)
+                            .setReceivePin(newPin);
                       }
                     }
                   },
@@ -196,24 +210,36 @@ class SettingsTab extends StatelessWidget {
                     label: t.settingsTab.receive.destination,
                     child: TextButton(
                       style: TextButton.styleFrom(
-                        backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
-                        shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
-                        foregroundColor: Theme.of(context).colorScheme.onSurface,
+                        backgroundColor:
+                            Theme.of(context).inputDecorationTheme.fillColor,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: Theme.of(context)
+                                .inputDecorationTheme
+                                .borderRadius),
+                        foregroundColor:
+                            Theme.of(context).colorScheme.onSurface,
                       ),
                       onPressed: () async {
                         if (vm.settings.destination != null) {
-                          await ref.notifier(settingsProvider).setDestination(null);
+                          await ref
+                              .notifier(settingsProvider)
+                              .setDestination(null);
                           return;
                         }
 
                         final directory = await pickDirectoryPath();
                         if (directory != null) {
-                          await ref.notifier(settingsProvider).setDestination(directory);
+                          await ref
+                              .notifier(settingsProvider)
+                              .setDestination(directory);
                         }
                       },
                       child: Padding(
                         padding: const EdgeInsets.symmetric(vertical: 5),
-                        child: Text(vm.settings.destination ?? t.settingsTab.receive.downloads, style: Theme.of(context).textTheme.titleMedium),
+                        child: Text(
+                            vm.settings.destination ??
+                                t.settingsTab.receive.downloads,
+                            style: Theme.of(context).textTheme.titleMedium),
                       ),
                     ),
                   ),
@@ -241,19 +267,6 @@ class SettingsTab extends StatelessWidget {
                 ),
               ],
             ),
-            if (vm.advanced)
-              _SettingsSection(
-                title: t.settingsTab.send.title,
-                children: [
-                  _BooleanEntry(
-                    label: t.settingsTab.send.shareViaLinkAutoAccept,
-                    value: vm.settings.shareViaLinkAutoAccept,
-                    onChanged: (b) async {
-                      await ref.notifier(settingsProvider).setShareViaLinkAutoAccept(b);
-                    },
-                  ),
-                ],
-              ),
             _SettingsSection(
               title: t.settingsTab.network.title,
               children: [
@@ -269,15 +282,19 @@ class SettingsTab extends StatelessWidget {
                   firstChild: Container(),
                   secondChild: Padding(
                     padding: const EdgeInsets.only(bottom: 15),
-                    child: Text(t.settingsTab.network.needRestart, style: TextStyle(color: Theme.of(context).colorScheme.warning)),
+                    child: Text(t.settingsTab.network.needRestart,
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.warning)),
                   ),
                 ),
                 _SettingsEntry(
-                  label: '${t.settingsTab.network.server}${vm.serverState == null ? ' (${t.general.offline})' : ''}',
+                  label:
+                      '${t.settingsTab.network.server}${vm.serverState == null ? ' (${t.general.offline})' : ''}',
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       color: Theme.of(context).inputDecorationTheme.fillColor,
-                      borderRadius: Theme.of(context).inputDecorationTheme.borderRadius,
+                      borderRadius:
+                          Theme.of(context).inputDecorationTheme.borderRadius,
                     ),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -286,7 +303,9 @@ class SettingsTab extends StatelessWidget {
                           Tooltip(
                             message: t.general.start,
                             child: TextButton(
-                              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
+                              style: TextButton.styleFrom(
+                                  foregroundColor:
+                                      Theme.of(context).colorScheme.onSurface),
                               onPressed: () => vm.onTapStartServer(context),
                               child: const Icon(Icons.play_arrow),
                             ),
@@ -295,7 +314,9 @@ class SettingsTab extends StatelessWidget {
                           Tooltip(
                             message: t.general.restart,
                             child: TextButton(
-                              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
+                              style: TextButton.styleFrom(
+                                  foregroundColor:
+                                      Theme.of(context).colorScheme.onSurface),
                               onPressed: () => vm.onTapRestartServer(context),
                               child: const Icon(Icons.refresh),
                             ),
@@ -303,8 +324,12 @@ class SettingsTab extends StatelessWidget {
                         Tooltip(
                           message: t.general.stop,
                           child: TextButton(
-                            style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
-                            onPressed: vm.serverState == null ? null : vm.onTapStopServer,
+                            style: TextButton.styleFrom(
+                                foregroundColor:
+                                    Theme.of(context).colorScheme.onSurface),
+                            onPressed: vm.serverState == null
+                                ? null
+                                : vm.onTapStopServer,
                             child: const Icon(Icons.stop),
                           ),
                         ),
@@ -322,107 +347,35 @@ class SettingsTab extends StatelessWidget {
                     },
                   ),
                 ),
-                if (vm.advanced)
-                  _SettingsEntry(
-                    label: t.settingsTab.network.deviceType,
-                    child: CustomDropdownButton<DeviceType>(
-                      value: vm.deviceInfo.deviceType,
-                      items: DeviceType.values.map((type) {
-                        return DropdownMenuItem(
-                          value: type,
-                          alignment: Alignment.center,
-                          child: Icon(type.icon),
-                        );
-                      }).toList(),
-                      onChanged: (type) async {
-                        await ref.notifier(settingsProvider).setDeviceType(type);
-                      },
-                    ),
-                  ),
-                if (vm.advanced)
-                  _SettingsEntry(
-                    label: t.settingsTab.network.deviceModel,
-                    child: TextFieldTv(
-                      name: t.settingsTab.network.deviceModel,
-                      controller: vm.deviceModelController,
-                      onChanged: (s) async {
-                        await ref.notifier(settingsProvider).setDeviceModel(s);
-                      },
-                    ),
-                  ),
-                if (vm.advanced)
-                  _SettingsEntry(
-                    label: t.settingsTab.network.port,
-                    child: TextFieldTv(
-                      name: t.settingsTab.network.port,
-                      controller: vm.portController,
-                      onChanged: (s) async {
-                        final port = int.tryParse(s);
-                        if (port != null) {
-                          await ref.notifier(settingsProvider).setPort(port);
-                        }
-                      },
-                    ),
-                  ),
-                if (vm.advanced)
-                  _SettingsEntry(
-                    label: t.settingsTab.network.discoveryTimeout,
-                    child: TextFieldTv(
-                      name: t.settingsTab.network.discoveryTimeout,
-                      controller: vm.timeoutController,
-                      onChanged: (s) async {
-                        final timeout = int.tryParse(s);
-                        if (timeout != null) {
-                          await ref.notifier(settingsProvider).setDiscoveryTimeout(timeout);
-                        }
-                      },
-                    ),
-                  ),
-                if (vm.advanced)
-                  _BooleanEntry(
-                    label: t.settingsTab.network.encryption,
-                    value: vm.settings.https,
-                    onChanged: (b) async {
-                      final old = vm.settings.https;
-                      await ref.notifier(settingsProvider).setHttps(b);
-                      if (old && !b && context.mounted) {
-                        await EncryptionDisabledNotice.open(context);
-                      }
-                    },
-                  ),
-                if (vm.advanced)
-                  _SettingsEntry(
-                    label: t.settingsTab.network.multicastGroup,
-                    child: TextFieldTv(
-                      name: t.settingsTab.network.multicastGroup,
-                      controller: vm.multicastController,
-                      onChanged: (s) async {
-                        await ref.notifier(settingsProvider).setMulticastGroup(s);
-                      },
-                    ),
-                  ),
                 AnimatedCrossFade(
-                  crossFadeState: vm.settings.port != defaultPort ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+                  crossFadeState: vm.settings.port != defaultPort
+                      ? CrossFadeState.showSecond
+                      : CrossFadeState.showFirst,
                   duration: const Duration(milliseconds: 200),
                   alignment: Alignment.topLeft,
                   firstChild: Container(),
                   secondChild: Padding(
                     padding: const EdgeInsets.only(bottom: 15),
                     child: Text(
-                      t.settingsTab.network.portWarning(defaultPort: defaultPort),
+                      t.settingsTab.network
+                          .portWarning(defaultPort: defaultPort),
                       style: const TextStyle(color: Colors.grey),
                     ),
                   ),
                 ),
                 AnimatedCrossFade(
-                  crossFadeState: vm.settings.multicastGroup != defaultMulticastGroup ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+                  crossFadeState:
+                      vm.settings.multicastGroup != defaultMulticastGroup
+                          ? CrossFadeState.showSecond
+                          : CrossFadeState.showFirst,
                   duration: const Duration(milliseconds: 200),
                   alignment: Alignment.topLeft,
                   firstChild: Container(),
                   secondChild: Padding(
                     padding: const EdgeInsets.only(bottom: 15),
                     child: Text(
-                      t.settingsTab.network.multicastGroupWarning(defaultMulticast: defaultMulticastGroup),
+                      t.settingsTab.network.multicastGroupWarning(
+                          defaultMulticast: defaultMulticastGroup),
                       style: const TextStyle(color: Colors.grey),
                     ),
                   ),
@@ -463,7 +416,8 @@ class SettingsTab extends StatelessWidget {
                     buttonLabel: t.general.open,
                     onTap: () async {
                       await launchUrl(
-                        Uri.parse('https://www.apple.com/legal/internet-services/itunes/dev/stdeula/'),
+                        Uri.parse(
+                            'https://www.apple.com/legal/internet-services/itunes/dev/stdeula/'),
                         mode: LaunchMode.externalApplication,
                       );
                     },
@@ -483,6 +437,149 @@ class SettingsTab extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 20),
+            // Advanced settings
+            if (vm.advanced)
+              _SettingsSection(
+                title: t.settingsTab.send.title,
+                children: [
+                  _BooleanEntry(
+                    label: t.settingsTab.send.shareViaLinkAutoAccept,
+                    value: vm.settings.shareViaLinkAutoAccept,
+                    onChanged: (b) async {
+                      await ref
+                          .notifier(settingsProvider)
+                          .setShareViaLinkAutoAccept(b);
+                    },
+                  ),
+                ],
+              ),
+            if (vm.advanced)
+              _SettingsSection(
+                title: t.settingsTab.network.title,
+                children: [
+                  if (vm.advanced)
+                    _SettingsEntry(
+                      label: t.settingsTab.network.deviceType,
+                      child: CustomDropdownButton<DeviceType>(
+                        value: vm.deviceInfo.deviceType,
+                        items: DeviceType.values.map((type) {
+                          return DropdownMenuItem(
+                            value: type,
+                            alignment: Alignment.center,
+                            child: Icon(type.icon),
+                          );
+                        }).toList(),
+                        onChanged: (type) async {
+                          await ref
+                              .notifier(settingsProvider)
+                              .setDeviceType(type);
+                        },
+                      ),
+                    ),
+                  if (vm.advanced)
+                    _SettingsEntry(
+                      label: t.settingsTab.network.deviceModel,
+                      child: TextFieldTv(
+                        name: t.settingsTab.network.deviceModel,
+                        controller: vm.deviceModelController,
+                        onChanged: (s) async {
+                          await ref
+                              .notifier(settingsProvider)
+                              .setDeviceModel(s);
+                        },
+                      ),
+                    ),
+                  if (vm.advanced)
+                    _SettingsEntry(
+                      label: t.settingsTab.network.port,
+                      child: TextFieldTv(
+                        name: t.settingsTab.network.port,
+                        controller: vm.portController,
+                        onChanged: (s) async {
+                          final port = int.tryParse(s);
+                          if (port != null) {
+                            await ref.notifier(settingsProvider).setPort(port);
+                          }
+                        },
+                      ),
+                    ),
+                  if (vm.advanced)
+                    _SettingsEntry(
+                      label: t.settingsTab.network.discoveryTimeout,
+                      child: TextFieldTv(
+                        name: t.settingsTab.network.discoveryTimeout,
+                        controller: vm.timeoutController,
+                        onChanged: (s) async {
+                          final timeout = int.tryParse(s);
+                          if (timeout != null) {
+                            await ref
+                                .notifier(settingsProvider)
+                                .setDiscoveryTimeout(timeout);
+                          }
+                        },
+                      ),
+                    ),
+                  if (vm.advanced)
+                    _BooleanEntry(
+                      label: t.settingsTab.network.encryption,
+                      value: vm.settings.https,
+                      onChanged: (b) async {
+                        final old = vm.settings.https;
+                        await ref.notifier(settingsProvider).setHttps(b);
+                        if (old && !b && context.mounted) {
+                          await EncryptionDisabledNotice.open(context);
+                        }
+                      },
+                    ),
+                  if (vm.advanced)
+                    _SettingsEntry(
+                      label: t.settingsTab.network.multicastGroup,
+                      child: TextFieldTv(
+                        name: t.settingsTab.network.multicastGroup,
+                        controller: vm.multicastController,
+                        onChanged: (s) async {
+                          await ref
+                              .notifier(settingsProvider)
+                              .setMulticastGroup(s);
+                        },
+                      ),
+                    ),
+                  AnimatedCrossFade(
+                    crossFadeState: vm.settings.port != defaultPort
+                        ? CrossFadeState.showSecond
+                        : CrossFadeState.showFirst,
+                    duration: const Duration(milliseconds: 200),
+                    alignment: Alignment.topLeft,
+                    firstChild: Container(),
+                    secondChild: Padding(
+                      padding: const EdgeInsets.only(bottom: 15),
+                      child: Text(
+                        t.settingsTab.network
+                            .portWarning(defaultPort: defaultPort),
+                        style: const TextStyle(color: Colors.grey),
+                      ),
+                    ),
+                  ),
+                  AnimatedCrossFade(
+                    crossFadeState:
+                        vm.settings.multicastGroup != defaultMulticastGroup
+                            ? CrossFadeState.showSecond
+                            : CrossFadeState.showFirst,
+                    duration: const Duration(milliseconds: 200),
+                    alignment: Alignment.topLeft,
+                    firstChild: Container(),
+                    secondChild: Padding(
+                      padding: const EdgeInsets.only(bottom: 15),
+                      child: Text(
+                        t.settingsTab.network.multicastGroupWarning(
+                            defaultMulticast: defaultMulticastGroup),
+                        style: const TextStyle(color: Colors.grey),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+
             const LocalSendLogo(withText: true),
             const SizedBox(height: 5),
             ref.watch(versionProvider).maybeWhen(
@@ -606,7 +703,9 @@ class _ButtonEntry extends StatelessWidget {
       child: TextButton(
         style: TextButton.styleFrom(
           backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
-          shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
+          shape: RoundedRectangleBorder(
+              borderRadius:
+                  Theme.of(context).inputDecorationTheme.borderRadius),
           foregroundColor: Theme.of(context).colorScheme.onSurface,
         ),
         onPressed: onTap,


### PR DESCRIPTION
fixes: #1779
Brought these setting entries under the Advanced settings checkbox
- 6 entries from the Network section
- The whole Send section

![Screenshot from 2024-09-13 00-26-58](https://github.com/user-attachments/assets/116ff304-4516-4f23-abf3-d0469d0bc219)
