### PR TITLE
fix: #2373 disable sleep preventing when files are uploaded/downloaded

### DIFF
--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -70,9 +70,19 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
 
       // Periodically call WakelockPlus.enable() to keep the screen awake
       _wakelockPlusTimer = Timer.periodic(const Duration(seconds: 30), (timer) {
-        try {
-          unawaited(WakelockPlus.enable());
-        } catch (_) {}
+        final finished = ref.read(serverProvider)?.session?.files.values.map((e) => e.status).isFinishedOrSkipped ??
+            ref.read(sendProvider)[widget.sessionId]?.files.values.map((e) => e.status).isFinishedOrSkipped ??
+            true;
+        if (finished) {
+          timer.cancel();
+          try {
+            unawaited(WakelockPlus.disable());
+          } catch (_) {}
+        } else {
+          try {
+            unawaited(WakelockPlus.enable());
+          } catch (_) {}
+        }
       });
 
       if (ref.read(settingsProvider).autoFinish) {


### PR DESCRIPTION
#2373 
Add check if uploading is finished, to disable wake lock.

Straightforward solution with minimum changes.

