### PR TITLE
fix: delete partial files on transfer cancellation

### DIFF
--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -115,7 +115,7 @@ Future<RefenaContainer> preInit(List<String> args) async {
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       startHidden = await isLaunchedAsLoginItem() && await getLaunchAtLoginMinimized();
     }
-    
+
     doWhenWindowReady(() {
       if (startHidden) {
         unawaited(hideToTray());

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -461,7 +461,7 @@ class ReceiveController {
             files: {
               ...oldState.session!.files,
               fileId: oldState.session!.files[fileId]!.copyWith(
-                path: saveToGallery ? null : destinationPath,
+                path: destinationPath,
               ),
             },
           ),
@@ -798,7 +798,6 @@ void _cancelBySender(ServerUtils server) {
     Routerino.context.popUntil(ReceivePage);
   }
 
-  // Add cleanup for partial files
   // Clean up any partially transferred files
   _cleanupPartialFiles(receiveSession);
 
@@ -814,7 +813,7 @@ void _cancelBySender(ServerUtils server) {
   server.ref.notifier(progressProvider).removeSession(receiveSession.sessionId);
 }
 
-// Add a new method to clean up partial files/// Cleans up partially transferred files for a given receiving session
+// Cleans up partially transferred files for a given receiving session
 void _cleanupPartialFiles(ReceiveSessionState receiveSession) {
   for (final receivingFile in receiveSession.files.values) {
     if (receivingFile.status == FileStatus.sending || receivingFile.status == FileStatus.failed) {

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -755,8 +755,8 @@ class ReceiveController {
       // the server is not running
       return;
     }
-     _cleanupPartialFiles(session);
-    
+    _cleanupPartialFiles(session);
+
     // notify sender
     try {
       // ignore: unawaited_futures
@@ -800,7 +800,7 @@ void _cancelBySender(ServerUtils server) {
 
   // Add cleanup for partial files
   // Clean up any partially transferred files
-   _cleanupPartialFiles(receiveSession);
+  _cleanupPartialFiles(receiveSession);
 
   // Update state
   server.setState((oldState) => oldState?.copyWith(
@@ -816,10 +816,6 @@ void _cancelBySender(ServerUtils server) {
 
 // Add a new method to clean up partial files/// Cleans up partially transferred files for a given receiving session
 void _cleanupPartialFiles(ReceiveSessionState receiveSession) {
-  if (receiveSession == null) {
-    return;
-  }
-
   for (final receivingFile in receiveSession.files.values) {
     if (receivingFile.status == FileStatus.sending || receivingFile.status == FileStatus.failed) {
       try {
@@ -837,6 +833,7 @@ void _cleanupPartialFiles(ReceiveSessionState receiveSession) {
     }
   }
 }
+
 extension on ReceiveSessionState {
   ReceiveSessionState fileFinished({
     required String fileId,


### PR DESCRIPTION
# Fix: Delete Partial Files on Transfer Cancellation

## Summary

This pull request introduces logic to automatically clean up partially transferred files when a transfer session is canceled—either by the sender or receiver. This ensures that incomplete or failed files do not persist on the device, improving overall system reliability and user experience.

## Changes Introduced

- **Partial File Cleanup**
  - Added a `_cleanupPartialFiles()` method to delete files with `FileStatus.sending` or `FileStatus.failed`.
  - Included error handling and logging to track cleanup results.

- **Improved Cancellation Handling**
  - Integrated cleanup logic in both sender-initiated and receiver-initiated cancellations.
  - Updated session state to reflect `canceledBySender` status and set the appropriate `endTime`.

- **Accurate File Path Assignment**
  - Updated the file path during transfer initiation using:
    ```dart
    path: saveToGallery ? null : destinationPath
    ```
    - This ensures the actual destination file name is captured (including any auto-renamed variants like `file(1).txt`), allowing accurate reference and cleanup if needed.
    - Note: The path is also updated again upon successful transfer (existing logic).

- **State Management**
  - Ensured the server’s session state remains consistent, especially when file paths or statuses are modified mid-transfer.

## Rationale

- Without cleanup, canceled transfers could leave behind partial or corrupted files, leading to wasted storage and potential user confusion. 
- Additionally, capturing the final resolved file path early allows proper handling of renamed files due to name collisions.

## Testing

- Manually tested various cancel scenarios during file transfer.
- Verified that:
  - Partial files are deleted appropriately.
  - Session metadata and UI reflect correct cancellation state.
  - File paths are correctly resolved and used for cleanup.

---

This update enhances transfer reliability by preventing orphaned files and ensuring consistent state management across cancellation scenarios.
