### PR TITLE
fix: text message content size is not calculated correctly

### DIFF
--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -48,6 +48,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:routerino/routerino.dart';
 import 'package:uuid/uuid.dart';
 import 'package:window_manager/window_manager.dart';
+import 'dart:convert';
 
 const _uuid = Uuid();
 
@@ -283,7 +284,7 @@ class ReceiveController {
               path: null,
               savedToGallery: false,
               isMessage: true,
-              fileSize: message.length,
+              fileSize: utf8.encode(message).length,
               senderAlias: server.getState().session!.senderAlias,
               timestamp: DateTime.now().toUtc(),
             ));


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/6aab9934-473d-46c0-90c9-124c6302f9f4)

Fixed:
![image](https://github.com/user-attachments/assets/b671a6a2-445f-4935-90d4-5604730227f7)
