### PR TITLE
Fix tray icon click behavior on Linux

### DIFF
--- a/app/lib/widget/watcher/tray_watcher.dart
+++ b/app/lib/widget/watcher/tray_watcher.dart
@@ -35,10 +35,10 @@ class _TrayWatcherState extends State<TrayWatcher> with TrayListener {
 
   @override
   void onTrayIconMouseDown() async {
-    if (checkPlatform([TargetPlatform.macOS])) {
-      await trayManager.popUpContextMenu();
-    } else {
+    if (checkPlatform([TargetPlatform.macOS, TargetPlatform.linux])) {
       await showFromTray();
+    } else {
+      await trayManager.popUpContextMenu();
     }
   }
 


### PR DESCRIPTION
Related to #2102

Update `onTrayIconMouseDown` method to differentiate behavior for Linux and macOS.

* Call `showFromTray` for left-clicks on Linux and macOS.
* Display context menu only for right-clicks on Linux and macOS.

