### PR TITLE
Fixed README_ID.md redirect and updated translators.dart

### DIFF
--- a/app/lib/pages/about/translators.dart
+++ b/app/lib/pages/about/translators.dart
@@ -47,6 +47,7 @@ const _translators = <AppLocale, List<String>>{
   ],
   AppLocale.it: [
     'Francesco Marastoni (@Francesco146)',
+    'Dario Landucci (@LandOfDar)',
   ],
   AppLocale.ja: [
     'soya_daizu (@soya-daizu)',

--- a/readme_i18n/README_ID.md
+++ b/readme_i18n/README_ID.md
@@ -7,7 +7,7 @@
 
 [Homepage][homepage] • [Discord][discord] • [GitHub][github] • [Codeberg][codeberg]
 
-[English](README.md) • [中文](readme_i18n/README_ZH.md) • [日本語](readme_i18n/README_JA.md) • [ภาษาไทย](readme_i18n/README_TH.md) • [Filipino](readme_i18n/README_PH.md) • [Polski](readme_i18n/README_PL.md) • [Español](readme_i18n/README_ES.md) • [Tiếng Việt](readme_i18n/README_VI.md) • [Portugês Brasil](readme_i18n/README_PT_BR.md) • [Italiano](readme_i18n/README_IT.md) • [Indonesia](readme_i18n/README_ID.md)
+[English](/README.md) • [中文](README_ZH.md) • [日本語](README_JA.md) • [ภาษาไทย](README_TH.md) • [Filipino](README_PH.md) • [Polski](README_PL.md) • [Español](README_ES.md) • [Tiếng Việt](README_VI.md) • [Portugês Brasil](README_PT_BR.md) • [Italiano](README_IT.md) • [Indonesia](README_ID.md)
 
 [homepage]: https://localsend.org
 [discord]: https://discord.gg/GSRWmQNP87


### PR DESCRIPTION
— README_ID.md was giving 404 while redirecting to duplicate readme_i18n folder,
— also added my contact to the translators.