### PR TITLE
fix: Add CJK font support for Linux to fix display issues for Chinese, Japanese, and Korean

### DIFF
--- a/app/lib/config/theme.dart
+++ b/app/lib/config/theme.dart
@@ -40,6 +40,14 @@ ThemeData getTheme(ColorMode colorMode, Brightness brightness, DynamicColors? dy
       AppLocale.zhHk || AppLocale.zhTw => 'Microsoft JhengHei UI',
       _ => 'Segoe UI Variable Display',
     };
+  } else if (checkPlatform([TargetPlatform.linux])) {
+    fontFamily = switch (LocaleSettings.currentLocale) {
+      AppLocale.ja => 'Noto Sans CJK JP',
+      AppLocale.ko => 'Noto Sans CJK KR',
+      AppLocale.zhCn => 'Noto Sans CJK SC',
+      AppLocale.zhHk || AppLocale.zhTw => 'Noto Sans CJK TC',
+      _ => 'Noto Sans', 
+    };
   } else {
     fontFamily = null;
   }


### PR DESCRIPTION
- 针对 Linux 系统，为不同语言指定了合适的字体：
  - 中文（简体）：Noto Sans CJK SC
  - 中文（繁体）：Noto Sans CJK TC
  - 日文：Noto Sans CJK JP
  - 韩文：Noto Sans CJK KR
- 中文、日文和韩文现在可以正常显示
- 已在 Ubuntu 和银河麒麟系统上测试通过

- Add CJK font support for Linux by specifying appropriate fonts per language:
  - Chinese (Simplified): Noto Sans CJK SC
  - Chinese (Traditional): Noto Sans CJK TC
  - Japanese: Noto Sans CJK JP
  - Korean: Noto Sans CJK KR
- Chinese, Japanese, and Korean now display correctly on Linux
- Tested on Ubuntu and Kylin Linux

Before:
<img width="902" height="641" alt="484152689-7d62c514-4915-4520-8e4e-54a9bcd54cf5" src="https://github.com/user-attachments/assets/1af8f29f-5cb4-4634-a786-aee533da83b2" />

After:
<img width="900" height="640" alt="2025-09-23_19-10-38" src="https://github.com/user-attachments/assets/94e22e37-6f29-42a9-9d34-6367ab9c1fec" />
