### PR TITLE
fix: link systemconfiguration framework

### DIFF
--- a/app/rust_builder/macos/rust_lib_localsend_app.podspec
+++ b/app/rust_builder/macos/rust_lib_localsend_app.podspec
@@ -22,6 +22,7 @@ A new Flutter FFI plugin project.
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.11'
+  s.framework = 'SystemConfiguration'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 


### PR DESCRIPTION
Fixes this build error:
```
rust_lib_localsend_app
Undefined symbol: _SCDynamicStoreCopyProxies

Undefined symbol: _SCDynamicStoreCreateWithOptions

Undefined symbol: _SCNetworkInterfaceCopyAll

Undefined symbol: _SCNetworkInterfaceGetBSDName

Undefined symbol: _SCNetworkInterfaceGetInterfaceType

Undefined symbol: _SCNetworkInterfaceGetLocalizedDisplayName

Undefined symbol: _SCNetworkReachabilityCreateWithAddress

Undefined symbol: _SCNetworkReachabilityCreateWithAddressPair

Undefined symbol: _SCNetworkReachabilityCreateWithName

Undefined symbol: _SCNetworkReachabilityGetFlags

Undefined symbol: _SCNetworkReachabilityScheduleWithRunLoop

Undefined symbol: _SCNetworkReachabilityUnscheduleFromRunLoop

Undefined symbol: _SCNetworkServiceCopyAll

Undefined symbol: _SCNetworkServiceGetEnabled

Undefined symbol: _SCNetworkServiceGetInterface

Undefined symbol: _SCNetworkServiceGetServiceID

Undefined symbol: _SCNetworkSetCopyCurrent

Undefined symbol: _SCNetworkSetGetServiceOrder

Undefined symbol: _kSCDynamicStoreUseSessionKeys

Undefined symbol: _kSCNetworkInterfaceType6to4

Undefined symbol: _kSCNetworkInterfaceTypeBluetooth

Undefined symbol: _kSCNetworkInterfaceTypeBond

Undefined symbol: _kSCNetworkInterfaceTypeEthernet

Undefined symbol: _kSCNetworkInterfaceTypeFireWire

Undefined symbol: _kSCNetworkInterfaceTypeIEEE80211

Undefined symbol: _kSCNetworkInterfaceTypeIPSec

Undefined symbol: _kSCNetworkInterfaceTypeIPv4

Undefined symbol: _kSCNetworkInterfaceTypeL2TP

Undefined symbol: _kSCNetworkInterfaceTypeModem

Undefined symbol: _kSCNetworkInterfaceTypePPP

Undefined symbol: _kSCNetworkInterfaceTypePPTP

Undefined symbol: _kSCNetworkInterfaceTypeSerial

Undefined symbol: _kSCNetworkInterfaceTypeVLAN

Undefined symbol: _kSCNetworkInterfaceTypeWWAN

Undefined symbol: _kSCPropNetProxiesHTTPEnable

Undefined symbol: _kSCPropNetProxiesHTTPPort

Undefined symbol: _kSCPropNetProxiesHTTPProxy

Undefined symbol: _kSCPropNetProxiesHTTPSEnable

Undefined symbol: _kSCPropNetProxiesHTTPSPort

Undefined symbol: _kSCPropNetProxiesHTTPSProxy

Linker command failed with exit code 1 (use -v to see invocation)
```

Closes https://github.com/localsend/localsend/issues/2649