### PR TITLE
Update Dutch (NL) translation

### DIFF
--- a/app/assets/i18n/strings_nl.json
+++ b/app/assets/i18n/strings_nl.json
@@ -31,7 +31,7 @@
     "quickSaveFromFavorites": "Snel opslaan voor 'Favorieten'",
     "renamed": "Hernoemd",
     "reset": "Herstellen",
-    "restart": "Opnieuw opstarten",
+    "restart": "Opnieuw starten",
     "settings": "Instellingen",
     "skipped": "Overgeslagen",
     "start": "Starten",
@@ -123,7 +123,7 @@
     },
     "network": {
       "title": "Netwerk",
-      "needRestart": "Start de server opnieuw op om de wijzigingen door te voeren.",
+      "needRestart": "Start de server opnieuw op om de instellingen toe te passen.",
       "server": "Server",
       "alias": "Apparaatnaam",
       "deviceType": "Apparaattype",
@@ -235,8 +235,8 @@
     "noRequests": "Nog geen verzoeken.",
     "encryption": "@:settingsTab.network.encryption",
     "autoAccept": "Verzoeken automatisch accepteren",
-    "requirePin": "Require PIN",
-    "pinHint": "The PIN is \"{pin}\"",
+    "requirePin": "Code vereisen",
+    "pinHint": "De code is '{pin}'.",
     "encryptionHint": "LocalSend maakt gebruik van een zelfondertekend certificaat. Je moet dit accepteren in je browser.",
     "pendingRequests": "Openstaande verzoeken: {n}"
   },
@@ -364,7 +364,7 @@
       "content": "Bestandsverzoeken van je favoriete apparaten worden nu automatisch geaccepteerd."
     },
     "pin": {
-      "title": "Vul de PIN in"
+      "title": "Vul de code in"
     },
     "sendModeHelp": {
       "title": "Verzendmodi",
@@ -388,8 +388,8 @@
   },
   "web": {
     "waiting": "@:sendPage.waiting",
-    "enterPin": "Vul de PIN in",
-    "invalidPin": "Ongeldige PIN",
+    "enterPin": "Vul de code in",
+    "invalidPin": "Ongeldige code",
     "tooManyAttempts": "Te veel pogingen",
     "rejected": "Geweigerd",
     "files": "Bestanden",

--- a/app/assets/i18n/strings_nl.json
+++ b/app/assets/i18n/strings_nl.json
@@ -189,8 +189,8 @@
       "one": "wil een bestand naar je verzenden",
       "other": "wil {n} bestanden naar je verzenden"
     },
-    "subTitleMessage": "heeft je een bericht gestuurd:",
-    "subTitleLink": "heeft je een link gestuurd:",
+    "subTitleMessage": "heeft een bericht naar je verzonden:",
+    "subTitleLink": "heeft een link naar je verzonden:",
     "canceled": "De verzender heeft het verzoek geannuleerd."
   },
   "receiveOptionsPage": {
@@ -209,7 +209,7 @@
   "progressPage": {
     "titleSending": "Bestanden verzenden",
     "titleReceiving": "Bestanden ontvangen",
-    "savedToGallery": "Opgeslagen in Foto's",
+    "savedToGallery": "Opgeslagen in galerij",
     "total": {
       "title": {
         "sending": "Totale voortgang ({time})",
@@ -281,7 +281,7 @@
     },
     "cannotOpenFile": {
       "title": "Kan bestand niet openen",
-      "content": "Het bestand '{file}' kan niet worden geopend. Het is mogelijk verplaatst, hernoemd of verwijderen."
+      "content": "Het bestand '{file}' kan niet worden geopend. Het is mogelijk verplaatst, hernoemd of verwijderd."
     },
     "encryptionDisabledNotice": {
       "title": "Versleuteling uitgeschakeld",
@@ -310,7 +310,7 @@
     "fileInfo": {
       "title": "Bestandsinformatie",
       "fileName": "Bestandsnaam:",
-      "path": "Pad:",
+      "path": "Locatie:",
       "size": "Grootte:",
       "sender": "Afzender:",
       "time": "Tijd:"
@@ -357,7 +357,7 @@
     },
     "quickSaveNotice": {
       "title": "@:general.quickSave",
-      "content": "Bestandsverzoeken worden nu automatisch geaccepteerd. Iedereen op het lokale netwerk kan je dus nu bestanden sturen."
+      "content": "Bestandsverzoeken worden nu automatisch geaccepteerd. Iedereen op het lokale netwerk kan nu dus bestanden naar je verzenden."
     },
     "quickSaveFromFavoritesNotice": {
       "title": "@:general.quickSaveFromFavorites",

--- a/app/assets/i18n/strings_nl.json
+++ b/app/assets/i18n/strings_nl.json
@@ -9,17 +9,17 @@
     "cancel": "Annuleren",
     "close": "Sluiten",
     "confirm": "Bevestigen",
-    "continueStr": "Ga verder",
+    "continueStr": "Doorgaan",
     "copy": "Kopiëren",
-    "copiedToClipboard": "Gekopieerd naar het klembord",
+    "copiedToClipboard": "Gekopieerd naar klembord",
     "decline": "Weigeren",
-    "done": "Klaar",
+    "done": "Gereed",
     "delete": "Verwijderen",
     "edit": "Bewerken",
     "error": "Fout",
     "example": "Voorbeeld",
     "files": "Bestanden",
-    "finished": "Afgewerkt",
+    "finished": "Voltooid",
     "hide": "Verbergen",
     "off": "Uit",
     "offline": "Offline",
@@ -28,24 +28,25 @@
     "open": "Openen",
     "queue": "Wachtrij",
     "quickSave": "Snel opslaan",
+    "quickSaveFromFavorites": "Snel opslaan voor 'Favorieten'",
     "renamed": "Hernoemd",
-    "reset": "Reset",
-    "restart": "Herstarten",
+    "reset": "Herstellen",
+    "restart": "Opnieuw opstarten",
     "settings": "Instellingen",
     "skipped": "Overgeslagen",
-    "start": "Start",
-    "stop": "Stop",
+    "start": "Starten",
+    "stop": "Stoppen",
     "save": "Opslaan",
     "unchanged": "Ongewijzigd",
     "unknown": "Onbekend",
-    "noItemInClipboard": "Niets in klembord"
+    "noItemInClipboard": "Het klembord is leeg."
   },
   "receiveTab": {
     "title": "Ontvangen",
     "infoBox": {
-      "ip": "IP:",
+      "ip": "IP-adres:",
       "port": "Poort:",
-      "alias": "Alias:"
+      "alias": "Apparaatnaam:"
     }
   },
   "sendTab": {
@@ -63,19 +64,20 @@
       "app": "App",
       "clipboard": "Plakken"
     },
-    "shareIntentInfo": "Je kan ook de  \"Delen\" functie van je telefoon gebruiken om bestanden gemakkelijker te selecteren.",
+    "shareIntentInfo": "Je kunt ook de functie 'Delen' van je mobiele apparaat gebruiken om gemakkelijker bestanden te selecteren.",
     "nearbyDevices": "Apparaten in de buurt",
     "thisDevice": "Dit apparaat",
-    "scan": "Zoek naar apparaten",
-    "sendMode": "Verzend modus",
+    "scan": "Apparaten zoeken",
+    "manualSending": "Handmatig verzenden",
+    "sendMode": "Verzendmodus",
     "sendModes": {
-      "single": "Één ontvanger",
+      "single": "Eén ontvanger",
       "multiple": "Meerdere ontvangers",
       "link": "Delen via link"
     },
-    "sendModeHelp": "Info",
-    "help": "Zorg ervoor dat het gewenste doel zich ook in hetzelfde wifi-netwerk bevindt.",
-    "placeItems": "Plaats items om te delen."
+    "sendModeHelp": "Informatie",
+    "help": "Zorg ervoor dat de ontvanger is verbonden met hetzelfde wifi-netwerk.",
+    "placeItems": "Zet items neer om te delen."
   },
   "settingsTab": {
     "title": "Instellingen",
@@ -96,101 +98,124 @@
       "languageOptions": {
         "system": "Systeem"
       },
-      "saveWindowPlacement": "Afsluiten: Vensterindeling behouden",
-      "minimizeToTray": "Stoppen: Minimaliseer naar systeemvak",
-      "launchAtStartup": "Autostart na inloggen",
-      "launchMinimized": "Autostart: Start verborgen",
+      "saveWindowPlacement": "Afsluiten: vensterindeling behouden",
+      "saveWindowPlacementWindows": "Afsluiten: vensterindeling behouden",
+      "minimizeToTray": "Sluiten: minimaliseren naar systeemvak/menubalk",
+      "launchAtStartup": "Automatisch starten na aanmelden",
+      "launchMinimized": "Automatisch starten: verborgen",
+      "showInContextMenu": "LocalSend weergeven in contextmenu",
       "animations": "Animaties"
     },
     "receive": {
       "title": "Ontvangen",
       "quickSave": "@:general.quickSave",
-      "destination": "Bestemming",
+      "quickSaveFromFavorites": "@:general.quickSaveFromFavorites",
+      "requirePin": "@:webSharePage.requirePin",
+      "autoFinish": "Automatisch voltooien",
+      "destination": "Opslaan in map",
       "downloads": "(Downloads)",
-      "saveToGallery": "Bewaar media in galerij",
+      "saveToGallery": "Media opslaan in galerij",
       "saveToHistory": "Opslaan in geschiedenis"
+    },
+    "send": {
+      "title": "Verzenden",
+      "shareViaLinkAutoAccept": "Automatisch verzoeken goedkeuren in modus 'Delen via link'"
     },
     "network": {
       "title": "Netwerk",
-      "needRestart": "Server herstarten om instellingen toe te passen!",
+      "needRestart": "Start de server opnieuw op om de wijzigingen door te voeren.",
       "server": "Server",
-      "alias": "Alias",
+      "alias": "Apparaatnaam",
       "deviceType": "Apparaattype",
       "deviceModel": "Apparaatmodel",
       "port": "Poort",
-      "portWarning": "Je wordt mogelijk niet gedetecteerd door andere apparaten omdat je een aagepaste poort gebruikt. (standaard: {defaultPort})",
-      "encryption": "Encryptie",
-      "multicastGroup": "Multicast",
-      "multicastGroupWarning": "Je wordt mogelijk niet gedetecteerd door andere apparaten omdate je een aangepast multicast-addres gebruikt. (standaard: {defaultMulticast})"
+      "discoveryTimeout": "Time-out voor scannen",
+      "portWarning": "Je apparaat kan mogelijk niet worden gevonden omdat je een aangepaste poort gebruikt. (Standaard: {defaultPort})",
+      "encryption": "Versleuteling",
+      "multicastGroup": "Multicast-adres",
+      "multicastGroupWarning": "Je apparaat kan mogelijk niet worden gevonden omdat je een aangepast multicast-adres gebruikt. (Standaard: {defaultMulticast})"
+    },
+    "other": {
+      "title": "Overig",
+      "support": "LocalSend steunen",
+      "donate": "Doneren",
+      "privacyPolicy": "Privacybeleid",
+      "termsOfUse": "Gebruiksvoorwaarden"
     },
     "advancedSettings": "Geavanceerde instellingen"
   },
   "troubleshootPage": {
-    "title": "Probleem oplossen",
-    "subTitle": "Werkt de app niet als verwacht? Hier kun je algemene oplossingen vinden.",
+    "title": "Problemen oplossen",
+    "subTitle": "Werkt de app niet zoals verwacht? Op deze pagina vind je oplossingen voor veelvoorkomende problemen.",
     "solution": "Oplossing:",
     "fixButton": "Automatisch oplossen",
     "firewall": {
-      "symptom": "Deze app kan bestanden verzenden naar andere apparaten maar andere apparaten kunnen geen bestanden verzenden naar dit apparaat.",
-      "solution": "Dit is hoogstwaarschijnlijk een firewall probleem. Je kan dit oplossen door inkomende verbindingen (UDP en TCP) toe te staan op poort {port}.",
+      "symptom": "Dit apparaat kan bestanden naar andere apparaten verzenden, maar andere apparaten kunnen geen bestanden naar dit apparaat verzenden.",
+      "solution": "Dit is hoogstwaarschijnlijk een firewallprobleem. Je kunt dit oplossen door inkomende verbindingen (UDP en TCP) op poort {port} toe te staan.",
       "openFirewall": "Firewall openen"
     },
+    "noDiscovery": {
+      "symptom": "Dit apparaat vindt geen andere apparaten.",
+      "solution": "Zorg ervoor dat alle apparaten met hetzelfde wifi-netwerk zijn verbonden en dat ze dezelfde configuratie hebben (poort, multicast-adres, versleuteling). Je kunt proberen het IP-adres van het apparaat handmatig in te vullen. Als dat werkt, kun je het apparaat toevoegen aan je favorieten, zodat het voortaan automatisch kan worden gevonden."
+    },
     "noConnection": {
-      "symptom": "Beide apparaten kunnen elkaar niet ontdekken en kunnen ook geen bestanden delen.",
-      "solution": "Het probleem doet zich aan beide kanten voor? Dan moet je ervoor zorgen dat beide apparaten zich in hetzelfde wifi-netwerk bevinden en dezelfde configuratie delen (poort, multicast-adres, encryptie). De wifi staat mogelijk geen communicatie tussen deelnemers toe. In dit geval moet deze optie op de router zijn ingeschakeld."
+      "symptom": "Beide apparaten kunnen elkaar niet vinden en kunnen ook geen bestanden delen.",
+      "solution": "Doet het probleem zich aan beide kanten voor? Zorg er dan voor dat beide apparaten met hetzelfde wifi-netwerk zijn verbonden en dat ze dezelfde configuratie hebben (poort, multicast-address, versleuteling). Mogelijk is onderlinge communicatie tussen apparaten op het wifi-netwerk geblokkeerd (AP-isolatie). Dit moet je dan toestaan in de instellingen van je router."
     }
   },
   "receiveHistoryPage": {
     "title": "Geschiedenis",
-    "openFolder": "Map openen ",
+    "openFolder": "Map openen",
     "deleteHistory": "Geschiedenis verwijderen",
     "empty": "De geschiedenis is leeg.",
     "entryActions": {
       "open": "Bestand openen",
+      "showInFolder": "Weergeven in map",
       "info": "Informatie",
-      "deleteFromHistory": "Uit geschiedenis verwijderen"
+      "deleteFromHistory": "Verwijderen uit geschiedenis"
     }
   },
   "apkPickerPage": {
     "title": "Apps (APK)",
-    "excludeSystemApps": "Sluit systeem-apps uit",
-    "excludeAppsWithoutLaunchIntent": "Sluit niet-startbare apps uit",
-    "apps": "{n} Apps"
+    "excludeSystemApps": "Systeemapps uitsluiten",
+    "excludeAppsWithoutLaunchIntent": "Niet-startbare apps uitsluiten",
+    "apps": "{n} apps"
   },
   "selectedFilesPage": {
-    "deleteAll": "Verwijder alles"
+    "deleteAll": "Alles verwijderen"
   },
   "receivePage": {
     "subTitle": {
-      "one": "wil je een bestand verzenden",
-      "other": "wil je {n} bestanden verzenden"
+      "one": "wil een bestand naar je verzenden",
+      "other": "wil {n} bestanden naar je verzenden"
     },
-    "subTitleMessage": "heeft je een bericht verzonden:",
-    "subTitleLink": "heeft je een link verzonden:",
+    "subTitleMessage": "heeft je een bericht gestuurd:",
+    "subTitleLink": "heeft je een link gestuurd:",
     "canceled": "De verzender heeft het verzoek geannuleerd."
   },
   "receiveOptionsPage": {
     "title": "Opties",
     "destination": "@:settingsTab.receive.destination",
-    "appDirectory": "(LocalSend folder)",
+    "appDirectory": "(LocalSend-map)",
     "saveToGallery": "@:settingsTab.receive.saveToGallery",
-    "saveToGalleryOff": "Automatisch uitgezet want er zijn mappen."
+    "saveToGalleryOff": "Automatisch uitgezet omdat er mappen bij zitten."
   },
   "sendPage": {
     "waiting": "Wachten op antwoord...",
     "rejected": "De ontvanger heeft het verzoek geweigerd.",
-    "busy": "De ontvanger is met een ander verzoek bezig."
+    "tooManyAttempts": "@:web.tooManyAttempts",
+    "busy": "De ontvanger is bezig met een ander verzoek."
   },
   "progressPage": {
-    "titleSending": "Verzenden bestanden",
-    "titleReceiving": "Ontvangen bestanden",
-    "savedToGallery": "Bewaard in foto's",
+    "titleSending": "Bestanden verzenden",
+    "titleReceiving": "Bestanden ontvangen",
+    "savedToGallery": "Opgeslagen in Foto's",
     "total": {
       "title": {
-        "sending": "Totale vooruitgang ({time})",
-        "finishedError": "Afgerond met een foutmelding",
-        "canceledSender": "Geannuleerd door de verzender",
-        "canceledReceiver": "Geannuleerd door de ontvanger"
+        "sending": "Totale voortgang ({time})",
+        "finishedError": "Voltooid met fouten",
+        "canceledSender": "Geannuleerd door verzender",
+        "canceledReceiver": "Geannuleerd door ontvanger"
       },
       "count": "Bestanden: {curr} / {n}",
       "size": "Grootte: {curr} / {n}",
@@ -198,25 +223,43 @@
     }
   },
   "webSharePage": {
-    "title": "Delen via weblink",
+    "title": "Delen via link",
     "loading": "Server starten...",
     "stopping": "Server stoppen...",
-    "error": "Onverwachte fout bij het opstarten van de server.",
+    "error": "Er is een fout opgetreden bij het starten van de server.",
     "openLink": {
-      "one": "Open deze link in de browser:",
-      "other": "Open een van deze links in de browser:"
+      "one": "Open deze link in je browser:",
+      "other": "Open een van deze links in je browser:"
     },
     "requests": "Verzoeken",
     "noRequests": "Nog geen verzoeken.",
     "encryption": "@:settingsTab.network.encryption",
-    "encryptionHint": "LocalSend maakt gebruik van een zelfondertekend certificaat. U moet het accepteren in de browser.",
+    "autoAccept": "Verzoeken automatisch accepteren",
+    "requirePin": "Require PIN",
+    "pinHint": "The PIN is \"{pin}\"",
+    "encryptionHint": "LocalSend maakt gebruik van een zelfondertekend certificaat. Je moet dit accepteren in je browser.",
     "pendingRequests": "Openstaande verzoeken: {n}"
   },
   "aboutPage": {
-    "title": "Over LocalSend"
+    "title": "Over LocalSend",
+    "description": [
+      "LocalSend is een gratis en opensource app waarmee je veilig bestanden en berichten met apparaten op je lokale netwerk kunt delen, zonder internetverbinding.",
+      "De app is beschikbaar voor Android, iOS, macOS, Windows en Linux. Je vindt alle downloadopties op de officiële website."
+    ],
+    "author": "Auteur",
+    "contributors": "Bijdragers",
+    "packagers": "Distributeurs",
+    "translators": "Vertalers"
+  },
+  "donationPage": {
+    "title": "Doneren",
+    "info": "LocalSend is gratis, opensource en advertentievrij. Als je de app graag gebruikt, kun je de ontwikkeling steunen middels een donatie.",
+    "donate": "{amount} doneren",
+    "thanks": "Ontzettend bedankt!",
+    "restore": "Aankoop herstellen"
   },
   "changelogPage": {
-    "title": "Changelog"
+    "title": "Wijzigingenoverzicht"
   },
   "aliasGenerator(ignoreMissing, ignoreGpt)": {
     "@info": "Inherits from the English version"
@@ -227,141 +270,159 @@
       "content": "Wat wil je toevoegen?"
     },
     "addressInput": {
-      "title": "Adres ingeven",
+      "title": "Vul een adres in",
       "hashtag": "Hashtag",
-      "ip": "IP Adres",
-      "recentlyUsed": "Recent gebruikt: "
+      "ip": "IP-adres",
+      "recentlyUsed": "Onlangs gebruikt: "
     },
     "cancelSession": {
       "title": "Bestandsoverdracht annuleren",
-      "content": "Weet je zeker dat je de bestandsoverdracht wil annuleren?"
+      "content": "Wil je de bestandsoverdracht annuleren?"
     },
     "cannotOpenFile": {
-      "title": "Openen mislukt",
-      "content": "Kan het bestand \"{file}\" niet openen. Is het bestand van plaats veranderd, hernoemd of verwijderd?"
+      "title": "Kan bestand niet openen",
+      "content": "Het bestand '{file}' kan niet worden geopend. Het is mogelijk verplaatst, hernoemd of verwijderen."
     },
     "encryptionDisabledNotice": {
-      "title": "Encryptie uitgeschakeld",
-      "content": "Communicatie gebeurt nu via het onversleutelde HTTP-protocol. Schakel encryptie in om HTTPS opnieuw te gebruiken."
+      "title": "Versleuteling uitgeschakeld",
+      "content": "Communicatie verloopt nu via het onversleutelde HTTP-protocol. Schakel versleuteling weer in om het HTTPS-protocol te gebruiken."
     },
     "errorDialog": {
       "title": "@:general.error"
     },
     "favoriteDialog": {
-      "title": "Voorkeuren",
-      "noFavorites": "Geen Favoriete Apparaten",
+      "title": "Favorieten",
+      "noFavorites": "Nog geen favoriete apparaten.",
       "addFavorite": "Toevoegen"
     },
     "favoriteDeleteDialog": {
-      "title": "uit voorkeuren verwijderen",
-      "content": "Weet u zeker dat u  \"{name}\" wilt verwijderen uit uw favorieten?"
+      "title": "Verwijderen uit favorieten",
+      "content": "Wil je '{name}' uit je favorieten verwijderen?"
     },
     "favoriteEditDialog": {
-      "titleAdd": "Aan Favorieten toevoegen",
-      "titleEdit": "Aanpassen",
-      "name": "Alias",
-      "auto": "(auto)",
-      "ip": "IP Adres",
+      "titleAdd": "Toevoegen aan favorieten",
+      "titleEdit": "Instellingen",
+      "name": "Apparaatnaam",
+      "auto": "(automatisch)",
+      "ip": "IP-adres",
       "port": "Poort"
     },
     "fileInfo": {
       "title": "Bestandsinformatie",
       "fileName": "Bestandsnaam:",
-      "path": "Locatie:",
-      "size": "Groote:",
-      "sender": "Verzender:",
-      "time": "Tijdstip:"
+      "path": "Pad:",
+      "size": "Grootte:",
+      "sender": "Afzender:",
+      "time": "Tijd:"
     },
     "fileNameInput": {
-      "title": "Voer bestandsnaam in",
+      "title": "Vul een bestandsnaam in",
       "original": "Origineel: {original}"
     },
     "historyClearDialog": {
       "title": "Geschiedenis wissen",
-      "content": "Weet u zeker dat u de geschiedenis wilt wissen?"
+      "content": "Wil je de volledige geschiedenis verwijderen?"
     },
     "localNetworkUnauthorized": {
       "title": "@:dialogs.noPermission.title",
-      "description": "LocalSend kan geen andere apparaten op uw netwerk vinden zonder de juiste rechten voor netwerktoegang te hebben verkregen. Stel deze correct in in het instellingen menu.",
+      "description": "LocalSend heeft rechten nodig om op het lokale netwerk naar andere apparaten te kunnen zoeken. Verleen deze rechten in de instellingen.",
       "gotoSettings": "Instellingen"
     },
     "messageInput": {
-      "title": "Typ bericht",
-      "multiline": "Meerdere lijnen"
+      "title": "Typ een bericht",
+      "multiline": "Meerdere regels"
     },
     "noFiles": {
-      "title": "Geen bestand geselecteerd",
-      "content": "Selecteer minstens één bestand."
+      "title": "Geen bestanden geselecteerd",
+      "content": "Selecteer ten minste één bestand."
     },
     "noPermission": {
       "title": "Geen rechten",
-      "content": "U heeft de benodigde rechten niet verleend. Verleen deze alstublieft in de instellingen."
+      "content": "Je hebt de benodigde rechten niet verleend. Verleen deze in de instellingen."
     },
     "notAvailableOnPlatform": {
       "title": "Niet beschikbaar",
-      "content": "Deze functie is enkel beschikbaar op:"
+      "content": "Deze functie is alleen beschikbaar op:"
     },
     "qr": {
-      "title": "QR Code"
+      "title": "QR-code"
     },
     "quickActions": {
       "title": "Snelle acties",
       "counter": "Teller",
-      "prefix": "Prefix",
-      "padZero": "Met nullen aanvullen",
-      "sortBeforeCount": "Vooraf alfabetisch sorteren",
+      "prefix": "Voorvoegsel",
+      "padZero": "Aanvullen met nullen",
+      "sortBeforeCount": "Vooraf alfabetisch sorteren (A-Z)",
       "random": "Willekeurig"
     },
     "quickSaveNotice": {
       "title": "@:general.quickSave",
-      "content": "Bestandsoverdrachten worden automatisch geaccepteerd. Houd er rekening mee dat iedereen in het lokale netwerk je bestanden kan sturen."
+      "content": "Bestandsverzoeken worden nu automatisch geaccepteerd. Iedereen op het lokale netwerk kan je dus nu bestanden sturen."
+    },
+    "quickSaveFromFavoritesNotice": {
+      "title": "@:general.quickSaveFromFavorites",
+      "content": "Bestandsverzoeken van je favoriete apparaten worden nu automatisch geaccepteerd."
+    },
+    "pin": {
+      "title": "Vul de PIN in"
     },
     "sendModeHelp": {
-      "title": "Verzend opties",
-      "single": "Naar één ontvanger zenden. Selectie de-selecteren na verzending.",
-      "multiple": "Naar meerdere ontvangers zenden. Selectie blijft geselecteerd na verzending.",
-      "link": "Ontvangers die de app niet hebben geïnstalleerd kunnen bestanden downloaden door de link in hun browser te openen."
+      "title": "Verzendmodi",
+      "single": "Bestanden naar één ontvanger verzenden. De selectie wordt na de bestandsoverdracht gewist.",
+      "multiple": "Bestanden naar meerdere ontvangers verzenden. De selectie blijft na de bestandsoverdracht behouden.",
+      "link": "Ontvangers die LocalSend niet hebben geïnstalleerd kunnen de bestanden downloaden door de link in hun browser te openen."
+    },
+    "zoom": {
+      "title": "URL"
     }
   },
+  "sanitization": {
+    "empty": "Bestandsnaam mag niet leeg zijn",
+    "invalid": "Bestandsnaam bevat ongeldige tekens"
+  },
   "tray": {
-    "@info": "Apple Guidelines zijn zeer strikt met betrekking tot de 'close' formulering.",
+    "@info": "Apple Guidelines are very strict about the \"close\" wording.",
     "open": "@:general.open",
-    "close": "LocalSend afsluiten"
+    "close": "LocalSend afsluiten",
+    "closeWindows": "Sluiten"
   },
   "web": {
     "waiting": "@:sendPage.waiting",
+    "enterPin": "Vul de PIN in",
+    "invalidPin": "Ongeldige PIN",
+    "tooManyAttempts": "Te veel pogingen",
     "rejected": "Geweigerd",
     "files": "Bestanden",
     "fileName": "Bestandsnaam",
     "size": "Grootte"
   },
   "assetPicker": {
-    "@info": "Translations for the Media selection tool for Android and Iphone",
+    "@info": "Translations for the Media selection tool for Android and iPhone",
     "confirm": "Bevestigen",
-    "cancel": "Anuleren",
+    "cancel": "Annuleren",
     "edit": "Bewerken",
     "gifIndicator": "GIF",
-    "loadFailed": "Laadfout",
+    "loadFailed": "Laden mislukt",
     "original": "Herkomst",
-    "preview": "Preview",
+    "preview": "Voorbeeld",
     "select": "Selecteren",
     "emptyList": "Lege lijst",
     "unSupportedAssetType": "Niet-ondersteund bestandstype.",
-    "unableToAccessAll": "Geen toegang tot alle gegevens op apparaat",
-    "viewingLimitedAssetsTip": "Beperkte toegang tot gegevens voor deze app.",
-    "changeAccessibleLimitedAssets": "toegangelijke bestanden voor deze app aanpassen",
-    "accessAllTip": "De app heeft slechts beperkte toegang tot uw bestanden. Ga naar het instellingen menu van uw apparaat om de toegangsrechten aan te passen.",
-    "goToSystemSettings": "Ga naar het instellingen menu",
-    "accessLimitedAssets": "Behoud beperkte toegang tot bestanden",
-    "accessiblePathName": "Toegangkelijke bestanden",
+    "unableToAccessAll": "Geen toegang tot alle bestanden op het apparaat",
+    "viewingLimitedAssetsTip": "De app heeft beperkte toegang tot bestanden.",
+    "changeAccessibleLimitedAssets": "Toegankelijke bestanden aanpassen",
+    "accessAllTip": "De app heeft slechts beperkte toegang tot je bestanden. Ga naar de systeeminstellingen om de toegangsrechten aan te passen.",
+    "goToSystemSettings": "Naar systeeminstellingen",
+    "accessLimitedAssets": "Doorgaan met beperkte toegang",
+    "accessiblePathName": "Toegankelijke bestanden",
     "sTypeAudioLabel": "Audio",
-    "sTypeImageLabel": "Fotos",
-    "sTypeVideoLabel": "Videos",
-    "sTypeOtherLabel": "andere media",
-    "sActionPlayHint": "Afspelen",
-    "sActionPreviewHint": "preview",
+    "sTypeImageLabel": "Foto's",
+    "sTypeVideoLabel": "Video's",
+    "sTypeOtherLabel": "Andere media",
+    "sActionPlayHint": "afspelen",
+    "sActionPreviewHint": "voorbeeld",
     "sActionSelectHint": "selecteren",
-    "sActionSwitchPathLabel": "bestandspad aanpassen",
+    "sActionSwitchPathLabel": "pad wijzigen",
     "sActionUseCameraHint": "camera gebruiken",
     "sNameDurationLabel": "duur",
     "sUnitAssetCountLabel": "aantal"


### PR DESCRIPTION
The existing Dutch translation was outdated, in some places inconsistent (e.g. different forms of address) and contained several errors. This PR improves the translation. I assume `_missing_translations_nl.json` can be discarded afterwards.

Also added a Dutch translation for the website:  
https://github.com/localsend/website/pull/101