### PR TITLE
fix: content of the text message written three times

### DIFF
--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -48,6 +48,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:routerino/routerino.dart';
 import 'package:uuid/uuid.dart';
 import 'package:window_manager/window_manager.dart';
+import 'dart:convert';
 
 const _uuid = Uuid();
 
@@ -283,7 +284,7 @@ class ReceiveController {
               path: null,
               savedToGallery: false,
               isMessage: true,
-              fileSize: message.length,
+              fileSize: utf8.encode(message).length,
               senderAlias: server.getState().session!.senderAlias,
               timestamp: DateTime.now().toUtc(),
             ));

--- a/app/lib/widget/dialogs/file_info_dialog.dart
+++ b/app/lib/widget/dialogs/file_info_dialog.dart
@@ -70,7 +70,7 @@ class FileInfoDialog extends StatelessWidget {
               if (entry.isMessage)
                 Padding(
                   padding: const EdgeInsets.only(top: 10),
-                  child: SelectableText(entry.fileName + entry.fileName + entry.fileName),
+                  child: SelectableText(entry.fileName),
                 ),
             ],
           ),


### PR DESCRIPTION
Fixed: content of the text message in the history info dialog box was written three times

Before:
![image](https://github.com/user-attachments/assets/8b3fa215-4740-4a36-9f93-8e65ccfdf3ca)

Fix:
![image](https://github.com/user-attachments/assets/7e27bfe6-4573-4dd2-b5bc-d26d82ac8b2f)
