### PR TITLE
Fix transmission problem between two computers

### DIFF
--- a/app/lib/pages/tabs/receive_tab_vm.dart
+++ b/app/lib/pages/tabs/receive_tab_vm.dart
@@ -26,6 +26,7 @@ class ReceiveTabVm {
   final Future<void> Function() toggleAdvanced;
   final Future<void> Function(BuildContext context, bool enable) onSetQuickSave;
   final Future<void> Function(BuildContext context, bool enable) onSetQuickSaveFromFavorites;
+  final Future<void> Function(BuildContext context, bool enable) onSetTransferFiles;
 
   const ReceiveTabVm({
     required this.aliasSettings,
@@ -38,6 +39,7 @@ class ReceiveTabVm {
     required this.toggleAdvanced,
     required this.onSetQuickSave,
     required this.onSetQuickSaveFromFavorites,
+    required this.onSetTransferFiles,
   });
 }
 
@@ -76,6 +78,12 @@ final receiveTabVmProvider = ViewProvider((ref) {
       await ref.notifier(settingsProvider).setQuickSaveFromFavorites(enable);
       if (enable && context.mounted) {
         await QuickSaveFromFavoritesNotice.open(context);
+      }
+    },
+    onSetTransferFiles: (context, enable) async {
+      await ref.notifier(settingsProvider).setTransferFiles(enable);
+      if (enable && context.mounted) {
+        await QuickSaveNotice.open(context);
       }
     },
   );


### PR DESCRIPTION
Related to #2066

Add logic to handle the issue of transferring files from computer A to computer B when A is connected to both Wi-Fi and wired network.

* **ReceiveTabVm Class**
  - Add `onSetTransferFiles` function to handle file transfer settings.
  - Update constructor to include `onSetTransferFiles`.
  - Modify `receiveTabVmProvider` to handle `onSetTransferFiles` function.

