### PR TITLE
Replace Material Icons with Lucide Icons

### DIFF
--- a/app/lib/pages/home_page.dart
+++ b/app/lib/pages/home_page.dart
@@ -13,11 +13,12 @@ import 'package:localsend_app/provider/selection/selected_sending_files_provider
 import 'package:localsend_app/util/native/cross_file_converters.dart';
 import 'package:localsend_app/widget/responsive_builder.dart';
 import 'package:refena_flutter/refena_flutter.dart';
+import  'package:lucide_icons_flutter/lucide_icons.dart';
 
 enum HomeTab {
-  receive(Icons.wifi),
+  receive(LucideIcons.wifi),
   send(Icons.send),
-  settings(Icons.settings);
+  settings(LucideIcons.cog);
 
   const HomeTab(this.icon);
 

--- a/app/lib/pages/tabs/receive_tab.dart
+++ b/app/lib/pages/tabs/receive_tab.dart
@@ -14,6 +14,7 @@ import 'package:localsend_app/widget/responsive_list_view.dart';
 import 'package:localsend_app/widget/rotating_widget.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
+import  'package:lucide_icons_flutter/lucide_icons.dart';
 
 enum _QuickSaveMode {
   off,
@@ -169,7 +170,7 @@ class _CornerButtons extends StatelessWidget {
                   onPressed: () async {
                     await context.push(() => const ReceiveHistoryPage());
                   },
-                  child: const Icon(Icons.history),
+                  child: const Icon(LucideIcons.history),
                 ),
               ),
             CustomIconButton(

--- a/app/lib/pages/tabs/send_tab.dart
+++ b/app/lib/pages/tabs/send_tab.dart
@@ -33,6 +33,7 @@ import 'package:localsend_app/widget/responsive_list_view.dart';
 import 'package:localsend_app/widget/rotating_widget.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
+import  'package:lucide_icons_flutter/lucide_icons.dart';
 
 const _horizontalPadding = 15.0;
 final _options = FilePickerOption.getOptionsForPlatform();
@@ -179,14 +180,14 @@ class SendTab extends StatelessWidget {
                   message: t.sendTab.manualSending,
                   child: CustomIconButton(
                     onPressed: () async => vm.onTapAddress(context),
-                    child: const Icon(Icons.ads_click),
+                    child: const Icon(LucideIcons.squareMousePointer),
                   ),
                 ),
                 Tooltip(
                   message: t.dialogs.favoriteDialog.title,
                   child: CustomIconButton(
                     onPressed: () async => await vm.onTapFavorite(context),
-                    child: const Icon(Icons.favorite),
+                    child: const Icon(LucideIcons.heart),
                   ),
                 ),
                 _SendModeButton(
@@ -327,7 +328,7 @@ class _ScanButton extends StatelessWidget {
               context.redux(nearbyDevicesProvider).dispatch(ClearFoundDevicesAction());
               await context.global.dispatchAsync(StartSmartScan(forceLegacy: true));
             },
-            child: Icon(Icons.sync, color: iconColor),
+            child: Icon(LucideIcons.refreshCcw, color: iconColor),
           ),
         ),
       );
@@ -363,7 +364,7 @@ class _ScanButton extends StatelessWidget {
         reverse: true,
         child: Padding(
           padding: const EdgeInsets.all(8),
-          child: Icon(Icons.sync, color: iconColor),
+          child: Icon(LucideIcons.refreshCcw, color: iconColor),
         ),
       ),
     );
@@ -383,7 +384,7 @@ class _RotatingSyncIcon extends StatelessWidget {
       duration: const Duration(seconds: 2),
       spinning: scanningIps.contains(ip),
       reverse: true,
-      child: const Icon(Icons.sync),
+      child: const Icon(LucideIcons.refreshCcw),
     );
   }
 }
@@ -427,7 +428,7 @@ class _SendModeButton extends StatelessWidget {
                     maintainSize: true,
                     maintainAnimation: true,
                     maintainState: true,
-                    child: const Icon(Icons.check_circle),
+                    child: const Icon(LucideIcons.circleCheck),
                   );
                 },
               ),
@@ -449,7 +450,7 @@ class _SendModeButton extends StatelessWidget {
                     maintainSize: true,
                     maintainAnimation: true,
                     maintainState: true,
-                    child: const Icon(Icons.check_circle),
+                    child: const Icon(LucideIcons.circleCheck),
                   );
                 },
               ),
@@ -468,7 +469,7 @@ class _SendModeButton extends StatelessWidget {
                 maintainSize: true,
                 maintainAnimation: true,
                 maintainState: true,
-                child: Icon(Icons.check_circle),
+                child: Icon(LucideIcons.circleCheck),
               ),
               const SizedBox(width: 10),
               Text(t.sendTab.sendModes.link),
@@ -483,7 +484,7 @@ class _SendModeButton extends StatelessWidget {
             children: [
               const Directionality(
                 textDirection: TextDirection.ltr,
-                child: Icon(Icons.help),
+                child: Icon(LucideIcons.badgeHelp),
               ),
               const SizedBox(width: 10),
               Text(t.sendTab.sendModeHelp),
@@ -493,7 +494,7 @@ class _SendModeButton extends StatelessWidget {
       ],
       child: const Padding(
         padding: EdgeInsets.all(8),
-        child: Icon(Icons.settings),
+        child: Icon(LucideIcons.folderTree),
       ),
     );
   }

--- a/app/lib/util/device_type_ext.dart
+++ b/app/lib/util/device_type_ext.dart
@@ -1,14 +1,15 @@
 import 'package:common/model/device.dart';
 import 'package:flutter/material.dart';
+import  'package:lucide_icons_flutter/lucide_icons.dart';
 
 extension DeviceTypeExt on DeviceType {
   IconData get icon {
     return switch (this) {
-      DeviceType.mobile => Icons.smartphone,
-      DeviceType.desktop => Icons.computer,
-      DeviceType.web => Icons.language,
-      DeviceType.headless => Icons.terminal,
-      DeviceType.server => Icons.dns,
+      DeviceType.mobile => LucideIcons.smartphone,
+      DeviceType.desktop => LucideIcons.laptopMinimal,
+      DeviceType.web => LucideIcons.globe,
+      DeviceType.headless => LucideIcons.squareTerminal,
+      DeviceType.server => LucideIcons.server,
     };
   }
 }

--- a/app/lib/util/native/file_picker.dart
+++ b/app/lib/util/native/file_picker.dart
@@ -30,17 +30,18 @@ import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
 import 'package:uri_content/uri_content.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+import  'package:lucide_icons_flutter/lucide_icons.dart';
 
 final _logger = Logger('FilePickerHelper');
 final _uriContent = UriContent();
 
 enum FilePickerOption {
-  file(Icons.description),
-  folder(Icons.folder),
-  media(Icons.image),
-  text(Icons.subject),
-  app(Icons.apps),
-  clipboard(Icons.paste);
+  file(LucideIcons.file),
+  folder(LucideIcons.folder),
+  media(LucideIcons.fileImage),
+  text(LucideIcons.text),
+  app(LucideIcons.layoutGrid),
+  clipboard(LucideIcons.clipboard);
 
   const FilePickerOption(this.icon);
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   logging: 1.3.0
   # https://github.com/NightFeather0615/macos_dock_progress/issues/1
   # macos_dock_progress: 1.1.0
+  lucide_icons_flutter: ^3.0.0
   mime: 1.0.6
   moform: 0.2.5
   nanoid2: 2.0.1
@@ -47,7 +48,7 @@ dependencies:
   open_filex: 4.5.0
   package_info_plus: 8.1.1
   pasteboard: 0.3.0
-  path: 1.9.0
+  path: ^1.9.1
   path_provider: 2.1.5
   path_provider_foundation: 2.4.0
   permission_handler: 11.3.1


### PR DESCRIPTION
## Description

This PR replaces all **Material Icons** with **Lucide Icons** throughout the application to ensure a consistent, modern, and cohesive iconography style.

### Key changes:
- Replaced all usages of Material Icons with Lucide equivalents.
- Added `lucide_icons_flutter` as a new dependency.
- Updated relevant widgets, components, and views to support the new icon set.

## Visual Changes

The following images show the **before** and **after** of the updated icons:

| Screen | Before | After |
|:------:|:------:|:-----:|
| Home Page | ![Captura de pantalla 2025-04-27 a la(s) 8 43 56 p m](https://github.com/user-attachments/assets/51a7ef7e-e7db-4bed-8f0b-634977c2bdcc) | ![Captura de pantalla 2025-04-27 a la(s) 8 26 21 p m](https://github.com/user-attachments/assets/24eb5d94-c766-4a0a-8e07-09321e1181a7) |
| Receive Page | ![Captura de pantalla 2025-04-27 a la(s) 8 44 08 p m](https://github.com/user-attachments/assets/7fbecda6-0866-4e2c-994d-25d76ed688f6) | ![Captura de pantalla 2025-04-27 a la(s) 8 28 56 p m](https://github.com/user-attachments/assets/aed03a76-0a2d-4ceb-b450-7c74aa2b4ed3) |
| Receive Page | ![Captura de pantalla 2025-04-27 a la(s) 8 44 26 p m](https://github.com/user-attachments/assets/16d0e663-1c7c-433a-8f5d-51bdd34b88c5) | ![Captura de pantalla 2025-04-27 a la(s) 8 29 47 p m](https://github.com/user-attachments/assets/b25d68f8-935a-4912-b63f-e0bdfdaaf9de) |












