### PR TITLE
Fix file suffix removal issue

### DIFF
--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -42,6 +42,7 @@ import 'package:localsend_app/util/native/file_saver.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
 import 'package:localsend_app/util/simple_server.dart';
+import 'package:localsend_app/util/file_path_helper.dart'; // Import the file_path_helper.dart file
 import 'package:localsend_app/widget/dialogs/open_file_dialog.dart';
 import 'package:logging/logging.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -565,7 +566,7 @@ class ReceiveController {
                 // ignore: use_build_context_synchronously
                 Routerino.context,
                 filePath: destinationPath,
-                fileName: receivingFile.desiredName!,
+                fileName: receivingFile.desiredName!.preserveFileNameAndExtension(receivingFile.desiredName!), // Preserve file name and extension
                 fileType: fileType);
           }
         });

--- a/app/lib/util/file_path_helper.dart
+++ b/app/lib/util/file_path_helper.dart
@@ -77,4 +77,15 @@ extension FilePathStringExt on String {
         return FileType.other;
     }
   }
+
+  String preserveFileNameAndExtension(String fileName) {
+    final index = fileName.lastIndexOf('.');
+    if (index != -1) {
+      final name = fileName.substring(0, index);
+      final ext = fileName.substring(index + 1);
+      return '$name.$ext';
+    } else {
+      return fileName;
+    }
+  }
 }


### PR DESCRIPTION
Related to #2091

Added method to preserve file name and extension during file transfer.

* Added `preserveFileNameAndExtension` method in `app/lib/util/file_path_helper.dart` to handle file extensions and file names.
* Imported `file_path_helper.dart` in `app/lib/provider/network/server/controller/receive_controller.dart`.
* Updateed file transfer process in `receive_controller.dart` to use `preserveFileNameAndExtension` method to ensure file name and extension are preserved.