### PR TITLE
feat: Convert Clipboard image to png

### DIFF
--- a/app/lib/util/native/file_picker.dart
+++ b/app/lib/util/native/file_picker.dart
@@ -6,6 +6,7 @@ import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:image/image.dart' as img;
 import 'package:localsend_app/config/theme.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/cross_file.dart';
@@ -270,11 +271,25 @@ Future<void> _pickClipboard(BuildContext context, Ref ref) async {
     return;
   }
 
-  final image = await Pasteboard.image;
+  var image = await Pasteboard.image;
   if (image != null) {
+    // On Windows, Pasteboard read image from clipboard as BMP which is large and inefficient. Attempt to convert to PNG
+    if (determineImageType(image) == 'bmp') {
+        try {
+          final pngImage = await (img.Command()
+          ..decodeBmp(image)
+          ..encodePng())
+          .getBytesThread();
+          if (pngImage != null) {
+            image = pngImage;
+          }
+        } catch (err) {
+          // Fail to convert to png, proceed with existing bmp
+        }
+    }
     final now = DateTime.now();
     final fileName =
-        'clipboard_${now.year}-${now.month.twoDigitString}-${now.day.twoDigitString}_${now.hour.twoDigitString}-${now.minute.twoDigitString}.${determineImageType(image)}';
+        'clipboard_${now.year}-${now.month.twoDigitString}-${now.day.twoDigitString}_${now.hour.twoDigitString}-${now.minute.twoDigitString}.${determineImageType(image!)}';
     ref.redux(selectedSendingFilesProvider).dispatch(AddBinaryAction(
           bytes: image,
           fileType: FileType.image,

--- a/app/lib/util/native/file_picker.dart
+++ b/app/lib/util/native/file_picker.dart
@@ -275,17 +275,17 @@ Future<void> _pickClipboard(BuildContext context, Ref ref) async {
   if (image != null) {
     // On Windows, Pasteboard read image from clipboard as BMP which is large and inefficient. Attempt to convert to PNG
     if (determineImageType(image) == 'bmp') {
-        try {
-          final pngImage = await (img.Command()
-          ..decodeBmp(image)
-          ..encodePng())
-          .getBytesThread();
-          if (pngImage != null) {
-            image = pngImage;
-          }
-        } catch (err) {
-          // Fail to convert to png, proceed with existing bmp
+      try {
+        final pngImage = await (img.Command()
+              ..decodeBmp(image)
+              ..encodePng())
+            .getBytesThread();
+        if (pngImage != null) {
+          image = pngImage;
         }
+      } catch (err) {
+        // Fail to convert to png, proceed with existing bmp
+      }
     }
     final now = DateTime.now();
     final fileName =

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -666,7 +666,7 @@ packages:
     source: hosted
     version: "4.0.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
     sdk: flutter
   flutter_markdown: 0.7.4+2
   gal: 2.3.0
+  image: ^4.3.0
   image_picker: 1.1.2
   in_app_purchase: 3.2.0 # [FOSS_REMOVE]
   intl: ^0.19.0 # allow newer versions, so it can compile with newer Flutter versions


### PR DESCRIPTION
fixes #872

Alternatively, we can request pasteboard to make this change. Their Mac [mac](https://github.com/MixinNetwork/flutter-plugins/blob/b2beb15590f7b6c38e650ae501923b9bd3e7849c/packages/pasteboard/macos/Classes/PasteboardPlugin.swift#L42-L47) and [Linux](https://github.com/MixinNetwork/flutter-plugins/blob/b2beb15590f7b6c38e650ae501923b9bd3e7849c/packages/pasteboard/linux/pasteboard_plugin.cc#L92) native codes are already converting image buffer to png.

pasteboard's bmp seems to discard alpha channel, so transparency is already lost.
Even with this limitation, I would guess this already covers most use cases

Screenshot:
![image](https://github.com/user-attachments/assets/289b8fc7-20c1-42fa-ae03-e6842f7b8c29)

I have only tested this change on Windows, but don't expect this to be an issue with any other platform

Apologies for the half-baked PR. I have never used flutter/dart before and thus don't know best practices.
Feel free to clean up this patch as needed.