### PR TITLE
Fix incorrect APP_NAME on macOS

### DIFF
--- a/app/macos/Runner/Base.lproj/MainMenu.xib
+++ b/app/macos/Runner/Base.lproj/MainMenu.xib
@@ -22,11 +22,11 @@
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
             <items>
-                <menuItem title="APP_NAME" id="1Xt-HY-uBw">
+                <menuItem title="LocalSend" id="1Xt-HY-uBw">
                     <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="APP_NAME" systemMenu="apple" id="uQy-DD-JDr">
+                    <menu key="submenu" title="LocalSend" systemMenu="apple" id="uQy-DD-JDr">
                         <items>
-                            <menuItem title="About APP_NAME" id="5kV-Vb-QxS">
+                            <menuItem title="About LocalSend" id="5kV-Vb-QxS">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
@@ -40,7 +40,7 @@
                                 <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
-                            <menuItem title="Hide APP_NAME" keyEquivalent="h" id="Olw-nP-bQN">
+                            <menuItem title="Hide LocalSend" keyEquivalent="h" id="Olw-nP-bQN">
                                 <connections>
                                     <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
                                 </connections>
@@ -58,7 +58,7 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
-                            <menuItem title="Quit APP_NAME" keyEquivalent="q" id="4sb-4s-VLi">
+                            <menuItem title="Quit LocalSend" keyEquivalent="q" id="4sb-4s-VLi">
                                 <connections>
                                     <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>
                                 </connections>
@@ -330,7 +330,7 @@
             </items>
             <point key="canvasLocation" x="142" y="-258"/>
         </menu>
-        <window title="APP_NAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
+        <window title="LocalSend" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="335" y="390" width="800" height="600"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1577"/>

--- a/app/macos/ShareExtension/Info.plist
+++ b/app/macos/ShareExtension/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>CFBundleIconFile</key>
 	<string>icon</string>
+	<key>CFBundleDisplayName</key>
+	<string>LocalSend</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
Fixes #2059

Fix the incorrect window name "APP_NAME" on macOS.

* Update `app/macos/Runner/Base.lproj/MainMenu.xib` to change the `CFBundleDisplayName` key to "LocalSend".
* Add `CFBundleDisplayName` key with value "LocalSend" in `app/macos/ShareExtension/Info.plist`.
