### PR TITLE
Update (mainly) zh-* Translations for v1.16

### DIFF
--- a/app/assets/i18n/_missing_translations_zh_HK.json
+++ b/app/assets/i18n/_missing_translations_zh_HK.json
@@ -4,54 +4,54 @@
     "After editing this file, you can run 'dart run slang apply --locale=zh-HK' to quickly apply the newly added translations."
   ],
   "general": {
-    "quickSaveFromFavorites": "Quick Save for \"Favorites\""
+    "quickSaveFromFavorites": "自動儲存來自已收藏裝置嘅檔案"
   },
   "receiveTab": {
     "quickSave": {
-      "off": "@:general.off",
-      "favorites": "Favorites",
-      "on": "@:general.on"
+      "off": "關閉",
+      "favorites": "僅來自已收藏裝置嘅檔案",
+      "on": "來自所有裝置嘅檔案"
     }
   },
   "sendTab": {
-    "manualSending": "Manual sending"
+    "manualSending": "手動傳送"
   },
   "settingsTab": {
     "general": {
-      "saveWindowPlacementWindows": "Save window position after exit"
+      "saveWindowPlacementWindows": "離開嗰陣記低視窗位置"
     },
     "receive": {
       "quickSaveFromFavorites": "@:general.quickSaveFromFavorites"
     },
     "network": {
-      "useSystemName": "Use system name",
-      "generateRandomAlias": "Generate random alias"
+      "useSystemName": "使用系統名稱",
+      "generateRandomAlias": "求其改個名"
     }
   },
   "troubleshootPage": {
     "noDiscovery": {
-      "symptom": "This device cannot discover other devices.",
-      "solution": "Please make sure that all devices are on the same Wi-Fi network and share the same configuration (port, multicast address, encryption). You can try to type the IP address of the target device manually. If this works, consider adding this device to the favorites so it can be automatically discovered in the future."
+      "symptom": "呢部機偵測唔到其他裝置。",
+      "solution": "請確保所有裝置都駁緊同一個 Wi‑Fi 網路同用緊相同嘅設定（port、多播 IP 地址同有冇開加密傳送）。你亦都可以試下人手輸入目標裝置嘅 IP 地址。如果 work 嘅話可以選擇收藏呢部裝置，噉樣日後就會自動偵測到佢，毋須重新輸入。"
     }
   },
   "aboutPage": {
-    "packagers": "Packagers"
+    "packagers": "封裝人員"
   },
   "dialogs": {
     "openFile": {
-      "title": "Open file",
-      "content": "Do you want to open the received file?"
+      "title": "開啟檔案",
+      "content": "你係咪要開啟接收咗嘅檔案？"
     },
     "quickSaveFromFavoritesNotice": {
       "title": "@:general.quickSaveFromFavorites",
       "content": [
-        "File requests are now accepted automatically from devices in your favorites list.",
-        "Warning! Currently, this is not entirely secure, as a hacker who has the fingerprint of any device from your favorites list can send you files without restriction.",
-        "However, this option is still safer than allowing all users on the local network to send you files without restriction."
+        "自動接受來自已收藏裝置嘅檔案傳輸請求。",
+        "警告：目前呢個選項並非絕對安全，因為只要黑客攞到你任何一部已收藏裝置嘅指紋，佢就可以無限制噉 send 嘢畀你。",
+        "不過揀已收藏裝置點都安全過揀所有裝置嘅。"
       ]
     }
   },
   "tray": {
-    "closeWindows": "Exit"
+    "closeWindows": "離開"
   }
 }

--- a/app/assets/i18n/strings.json
+++ b/app/assets/i18n/strings.json
@@ -167,7 +167,7 @@
     },
     "noConnection": {
       "symptom": "Both devices cannot discover each other nor can they share files.",
-      "solution": "Does the problem exist on both sides? If so, you need to make sure that both devices are on the same Wi-Fi network and share the same configuration (port, multicast address, encryption). The Wi-Fi network may not allow communication between participants (AP isolation). In this case, this option must be enabled on the router."
+      "solution": "Does the problem exist on both sides? If so, you need to make sure that both devices are on the same Wi-Fi network and share the same configuration (port, multicast address, encryption). The Wi-Fi network may not allow communication between participants due to Access Point (AP) Isolation. In this case, this option must be disabled on the router."
     }
   },
   "receiveHistoryPage": {

--- a/app/assets/i18n/strings_ja.json
+++ b/app/assets/i18n/strings_ja.json
@@ -28,7 +28,7 @@
     "open": "開く",
     "queue": "順番待ち",
     "quickSave": "クイックセーブ",
-    "quickSaveFromFavorites": "\"Favorites\"からクイックセーブ",
+    "quickSaveFromFavorites": "「お気に入り」からクイックセーブ",
     "renamed": "改名済み",
     "reset": "リセット",
     "restart": "再起動",

--- a/app/assets/i18n/strings_zh-CN.json
+++ b/app/assets/i18n/strings_zh-CN.json
@@ -27,8 +27,8 @@
     "online": "在线",
     "open": "打开",
     "queue": "队列",
-    "quickSave": "快速保存",
-    "quickSaveFromFavorites": "快速保存到\"收藏\"",
+    "quickSave": "自动保存",
+    "quickSaveFromFavorites": "自动保存来自“收藏夹”设备的文件",
     "renamed": "已重命名",
     "reset": "重置",
     "restart": "重启",
@@ -103,9 +103,9 @@
       "languageOptions": {
         "system": "跟随系统"
       },
-      "saveWindowPlacement": "关闭时保存窗口位置",
-      "saveWindowPlacementWindows": "退出时保存窗口位置",
-      "minimizeToTray": "关闭时：最小化到系统托盘",
+      "saveWindowPlacement": "退出时保存窗口位置",
+      "saveWindowPlacementWindows": "离开时保存窗口位置",
+      "minimizeToTray": "关闭时最小化到系统托盘",
       "launchAtStartup": "登录系统后自动启动程序",
       "launchMinimized": "静默自启：只启动托盘服务",
       "showInContextMenu": "在“发送到”文件菜单中显示 LocalSend",
@@ -163,11 +163,11 @@
     },
     "noDiscovery": {
       "symptom": "此设备未能发现其他设备。",
-      "solution": "确保所有设备都在同一个Wi-Fi网络上，并共享相同的配置（端口、多播地址、加密）。您可以尝试手动键入目标设备的IP地址。如果这有效，请考虑将此设备添加到收藏夹中，以便将来可以自动发现。"
+      "solution": "确保所有设备都处于同一个 Wi‑Fi 网络上，且共享相同的网络配置（端口、多播地址、加密选项）。您可以尝试手动键入目标设备的 IP 地址。如果这有效，请考虑将此设备添加到收藏夹中，以便将来可以自动发现。"
     },
     "noConnection": {
       "symptom": "双方设备均无法发现对方或者分享文件。",
-      "solution": "当问题发生在双方设备上时，请先确认双方设备处于同一 Wi‑Fi 网络内，且有相同的网络（端口、多播地址、加密选项）配置。若因 Wi‑Fi 不允许参与者间通信，那么请在路由器中关闭这个（如：AP 隔离）选项。"
+      "solution": "当问题发生在双方设备上时，请先确认双方设备处于同一个 Wi‑Fi 网络上，且共享相同的网络配置（端口、多播地址、加密选项）。若因 Wi‑Fi 不允许参与者间通信，那么请在路由器中关闭“接入点 (AP) 隔离”选项。"
     }
   },
   "receiveHistoryPage": {
@@ -255,7 +255,7 @@
     ],
     "author": "作者",
     "contributors": "贡献者",
-    "packagers": "包",
+    "packagers": "打包者",
     "translators": "翻译者"
   },
   "donationPage": {
@@ -443,7 +443,7 @@
       "title": "@:general.quickSaveFromFavorites",
       "content": [
         "当前会自动接受收藏夹中设备的文件请求。",
-        "警告：这目前并不完全安全，知道您收藏夹列表中设备指纹的黑客仍可以向您发送文件。",
+        "警告：这目前并非绝对安全，知道您收藏夹列表中设备指纹的黑客仍可以向您发送文件。",
         "但是，此选项比“允许任何设备”更安全。"
       ]
     },
@@ -468,7 +468,7 @@
     "@info": "Apple Guidelines are very strict about the \"close\" wording.",
     "open": "@:general.open",
     "close": "退出 LocalSend",
-    "closeWindows": "退出"
+    "closeWindows": "离开"
   },
   "web": {
     "waiting": "@:sendPage.waiting",

--- a/app/assets/i18n/strings_zh-HK.json
+++ b/app/assets/i18n/strings_zh-HK.json
@@ -27,7 +27,7 @@
     "online": "線上",
     "open": "開啟",
     "queue": "佇列",
-    "quickSave": "快速儲存",
+    "quickSave": "自動儲存",
     "renamed": "改咗名",
     "reset": "重設",
     "restart": "重新啟動",
@@ -97,7 +97,7 @@
         "system": "跟機"
       },
       "saveWindowPlacement": "退出嗰陣記低視窗位置",
-      "minimizeToTray": "退出嗰陣縮細做通知圖示",
+      "minimizeToTray": "關閉嗰陣縮細做通知圖示",
       "launchAtStartup": "開機自動啟動",
       "launchMinimized": "自動啟動成通知圖示",
       "showInContextMenu": "喺檔案功能表嘅「傳送到」項目顯示 LocalSend",
@@ -153,7 +153,7 @@
     },
     "noConnection": {
       "symptom": "兩部裝置都偵測唔到同 send 唔到嘢畀對方。",
-      "solution": "如果兩邊都發生同樣嘅情況，你要 check 清楚兩邊係咪駁緊同一個 Wi‑Fi 網路同用緊同樣嘅設定（port、多播 IP 地址同有冇開加密傳送）。亦可能係個 Wi‑Fi 唔畀裝置之間通訊，呢種情況下就要 router 嗰邊先開到。"
+      "solution": "如果兩邊都發生同樣嘅情況，你要 check 清楚兩邊係咪駁緊同一個 Wi‑Fi 網路同用緊相同嘅設定（port、多播 IP 地址同有冇開加密傳送）。亦可能係個 Wi‑Fi 唔畀裝置之間通訊，呢種情況下要喺 router 嗰邊熄咗「接入點 (AP) 隔離」模式至得。"
     }
   },
   "receiveHistoryPage": {
@@ -162,7 +162,7 @@
     "deleteHistory": "清除記錄",
     "empty": "得個吉噃 :(",
     "entryActions": {
-      "open": "開啟檔案",
+      "open": "@:dialogs.openFile.title",
       "showInFolder": "喺檔案瀏覽器顯示",
       "info": "資訊",
       "deleteFromHistory": "刪走呢筆記錄"

--- a/app/assets/i18n/strings_zh-TW.json
+++ b/app/assets/i18n/strings_zh-TW.json
@@ -27,8 +27,8 @@
     "online": "線上",
     "open": "開啟",
     "queue": "佇列",
-    "quickSave": "快速儲存",
-    "quickSaveFromFavorites": "快速儲存到 \"最愛\"",
+    "quickSave": "自動儲存",
+    "quickSaveFromFavorites": "自動儲存來自「最愛」裝置的檔案",
     "renamed": "已重新命名",
     "reset": "重設",
     "restart": "重新啟動",
@@ -103,9 +103,9 @@
       "languageOptions": {
         "system": "系統"
       },
-      "saveWindowPlacement": "離開：儲存視窗位置",
-      "saveWindowPlacementWindows": "離開後儲存視窗位置",
-      "minimizeToTray": "離開：最小化至系統匣",
+      "saveWindowPlacement": "退出時儲存視窗位置",
+      "saveWindowPlacementWindows": "離開時儲存視窗位置",
+      "minimizeToTray": "關閉時最小化至系統匣",
       "launchAtStartup": "登入後自動啟動",
       "launchMinimized": "自動啟動至系統匣",
       "showInContextMenu": "在檔案功能表「傳送到」項目中顯示 LocalSend",
@@ -163,11 +163,11 @@
     },
     "noDiscovery": {
       "symptom": "本設備無法探索其他設備。",
-      "solution": "請確保所有裝置都在同一個 Wi-Fi 網路上並分享相同的設定（埠、多播位址、加密）。您可以嘗試手動輸入目標裝置的 IP 位址。如果這樣可以運作，考慮將此裝置新增至最愛，以便未來可以自動偵測到。"
+      "solution": "請確保所有裝置都在同一個 Wi‑Fi 網路上並分享相同的設定（通訊埠、多點傳送位址、加密選項）。您可以嘗試手動輸入目標裝置的 IP 位址。如果這樣可以運作，考慮將此裝置新增至最愛，以便未來可以自動偵測到。"
     },
     "noConnection": {
       "symptom": "兩部裝置無法探索彼此，也無法分享檔案。",
-      "solution": "雙方都存在問題？然後你需要確保兩部裝置處於相同的 Wi‑Fi 網路中並共用相同的組態 (通訊埠、多點傳送位址、加密)。Wi‑Fi 可能不允許參與者之間進行通訊。在這種狀況下，必須在路由器上啟用此選項。"
+      "solution": "雙方都存在問題？然後你需要確保兩部裝置處於相同的 Wi‑Fi 網路中並共用相同的組態（通訊埠、多點傳送位址、加密選項）。Wi‑Fi 可能不允許參與者之間進行通訊。在這種狀況下，必須在路由器上停用「存取點 (AP) 隔離」選項。"
     }
   },
   "receiveHistoryPage": {
@@ -315,7 +315,7 @@
       "titleEdit": "調整",
       "name": "別名",
       "auto": "(自動)",
-      "ip": "IP位址",
+      "ip": "IP 位址",
       "port": "連接埠"
     },
     "fileInfo": {
@@ -374,7 +374,7 @@
       "title": "@:general.quickSaveFromFavorites",
       "content": [
         "自動接受來自您最愛列表中裝置傳送的檔案。",
-        "警告：目前這並不完全安全，因為知道您最愛裝置指紋的駭客仍然可以向您發送檔案。",
+        "警告：目前這並非絕對安全，因為知道您最愛裝置指紋的駭客仍然可以向您發送檔案。",
         "但仍然比允許任何裝置更安全。"
       ]
     },
@@ -398,7 +398,7 @@
   "tray": {
     "@info": "Apple Guidelines are very strict about the 'close' wording.",
     "open": "@:general.open",
-    "close": "離開 LocalSend",
+    "close": "退出 LocalSend",
     "closeWindows": "離開"
   },
   "web": {


### PR DESCRIPTION
Added `zh-HK` translations and addressed some inconsistencies in `zh-TW` and `zh-CN` translations.

Notably:
| en | zh |
|:---:|:---:|
| exit | 離開／离开 |
| quit | 退出 |
| close | 關閉／关闭 |