### PR TITLE
fix: black screen when tapping on "Back" twice in "Share via link"

### DIFF
--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.0 (unreleased)
+
+- fix: black screen when tapping on "Back" twice in "Share via link" (@Tienisto)
+
 ## 1.16.2 (2024-11-06)
 
 - fix(ios): share from other apps to LocalSend doesn't work in iOS 18 (@Tienisto)

--- a/app/lib/pages/web_send_page.dart
+++ b/app/lib/pages/web_send_page.dart
@@ -82,6 +82,10 @@ class _WebSendPageState extends State<WebSendPage> with Refena {
   Widget build(BuildContext context) {
     return PopScope(
       onPopInvokedWithResult: (_, __) async {
+        if (_stateEnum != _ServerState.running) {
+          return;
+        }
+
         setState(() {
           _stateEnum = _ServerState.stopping;
         });


### PR DESCRIPTION
Closes #2061