### PR TITLE
feat: enable starting text share via command line

### DIFF
--- a/app/lib/provider/selection/selected_sending_files_provider.dart
+++ b/app/lib/provider/selection/selected_sending_files_provider.dart
@@ -289,9 +289,14 @@ class LoadSelectionFromArgsAction extends AsyncReduxActionWithResult<SelectedSen
   Future<(List<CrossFile>, bool)> reduce() async {
     bool filesAdded = false;
     bool nextShare = false;
+    bool nextText = false;
     for (final arg in args) {
       if (arg == '--share') {
         nextShare = true;
+        continue;
+      }
+      if (arg == '--text' || arg == '-t') {
+        nextText = true;
         continue;
       }
       if (nextShare) {
@@ -307,6 +312,14 @@ class LoadSelectionFromArgsAction extends AsyncReduxActionWithResult<SelectedSen
               converter: CrossFileConverters.convertSharedAttachment,
             ));
         filesAdded = true;
+        continue;
+      }
+      if (nextText) {
+        nextText = false;
+        if (arg.trim().isNotEmpty) {
+          dispatch(AddMessageAction(message: arg.trim()));
+          filesAdded = true;
+        }
         continue;
       }
       if (arg.startsWith('-')) {


### PR DESCRIPTION
## Summary

• Add support for starting text share via command line using --text or -t flag
• Enables users to quickly share text content by passing it as a command line argument

## Changes

• Enhanced LoadSelectionFromArgsAction in selected_sending_files_provider.dart to handle --text and -t flags
• Added logic to process text content passed after the text flag and add it as a message for sharing
• Maintains existing file sharing functionality while extending command line capabilities

This feature improves the CLI experience by allowing direct text sharing without needing to launch the full UI first.