### PR TITLE
Add 'Deselect All' button to clear selected files

### DIFF
--- a/app/lib/pages/selected_files_page.dart
+++ b/app/lib/pages/selected_files_page.dart
@@ -46,12 +46,13 @@ class SelectedFilesPage extends StatelessWidget {
                       ],
                     ),
                   ),
-                  FilledButton(
+                  FilledButton.icon(
                     onPressed: () {
                       ref.redux(selectedSendingFilesProvider).dispatch(ClearSelectionAction());
                       context.popUntilRoot();
                     },
-                    child: Text(t.selectedFilesPage.deleteAll),
+                    icon: const Icon(Icons.deselect),
+                    label: const Text('Deselect All'),
                   ),
                 ],
               ),


### PR DESCRIPTION
     ## Description
     This PR adds a "Deselect All" button to the selected files page, allowing users to clear all selected files at once. This addresses the issue where users accidentally trigger multiselect while scrolling through a large list of files.

     ## Changes
     - Updated the button in `selected_files_page.dart` to use `FilledButton.icon` with a clear "Deselect All" label and icon.
     - The button triggers the existing `ClearSelectionAction` to clear all selected files.

     ## Testing
     - Tested by selecting multiple files and verifying that the "Deselect All" button clears the list and redirects back to the previous page.
     
     Issue#2450