### PR TITLE
file_picker: add clipboard option to iOS.

### DIFF
--- a/app/lib/util/native/file_picker.dart
+++ b/app/lib/util/native/file_picker.dart
@@ -70,6 +70,7 @@ enum FilePickerOption {
       return [
         FilePickerOption.media,
         FilePickerOption.text,
+        FilePickerOption.clipboard,
         FilePickerOption.file,
         FilePickerOption.folder,
       ];


### PR DESCRIPTION
Following https://github.com/localsend/localsend/issues/1866
I did manage to build the app to test the change. It seems to be working when running on ipad. It also seems to be working on iphone simulator. 
Please let me know if there is any reason not to do this change, as it seems like it was left out on purpose.


![Simulator Screenshot - iPhone 16 - 2024-10-06 at 22 28 38](https://github.com/user-attachments/assets/651e84fa-802f-46e3-a353-f8b2728b8f59)
