### PR TITLE
fix: dock progress shows only once

### DIFF
--- a/app/lib/util/native/taskbar_helper.dart
+++ b/app/lib/util/native/taskbar_helper.dart
@@ -26,7 +26,6 @@ class TaskbarHelper {
       if (_isWindows) {
         await WindowsTaskbar.setProgress(digestedProgress, digestedTotal);
       } else if (_isMacos) {
-        print(progress);
         await updateDockProgress(progress / total);
       }
     } else {

--- a/app/macos/Podfile
+++ b/app/macos/Podfile
@@ -33,7 +33,6 @@ target 'Runner' do
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
   
   pod 'Defaults', '~> 4.2'
-  pod 'DockProgress'
 end
 
 post_install do |installer|

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -7,7 +7,6 @@ PODS:
     - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
-  - DockProgress (3.2.0)
   - dynamic_color (0.0.2):
     - FlutterMacOS
   - file_selector_macos (0.0.1):
@@ -56,7 +55,6 @@ DEPENDENCIES:
   - Defaults (~> 4.2)
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - DockProgress
   - dynamic_color (from `Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
@@ -79,7 +77,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Defaults
-    - DockProgress
     - ReachabilitySwift
 
 EXTERNAL SOURCES:
@@ -131,7 +128,6 @@ SPEC CHECKSUMS:
   Defaults: d785e56c0fb8890dc40351603f05c8e1df1bdd45
   desktop_drop: 69eeff437544aa619c8db7f4481b3a65f7696898
   device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
-  DockProgress: 94765d097d5c54579bf93385b5be71bd6a74fdf6
   dynamic_color: 2eaa27267de1ca20d879fbd6e01259773fb1670f
   file_selector_macos: 54fdab7caa3ac3fc43c9fac4d7d8d231277f8cf2
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
@@ -152,6 +148,6 @@ SPEC CHECKSUMS:
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 
-PODFILE CHECKSUM: 660eab236b19bb36037d2fc653a1e4ae4c99e9b4
+PODFILE CHECKSUM: 5c6550f5101fcba381ddb97e2135e4cacca4f31f
 
 COCOAPODS: 1.15.2

--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		053DADFE2C89F83500C3B4DE /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053DADFA2C89F25E00C3B4DE /* Shared.swift */; };
 		0543E87B2C8A93A9004AA8B7 /* ContentDropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0543E87A2C8A93A9004AA8B7 /* ContentDropView.swift */; };
 		05BAA8D02C8CE248003CFCF1 /* SecurityScopedResourceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05BAA8CF2C8CE248003CFCF1 /* SecurityScopedResourceManager.swift */; };
+		05CD1E642C98F2220044F24D /* DockProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 05CD1E632C98F2220044F24D /* DockProgress */; };
 		0F663CE30FCD07225E44A808 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F8CCFF0FAB783405F067709 /* Pods_Runner.framework */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
@@ -122,6 +123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				05CD1E642C98F2220044F24D /* DockProgress in Frameworks */,
 				0F663CE30FCD07225E44A808 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -272,6 +274,7 @@
 			);
 			name = Runner;
 			packageProductDependencies = (
+				05CD1E632C98F2220044F24D /* DockProgress */,
 			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* LocalSend.app */;
@@ -317,6 +320,7 @@
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
 			packageReferences = (
+				05CD1E622C98F2220044F24D /* XCRemoteSwiftPackageReference "DockProgress" */,
 			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
@@ -921,6 +925,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		05CD1E622C98F2220044F24D /* XCRemoteSwiftPackageReference "DockProgress" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/DockProgress";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.3.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		05CD1E632C98F2220044F24D /* DockProgress */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 05CD1E622C98F2220044F24D /* XCRemoteSwiftPackageReference "DockProgress" */;
+			productName = DockProgress;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/app/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "3e0046e1b0518dc180bd8a7c98fa476d9af079586f505a34aa5b924f90460bda",
+  "pins" : [
+    {
+      "identity" : "dockprogress",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/DockProgress",
+      "state" : {
+        "revision" : "d4f23b5a8f5ca0fac393eb7ba78c2fe3e32e52da",
+        "version" : "4.3.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/app/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "3e0046e1b0518dc180bd8a7c98fa476d9af079586f505a34aa5b924f90460bda",
+  "pins" : [
+    {
+      "identity" : "dockprogress",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/DockProgress",
+      "state" : {
+        "revision" : "d4f23b5a8f5ca0fac393eb7ba78c2fe3e32e52da",
+        "version" : "4.3.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -47,14 +47,11 @@ class AppDelegate: FlutterAppDelegate {
     private func setDockIcon(icon: DockIcon) {
         switch icon {
         case .regular:
-            let newIcon = NSImage(named: "AppIcon")!
-            NSApplication.shared.applicationIconImage = newIcon
+            NSApplication.shared.applicationIconImage = NSImage(named: NSImage.applicationIconName)
         case .error:
-            let newIcon = NSImage(named: "AppIconWithErrorMark")!
-            NSApplication.shared.applicationIconImage = newIcon
+           NSApplication.shared.applicationIconImage = NSImage(named: "AppIconWithErrorMark")!
         case .success:
-            let newIcon = NSImage(named: "AppIconWithSuccessMark")!
-            NSApplication.shared.applicationIconImage = newIcon
+           NSApplication.shared.applicationIconImage = NSImage(named: "AppIconWithSuccessMark")!
         }
     }
     
@@ -135,7 +132,7 @@ class AppDelegate: FlutterAppDelegate {
     }
     
     // START: handle opened files
-    private func handleFlutterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    @MainActor private func handleFlutterCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "methodChannelInitialized":
             /// Any call to the channel is dropped until methodChannelInitialized is called from Flutter


### PR DESCRIPTION
Currently, changing the Dock icon (#1783) breaks DockProgress, so that after one completed transfer, the progress is no longer displayed in the Dock.
The behavior is the same in DockProgress v v4.3.0 but in v4.3.1 it has been fixed, so we have to use the Swift Package Manager through Xcode at the moment to resolve this package (because the cocoapods version will no longer be updated), and then it will be possible to build normally using the flutter command.