### PR TITLE
fix: macOS Dock icon file-drop & Share Extension

### DIFF
--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -264,6 +264,18 @@ class AppDelegate: FlutterAppDelegate {
             }
         }
     }
+
+    override func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            if url.isFileURL {
+                if let fileBookmark = createBookmarkForFile(at: url) {
+                    Defaults[.pendingFiles].append(fileBookmark)
+                }
+            } else {
+                Defaults[.pendingStrings].append(url.absoluteString)
+            }
+        }
+    }
     // END: handle opened files
     
     /// Handle **text** dropped onto the Dock icon


### PR DESCRIPTION
Fixes macOS Dock icon file-drop, and the Share Extension as well

Not clear since when Apple turned opening a file into opening a URL hook - the hooks [`application:openFile`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/application(_:openfile:)) and [`application:openFiles`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/application(_:openfiles:)) called at the time of the original implementation...

Closes https://github.com/localsend/localsend/issues/2023, Closes https://github.com/localsend/localsend/issues/2224, Closes https://github.com/localsend/localsend/issues/2337 (See https://github.com/localsend/localsend/issues/2023#issuecomment-3310100840)