### PR TITLE
Linux: Use different tray icon path for Flatpak

### DIFF
--- a/app/lib/util/native/tray_helper.dart
+++ b/app/lib/util/native/tray_helper.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:localsend_app/gen/assets.gen.dart';
 import 'package:localsend_app/gen/strings.g.dart';
@@ -26,7 +28,15 @@ Future<void> initTray() async {
       // The menu bar icon will created in AppDelegate.swift
       return;
     } else if (checkPlatform([TargetPlatform.linux])) {
-      await tm.trayManager.setIcon(Assets.img.logo32White.path);
+      String icon;
+      if (await File("/.flatpak-info").exists()) {
+        // Icon for Flatpak, which must exist in /app/share/icons/hicolor/*x*/apps.
+        icon = 'org.localsend.localsend_app-tray';
+      } else {
+        icon = Assets.img.logo32White.path;
+      }
+      _logger.info('Using "$icon" as path of system tray icon');
+      await tm.trayManager.setIcon(icon);
     } else {
       await tm.trayManager.setIcon(Assets.img.logo32.path);
     }


### PR DESCRIPTION
This fixes the missing tray icon issue on the Flatpak package.

Please note that for this fix to work, the tray icon must be installed to `/app/share/icons/hicolor/*x*/apps/org.localsend.localsend_app-tray.png` when packaging for Flatpak.

If this gets merged, I'll send a pull request to the Flatpak repository, which will install the tray icon to the location above.

Closes #1788