### PR TITLE
FEAT #2333 Defaults to System Animations on Initial startup (andriod,ios and macos)

### DIFF
--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.database.Cursor
 import android.net.Uri
 import android.provider.DocumentsContract
+import android.provider.Settings;
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
@@ -54,9 +55,18 @@ class MainActivity : FlutterActivity() {
                     result.success(null)
                 }
 
+                "isAnimationsEnabled" -> {
+                    result.success(isAnimationsEnabled())
+                }
+
                 else -> result.notImplemented()
             }
         }
+    }
+
+    private fun isAnimationsEnabled() : Boolean {
+        return Settings.Global.getFloat(this.getContentResolver(),
+            Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f) != 0.0f;
     }
 
     private fun openDirectoryPicker(onlyPath: Boolean) {

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -7,6 +7,18 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+
+    let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
+    let channel = FlutterMethodChannel(name: "ios-delegate-channel",
+                                              binaryMessenger: controller.engine.binaryMessenger)
+    channel.setMethodCallHandler({
+      (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+      if call.method == "isReduceMotionEnabled" {
+        result(UIAccessibility.isReduceMotionEnabled)
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    })
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -165,7 +165,7 @@ class PersistenceService {
       await prefs.setString(_securityContext, jsonEncode(generateSecurityContext()));
     }
 
-    if(isFirstAppStart){
+    if (isFirstAppStart) {
       _logger.info('Is FirstStartUp');
       await prefs.setBool(_enableAnimations, await getSystemAnimationsStatus());
     }

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -20,6 +20,7 @@ import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/security_helper.dart';
 import 'package:localsend_app/util/shared_preferences/shared_preferences_file.dart';
 import 'package:localsend_app/util/shared_preferences/shared_preferences_portable.dart';
+import 'package:localsend_app/util/ui/animations_status.dart';
 import 'package:logging/logging.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -162,6 +163,11 @@ class PersistenceService {
 
     if (prefs.getString(_securityContext) == null) {
       await prefs.setString(_securityContext, jsonEncode(generateSecurityContext()));
+    }
+
+    if(isFirstAppStart){
+      _logger.info('Is FirstStartUp');
+      await prefs.setBool(_enableAnimations, await getSystemAnimationsStatus());
     }
 
     if (prefs.getString(_colorKey) == null) {

--- a/app/lib/util/native/channel/android_channel.dart
+++ b/app/lib/util/native/channel/android_channel.dart
@@ -40,6 +40,10 @@ Future<List<FileInfo>?> pickFilesAndroid() async {
   return result.map((e) => FileInfoMapper.fromJson((e as Map).cast<String, dynamic>())).toList();
 }
 
+Future<bool> getSystemAnimationsStatusAndroid() async {
+  return await _methodChannel.invokeMethod('isAnimationsEnabled') ?? true;
+}
+
 Future<void> createDirectory({
   required String documentUri,
   required String directoryName,

--- a/app/lib/util/native/ios_channel.dart
+++ b/app/lib/util/native/ios_channel.dart
@@ -1,0 +1,11 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+const _methodChannel = MethodChannel('ios-delegate-channel');
+
+
+
+Future<bool> isReduceMotionEnabledIOS() async {
+  return await _methodChannel.invokeMethod('isReduceMotionEnabled') ?? false;
+}

--- a/app/lib/util/native/ios_channel.dart
+++ b/app/lib/util/native/ios_channel.dart
@@ -4,8 +4,6 @@ import 'package:flutter/services.dart';
 
 const _methodChannel = MethodChannel('ios-delegate-channel');
 
-
-
 Future<bool> isReduceMotionEnabledIOS() async {
   return await _methodChannel.invokeMethod('isReduceMotionEnabled') ?? false;
 }

--- a/app/lib/util/native/macos_channel.dart
+++ b/app/lib/util/native/macos_channel.dart
@@ -50,6 +50,10 @@ Future<void> setDockIcon(TaskbarIcon icon) async {
   await _methodChannel.invokeMethod('setDockIcon', icon.index);
 }
 
+Future<bool> isReduceMotionEnabledMacOs() async {
+  return await _methodChannel.invokeMethod('isReduceMotionEnabled') ?? false;
+}
+
 // This happens:
 /// - on macOS when text is dropped onto the app Dock icon
 /// - on macOS when text is dropped onto the app menu bar icon

--- a/app/lib/util/ui/animations_status.dart
+++ b/app/lib/util/ui/animations_status.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+import 'package:localsend_app/util/native/channel/android_channel.dart';
+import 'package:localsend_app/util/native/ios_channel.dart';
+import 'package:localsend_app/util/native/macos_channel.dart';
+
+
+Future<bool> getSystemAnimationsStatus() async {
+
+      if (Platform.isAndroid) {
+        return await getSystemAnimationsStatusAndroid();
+      } else if (Platform.isIOS) {
+        bool isReduceMotionEnabledBool = await isReduceMotionEnabledIOS();
+        return !isReduceMotionEnabledBool;
+      }else if (Platform.isMacOS) {
+        bool isReduceMotionEnabledBool = await isReduceMotionEnabledMacOs();
+        return !isReduceMotionEnabledBool; 
+      }
+      
+      return true; // Default to true for other platforms.
+}

--- a/app/lib/util/ui/animations_status.dart
+++ b/app/lib/util/ui/animations_status.dart
@@ -3,18 +3,16 @@ import 'package:localsend_app/util/native/channel/android_channel.dart';
 import 'package:localsend_app/util/native/ios_channel.dart';
 import 'package:localsend_app/util/native/macos_channel.dart';
 
-
 Future<bool> getSystemAnimationsStatus() async {
+  if (Platform.isAndroid) {
+    return await getSystemAnimationsStatusAndroid();
+  } else if (Platform.isIOS) {
+    bool isReduceMotionEnabledBool = await isReduceMotionEnabledIOS();
+    return !isReduceMotionEnabledBool;
+  } else if (Platform.isMacOS) {
+    bool isReduceMotionEnabledBool = await isReduceMotionEnabledMacOs();
+    return !isReduceMotionEnabledBool;
+  }
 
-      if (Platform.isAndroid) {
-        return await getSystemAnimationsStatusAndroid();
-      } else if (Platform.isIOS) {
-        bool isReduceMotionEnabledBool = await isReduceMotionEnabledIOS();
-        return !isReduceMotionEnabledBool;
-      }else if (Platform.isMacOS) {
-        bool isReduceMotionEnabledBool = await isReduceMotionEnabledMacOs();
-        return !isReduceMotionEnabledBool; 
-      }
-      
-      return true; // Default to true for other platforms.
+  return true; // Default to true for other platforms.
 }

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -206,6 +206,8 @@ class AppDelegate: FlutterAppDelegate {
             }
         case "isLaunchedAsLoginItem":
             result(isLaunchedAsLoginItem)
+        case "isReduceMotionEnabled":
+            result(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion)
         default:
             result(FlutterMethodNotImplemented)
         }


### PR DESCRIPTION
Resolves #2333 on Andriod,IOS and MacOS

fetches system animations state on initial startup and toggles animations toggle based on that.

Andriod - tested and is working fine.
IOS and MacOS - Additional Testing is required.