### PR TITLE
fixbug #2043

### DIFF
--- a/app/lib/provider/network/server/controller/send_controller.dart
+++ b/app/lib/provider/network/server/controller/send_controller.dart
@@ -220,7 +220,10 @@ class SendController {
         });
       } else {
         final path = file.path!;
-        final fileStream = path.startsWith('content://') ? UriContent().getContentStream(Uri.parse(file.path!)) : File(file.path!).openRead();
+        final tmpfile = File(file.path!);
+        request.response.headers.set('content-length', '${tmpfile.lengthSync()}');
+
+        final fileStream = path.startsWith('content://') ? UriContent().getContentStream(Uri.parse(file.path!)) : tmpfile.openRead();
         final (streamController, subscription) = fileStream.digested();
 
         await request.response.addStream(streamController.stream).then((_) {


### PR DESCRIPTION
bugfix for #2043 

because the file length  will cached on file open; 
so http reponse length use older data(if file be replace with same name on download);
so the chrome download will be fail;

fix:
- on download event reload file length