### PR TITLE
fix: UninstallDisplayIcon missing in Windows Registry

### DIFF
--- a/scripts/compile_windows_exe-inno.iss
+++ b/scripts/compile_windows_exe-inno.iss
@@ -28,6 +28,7 @@ PrivilegesRequiredOverridesAllowed=dialog
 OutputDir=D:\inno-result
 OutputBaseFilename=localsend
 SetupIconFile=D:\inno\logo.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/f7d79c39-f3be-4b76-95cb-c8b89018589a)

after:
![image](https://github.com/user-attachments/assets/a66b8467-53c7-4e39-8884-ba373a5087bb)


