### PR TITLE
Update files name duplicate counter (#2391)

### DIFF
--- a/app/lib/util/file_path_helper.dart
+++ b/app/lib/util/file_path_helper.dart
@@ -1,7 +1,7 @@
 import 'package:common/model/file_type.dart';
 
-/// Matches myFile-123 -> 123
-final _fileNumberRegex = RegExp(r'^(.*)(?:-(\d+))$');
+/// Matches myFile (123) -> "myFile", " (123)"
+final _fileNumberRegex = RegExp(r'^(.*)(?:(\s\(\d+\)))$');
 
 extension FilePathStringExt on String {
   String get extension {
@@ -43,9 +43,9 @@ extension FilePathStringExt on String {
 
     final match = _fileNumberRegex.firstMatch(fileName);
     if (match != null) {
-      return '${match.group(1)}-$count'.withExtension(extension);
+      return '${match.group(1)} ($count)'.withExtension(extension);
     } else {
-      return '$fileName-$count'.withExtension(extension);
+      return '$fileName ($count)'.withExtension(extension);
     }
   }
 

--- a/app/test/unit/util/file_path_helper_test.dart
+++ b/app/test/unit/util/file_path_helper_test.dart
@@ -3,15 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('fileName with counter', () async {
-    final fileName = 'myFile';
-
-    final fileNameWithCounter1 = 'myFile (1)';
-    final fileNameWithCounter2 = 'myFile (2)';
-
-    final fileNameAddCounter1 = fileName.withCount(1);
-    final fileNameAddCounter2 = fileNameWithCounter1.withCount(2);
-
-    expect(fileNameWithCounter1, fileNameAddCounter1);
-    expect(fileNameWithCounter2, fileNameAddCounter2);
+    expect('myFile'.withCount(1), 'myFile (1)');
+    expect('myFile (1)'.withCount(2), 'myFile (2)');
   });
 }

--- a/app/test/unit/util/file_path_helper_test.dart
+++ b/app/test/unit/util/file_path_helper_test.dart
@@ -1,0 +1,17 @@
+import 'package:localsend_app/util/file_path_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('fileName with counter', () async {
+    final fileName = 'myFile';
+
+    final fileNameWithCounter1 = 'myFile (1)';
+    final fileNameWithCounter2 = 'myFile (2)';
+
+    final fileNameAddCounter1 = fileName.withCount(1);
+    final fileNameAddCounter2 = fileNameWithCounter1.withCount(2);
+
+    expect(fileNameWithCounter1, fileNameAddCounter1);
+    expect(fileNameWithCounter2, fileNameAddCounter2);
+  });
+}


### PR DESCRIPTION
Updated file duplication naming to a more user-friendly format.
Fixing: #2391

Previous: file.txt → file-1.txt
Now: file.txt → file (1).txt → file (2).txt