### PR TITLE
Add persistence for 'Advanced Settings'

### DIFF
--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -32,6 +32,7 @@ class SettingsState with SettingsStateMappable {
   final String? deviceModel;
   final bool shareViaLinkAutoAccept;
   final int discoveryTimeout;
+  final bool advancedSettings;
 
   const SettingsState({
     required this.showToken,
@@ -57,5 +58,6 @@ class SettingsState with SettingsStateMappable {
     required this.deviceModel,
     required this.shareViaLinkAutoAccept,
     required this.discoveryTimeout,
+    required this.advancedSettings,
   });
 }

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -67,6 +67,8 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
   static const Field<SettingsState, bool> _f$shareViaLinkAutoAccept = Field('shareViaLinkAutoAccept', _$shareViaLinkAutoAccept);
   static int _$discoveryTimeout(SettingsState v) => v.discoveryTimeout;
   static const Field<SettingsState, int> _f$discoveryTimeout = Field('discoveryTimeout', _$discoveryTimeout);
+  static bool _$advancedSettings(SettingsState v) => v.advancedSettings;
+  static const Field<SettingsState, bool> _f$advancedSettings = Field('advancedSettings', _$advancedSettings);
 
   @override
   final MappableFields<SettingsState> fields = const {
@@ -93,6 +95,7 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #deviceModel: _f$deviceModel,
     #shareViaLinkAutoAccept: _f$shareViaLinkAutoAccept,
     #discoveryTimeout: _f$discoveryTimeout,
+    #advancedSettings: _f$advancedSettings,
   };
 
   static SettingsState _instantiate(DecodingData data) {
@@ -119,7 +122,8 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
         deviceType: data.dec(_f$deviceType),
         deviceModel: data.dec(_f$deviceModel),
         shareViaLinkAutoAccept: data.dec(_f$shareViaLinkAutoAccept),
-        discoveryTimeout: data.dec(_f$discoveryTimeout));
+        discoveryTimeout: data.dec(_f$discoveryTimeout),
+        advancedSettings: data.dec(_f$advancedSettings));
   }
 
   @override
@@ -189,7 +193,8 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out> implem
       DeviceType? deviceType,
       String? deviceModel,
       bool? shareViaLinkAutoAccept,
-      int? discoveryTimeout});
+      int? discoveryTimeout,
+      bool? advancedSettings,});
   SettingsStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -223,7 +228,8 @@ class _SettingsStateCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Setting
           Object? deviceType = $none,
           Object? deviceModel = $none,
           bool? shareViaLinkAutoAccept,
-          int? discoveryTimeout}) =>
+          int? discoveryTimeout,
+          bool? advancedSettings}) =>
       $apply(FieldCopyWithData({
         if (showToken != null) #showToken: showToken,
         if (alias != null) #alias: alias,
@@ -247,7 +253,8 @@ class _SettingsStateCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Setting
         if (deviceType != $none) #deviceType: deviceType,
         if (deviceModel != $none) #deviceModel: deviceModel,
         if (shareViaLinkAutoAccept != null) #shareViaLinkAutoAccept: shareViaLinkAutoAccept,
-        if (discoveryTimeout != null) #discoveryTimeout: discoveryTimeout
+        if (discoveryTimeout != null) #discoveryTimeout: discoveryTimeout,
+        if (advancedSettings != null) #advancedSettings: advancedSettings
       }));
   @override
   SettingsState $make(CopyWithData data) => SettingsState(
@@ -273,7 +280,8 @@ class _SettingsStateCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Setting
       deviceType: data.get(#deviceType, or: $value.deviceType),
       deviceModel: data.get(#deviceModel, or: $value.deviceModel),
       shareViaLinkAutoAccept: data.get(#shareViaLinkAutoAccept, or: $value.shareViaLinkAutoAccept),
-      discoveryTimeout: data.get(#discoveryTimeout, or: $value.discoveryTimeout));
+      discoveryTimeout: data.get(#discoveryTimeout, or: $value.discoveryTimeout),
+      advancedSettings: data.get(#advancedSettings, or: $value.advancedSettings));
 
   @override
   SettingsStateCopyWith<$R2, SettingsState, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) => _SettingsStateCopyWithImpl($value, $cast, t);

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -194,7 +194,7 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out> implem
       String? deviceModel,
       bool? shareViaLinkAutoAccept,
       int? discoveryTimeout,
-      bool? advancedSettings,});
+      bool? advancedSettings});
   SettingsStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -474,8 +474,8 @@ class SettingsTab extends StatelessWidget {
                   value: vm.advanced,
                   labelFirst: true,
                   onChanged: (b) async {
-                      vm.onTapAdvanced(b == true);
-                      await ref.notifier(settingsProvider).setAdvancedSettingsEnabled(b == true);
+                    vm.onTapAdvanced(b == true);
+                    await ref.notifier(settingsProvider).setAdvancedSettingsEnabled(b == true);
                   },
                 ),
                 const SizedBox(width: 10),

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -473,7 +473,10 @@ class SettingsTab extends StatelessWidget {
                   label: t.settingsTab.advancedSettings,
                   value: vm.advanced,
                   labelFirst: true,
-                  onChanged: (b) => vm.onTapAdvanced(b == true),
+                  onChanged: (b) async {
+                      vm.onTapAdvanced(b == true);
+                      await ref.notifier(settingsProvider).setAdvancedSettingsEnabled(b == true);
+                  },
                 ),
                 const SizedBox(width: 10),
               ],

--- a/app/lib/pages/tabs/settings_tab_controller.dart
+++ b/app/lib/pages/tabs/settings_tab_controller.dart
@@ -48,7 +48,7 @@ class SettingsTabController extends ReduxNotifier<SettingsTabVm> {
   @override
   SettingsTabVm init() {
     return SettingsTabVm(
-      advanced: false,
+      advanced: _settingsService.state.advancedSettings,
       aliasController: TextEditingController(text: _settingsService.state.alias),
       deviceModelController: TextEditingController(text: _initialDeviceInfo.deviceModel),
       portController: TextEditingController(text: _settingsService.state.port.toString()),

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -82,6 +82,7 @@ const _enableAnimations = 'ls_enable_animations';
 const _deviceType = 'ls_device_type';
 const _deviceModel = 'ls_device_model';
 const _shareViaLinkAutoAccept = 'ls_share_via_link_auto_accept';
+const _advancedSettingsKey = 'ls_advanced_settings';
 
 final persistenceProvider = Provider<PersistenceService>((ref) {
   throw Exception('persistenceProvider not initialized');
@@ -159,6 +160,10 @@ class PersistenceService {
 
     if (prefs.getString(_securityContext) == null) {
       await prefs.setString(_securityContext, jsonEncode(generateSecurityContext()));
+    }
+
+    if (prefs.getBool(_advancedSettingsKey) == null) {
+      await prefs.setBool(_advancedSettingsKey, false);
     }
 
     if (prefs.getString(_colorKey) == null) {
@@ -335,6 +340,14 @@ class PersistenceService {
 
   Future<void> setSaveToHistory(bool saveToHistory) async {
     await _prefs.setBool(_saveToHistory, saveToHistory);
+  }
+
+  bool getAdvancedSettingsEnabled() {
+    return _prefs.getBool(_advancedSettingsKey) ?? false;
+  }
+
+  Future<void> setAdvancedSettingsEnabled(bool isEnabled) async {
+    await _prefs.setBool(_advancedSettingsKey, isEnabled);
   }
 
   bool isQuickSave() {

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -162,10 +162,6 @@ class PersistenceService {
       await prefs.setString(_securityContext, jsonEncode(generateSecurityContext()));
     }
 
-    if (prefs.getBool(_advancedSettingsKey) == null) {
-      await prefs.setBool(_advancedSettingsKey, false);
-    }
-
     if (prefs.getString(_colorKey) == null) {
       await _initColorSetting(prefs, supportsDynamicColors);
     } else {

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -52,6 +52,7 @@ class SettingsService extends PureNotifier<SettingsState> {
         deviceModel: _persistence.getDeviceModel(),
         shareViaLinkAutoAccept: _persistence.getShareViaLinkAutoAccept(),
         discoveryTimeout: _persistence.getDiscoveryTimeout(),
+        advancedSettings: _persistence.getAdvancedSettingsEnabled(),
       );
 
   Future<void> setAlias(String alias) async {
@@ -72,6 +73,13 @@ class SettingsService extends PureNotifier<SettingsState> {
     await _persistence.setColorMode(mode);
     state = state.copyWith(
       colorMode: mode,
+    );
+  }
+
+  Future<void> setAdvancedSettingsEnabled(bool isEnabled) async {
+    await _persistence.setAdvancedSettingsEnabled(isEnabled);
+    state = state.copyWith(
+      advancedSettings: isEnabled,
     );
   }
 


### PR DESCRIPTION
Persist the boolean for 'Advanced Settings', making it more user-friendly.
The thought behind the PR is that users enabling 'Advanced Settings' would like to always have it enabled, and not have to always enable it when closing and opening the application.

**Key Changes:**
- Add persistence for 'Advanced Settings' boolean

**Tested on:**
Windows 10



