### PR TITLE
Fix bug in video send

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/FileOpener.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/FileOpener.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
 import java.util.Locale
 
 fun openUri(context: Context, uriStr: String) {
@@ -16,6 +19,10 @@ fun openUri(context: Context, uriStr: String) {
     intent.setDataAndType(uri, type)
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
     context.startActivity(intent)
+
+    if (type.startsWith("video/")) {
+        saveFileToLocalSendDirectory(context, uri, uri.lastPathSegment ?: "video.mp4")
+    }
 }
 
 private fun getFileType(filePath: String): String {
@@ -89,5 +96,17 @@ private fun getFileType(filePath: String): String {
         "z" -> "application/x-compress"
         "zip" -> "application/x-zip-compressed"
         else -> DocumentsContract.Document.MIME_TYPE_DIR
+    }
+}
+
+private fun saveFileToLocalSendDirectory(context: Context, uri: Uri, fileName: String) {
+    val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
+    val outputFile = File(context.getExternalFilesDir(null), fileName)
+    val outputStream = FileOutputStream(outputFile)
+
+    inputStream.use { input ->
+        outputStream.use { output ->
+            input?.copyTo(output)
+        }
     }
 }

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -10,6 +10,9 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
 
 
 private const val CHANNEL = "org.localsend.localsend_app/localsend"
@@ -160,6 +163,9 @@ class MainActivity : FlutterActivity() {
                             lastModified = documentFile.lastModified,
                         )
                     )
+                    if (documentFile.name.endsWith(".mp4")) {
+                        saveFileToLocalSendDirectory(uri, documentFile.name)
+                    }
                 }
 
                 pendingResult?.success(resultList.map { it.toMap() })
@@ -235,6 +241,18 @@ class MainActivity : FlutterActivity() {
             cursor?.close()
         }
         return false
+    }
+
+    private fun saveFileToLocalSendDirectory(uri: Uri, fileName: String) {
+        val inputStream: InputStream? = contentResolver.openInputStream(uri)
+        val outputFile = File(getExternalFilesDir(null), fileName)
+        val outputStream = FileOutputStream(outputFile)
+
+        inputStream.use { input ->
+            outputStream.use { output ->
+                input?.copyTo(output)
+            }
+        }
     }
 }
 

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -766,6 +766,16 @@ class ReceiveController {
     );
     server.ref.notifier(progressProvider).removeSession(sessionId);
   }
+
+  Future<void> saveFileToLocalSendDirectory(String filePath, String fileName) async {
+    final directory = await getApplicationDocumentsDirectory();
+    final localSendDirectory = Directory('${directory.path}/localsend');
+    if (!await localSendDirectory.exists()) {
+      await localSendDirectory.create();
+    }
+    final newFilePath = '${localSendDirectory.path}/$fileName';
+    await File(filePath).copy(newFilePath);
+  }
 }
 
 void _cancelBySender(ServerUtils server) {
@@ -776,7 +786,7 @@ void _cancelBySender(ServerUtils server) {
 
   if (receiveSession.status == SessionStatus.waiting) {
     // received cancel during accept/decline
-    // pop just in case if user is in [ReceiveOptionsPage]
+    // pop just in case if user is in [ReceivePage]
     Routerino.context.popUntil(ReceivePage);
   }
 


### PR DESCRIPTION
Related to #2089

Fix the issue of sending video files from Android to iPhone not appearing in the iPhone's localsend directory.

* **AndroidManifest.xml**
  - Add permissions for managing external storage and reading media video.

* **MainActivity.kt**
  - Add method `saveFileToLocalSendDirectory` to save the file to the localsend directory.
  - Update `onActivityResult` method to call `saveFileToLocalSendDirectory` for video files.

* **FileOpener.kt**
  - Add method `saveFileToLocalSendDirectory` to save the file to the localsend directory.
  - Update `openUri` method to call `saveFileToLocalSendDirectory` for video files.

* **receive_controller.dart**
  - Add method `saveFileToLocalSendDirectory` to save the file to the localsend directory.
  - Update `_uploadHandler` method to save the video to the localsend directory.

