### PR TITLE
chore: Preserve trailing commas

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -17,6 +17,9 @@ analyzer:
     - lib/**.freezed.dart
     - submodules/**
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     use_key_in_widget_constructors: false


### PR DESCRIPTION
Without this setting the new formatter will sometimes remove trailing commas, which makes the diff and the code harder to read.