### PR TITLE
Disable GTK3 header bar by default on Linux and use regular title bar instead

### DIFF
--- a/app/linux/my_application.cc
+++ b/app/linux/my_application.cc
@@ -23,28 +23,10 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  // If have GTK_CSD in env and it is equal to 0 then don't add the gtk header bar
-  // to disable client side decorations
+  // If have GTK_CSD in env and it is equal to 1 then add the gtk header bar
+  // to always use client side decorations
   const char* GTK_CSD = getenv("GTK_CSD");
-  gboolean use_gtk_csd = !GTK_CSD || strcmp(GTK_CSD, "0") != 0;
-  if (use_header_bar && use_gtk_csd) {
+  if (GTK_CSD && strcmp(GTK_CSD, "1") == 0) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
     gtk_header_bar_set_title(header_bar, "LocalSend");
@@ -104,6 +86,12 @@ static void my_application_class_init(MyApplicationClass* klass) {
 static void my_application_init(MyApplication* self) {}
 
 MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
                                      "flags", G_APPLICATION_NON_UNIQUE,


### PR DESCRIPTION
I don't know why, but when Google created the Flutter Linux template, they decided to use the GTK3 header bar on Linux, even though almost no Flutter projects intend to place any buttons or functionality in the header bar. This results in the title bar being unnecessarily large in Wayland environments and GNOME in X11 mode.  

When a GTK window uses the header bar, it also does not respect the request from the Wayland compositor to draw server-side window decorations through the [XDG Decoration protocol](https://wayland.app/protocols/xdg-decoration-unstable-v1). This leads to non-native window decorations on KDE Wayland, Sway, and any other Wayland compositor that supports the protocol.  

This PR ensures that LocalSend always uses the regular GTK3 title bar unless the `GTK_CSD` environment variable  [introduced in this PR](https://github.com/localsend/localsend/pull/669) is set to `1`. This makes GTK properly respect the XDG Decoration protocol.

Additionally, I added [some newer code](https://github.com/flutter/flutter/pull/154522/commits/c99d84f45357986516f3290b50d3af6f0fd08aeb) from the `my_application.cc` Flutter template that makes the title bar icon be correct on KDE Wayland and not a generic Wayland icon.

Another small benefit is that the [Unite shell extension](https://extensions.gnome.org/extension/1287/unite/) for GNOME can merge the regular GTK title bar with the top bar, but not header bars.

| Environment | Before | After |
|-|-|-|
| GNOME | ![GNOME before](https://github.com/user-attachments/assets/a481ba63-b221-4b61-b9b5-1084c3ec1f9e) | ![GNOME after](https://github.com/user-attachments/assets/e04eaa14-d3bb-41e8-aa0f-2ea07009c070) |
| KDE |![KDE before](https://github.com/user-attachments/assets/22117c79-c270-47d8-88ee-025a4bdff393) |  ![KDE after](https://github.com/user-attachments/assets/965b5eab-91db-4bea-af1e-094eb9c0db31) |
| Sway | ![Sway before](https://github.com/user-attachments/assets/506d2671-0731-48d4-8ffc-2d8eda34f71c) | ![Sway after](https://github.com/user-attachments/assets/3b2588ef-cc0c-4917-bdf1-27b22c308411) |

Note that I also had to upgrade the `path` Dart dependency from `1.9.0` to `1.9.1` to actually build the app but that is not included in this PR.

