### PR TITLE
feat: enable silent startup using `LSUIElement`

### DIFF
--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -118,7 +118,7 @@ Future<RefenaContainer> preInit(List<String> args) async {
     if (startHidden) {
       unawaited(hideToTray());
     } else {
-      await WindowManager.instance.show();
+      unawaited(showFromTray());
     }
 
     if (defaultTargetPlatform == TargetPlatform.macOS) {

--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>LSUIElement</key>
+	<true/>
     <key>AppIdentifierPrefix</key>
 	<string>$(AppIdentifierPrefix)</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Currently when logging in (when `Autostart after login` is enabled) LocalSend appears in the Dock for a few seconds, even with `Autostart: Start hidden`, this PR improves the UX so that if `Autostart: Start hidden` is enabled, the icon will not appear at all