### PR TITLE
Fix file size display: use decimal (SI) units instead of mislabeled binary units

### DIFF
--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -23,7 +23,7 @@
 - fix: text message content size calculation (@ew-sirenko, https://github.com/localsend/localsend/pull/2297)
 - fix(linux): add CJK font support for Chinese, Japanese, and Korean text (@Mr-Ebonycat, https://github.com/localsend/localsend/pull/2719)
 - fix: save DNG files to image gallery (@ShlomoCode, https://github.com/localsend/localsend/pull/2728)
-- fix: use decimal (SI) units for file sizes to match file manager displays
+- fix: use decimal (SI) units for file sizes to match file manager displays (@navuxneeth, https://github.com/localsend/localsend/pull/2865)
 
 ## 1.17.0 (2025-02-19)
 

--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fix: text message content size calculation (@ew-sirenko, https://github.com/localsend/localsend/pull/2297)
 - fix(linux): add CJK font support for Chinese, Japanese, and Korean text (@Mr-Ebonycat, https://github.com/localsend/localsend/pull/2719)
 - fix: save DNG files to image gallery (@ShlomoCode, https://github.com/localsend/localsend/pull/2728)
+- fix: use decimal (SI) units for file sizes to match file manager displays
 
 ## 1.17.0 (2025-02-19)
 

--- a/app/lib/util/file_size_helper.dart
+++ b/app/lib/util/file_size_helper.dart
@@ -1,14 +1,15 @@
 extension IntFileSize on int {
   /// Converts the integer representing bytes to a readable string
+  /// Uses decimal (SI) units: 1 KB = 1000 B, 1 MB = 1000 KB, 1 GB = 1000 MB
   String get asReadableFileSize {
-    if (this < 1024) {
+    if (this < 1000) {
       return '$this B';
-    } else if (this < 1024 * 1024) {
-      return '${(this / 1024).toStringAsFixed(1)} KB';
-    } else if (this < 1024 * 1024 * 1024) {
-      return '${(this / (1024 * 1024)).toStringAsFixed(1)} MB';
+    } else if (this < 1000 * 1000) {
+      return '${(this / 1000).toStringAsFixed(1)} KB';
+    } else if (this < 1000 * 1000 * 1000) {
+      return '${(this / (1000 * 1000)).toStringAsFixed(1)} MB';
     } else {
-      return '${(this / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+      return '${(this / (1000 * 1000 * 1000)).toStringAsFixed(1)} GB';
     }
   }
 }

--- a/app/test/unit/util/file_size_helper_test.dart
+++ b/app/test/unit/util/file_size_helper_test.dart
@@ -1,0 +1,60 @@
+import 'package:localsend_app/util/file_size_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('asReadableFileSize', () {
+    test('shows bytes for values less than 1000', () {
+      expect(0.asReadableFileSize, '0 B');
+      expect(1.asReadableFileSize, '1 B');
+      expect(100.asReadableFileSize, '100 B');
+      expect(999.asReadableFileSize, '999 B');
+    });
+
+    test('shows KB for values between 1000 and 999999 (less than 1MB)', () {
+      expect(1000.asReadableFileSize, '1.0 KB');
+      expect(1500.asReadableFileSize, '1.5 KB');
+      expect(10000.asReadableFileSize, '10.0 KB');
+      expect(100000.asReadableFileSize, '100.0 KB');
+      expect(999999.asReadableFileSize, '1000.0 KB');
+    });
+
+    test('shows MB for values between 1000000 and 999999999 (less than 1GB)', () {
+      expect(1000000.asReadableFileSize, '1.0 MB');
+      expect(1500000.asReadableFileSize, '1.5 MB');
+      expect(10000000.asReadableFileSize, '10.0 MB');
+      expect(100000000.asReadableFileSize, '100.0 MB');
+      expect(999999999.asReadableFileSize, '1000.0 MB');
+    });
+
+    test('shows GB for values 1000000000 or more', () {
+      expect(1000000000.asReadableFileSize, '1.0 GB');
+      expect(1500000000.asReadableFileSize, '1.5 GB');
+      expect(10000000000.asReadableFileSize, '10.0 GB');
+      expect(100000000000.asReadableFileSize, '100.0 GB');
+    });
+
+    test('formats decimal places correctly', () {
+      expect(1234.asReadableFileSize, '1.2 KB');
+      expect(1567.asReadableFileSize, '1.6 KB');
+      expect(1234567.asReadableFileSize, '1.2 MB');
+      expect(1567890.asReadableFileSize, '1.6 MB');
+      expect(1234567890.asReadableFileSize, '1.2 GB');
+      expect(1567890123.asReadableFileSize, '1.6 GB');
+    });
+
+    test('real-world file sizes match expected values', () {
+      // 1 GB file should show as 1.0 GB, not 0.9 GB as it would with binary
+      expect(1000000000.asReadableFileSize, '1.0 GB');
+      
+      // 1 GiB (1073741824 bytes) should show as approximately 1.1 GB with decimal
+      expect(1073741824.asReadableFileSize, '1.1 GB');
+      
+      // 10 GB file
+      expect(10000000000.asReadableFileSize, '10.0 GB');
+      
+      // Common file sizes
+      expect(4700000000.asReadableFileSize, '4.7 GB'); // DVD-sized file
+      expect(25000000000.asReadableFileSize, '25.0 GB'); // Blu-ray-sized file
+    });
+  });
+}


### PR DESCRIPTION
LocalSend was calculating file sizes using binary units (base-1024) but labeling them as decimal units (KB/MB/GB), causing displayed sizes to be ~7-10% smaller than file managers show.

**Changes**
```
app/lib/util/file_size_helper.dart: Changed divisor from 1024 to 1000 and thresholds from powers of 1024 to powers of 1000
app/test/unit/util/file_size_helper_test.dart: Added test coverage for all size ranges and real-world examples
app/assets/CHANGELOG.md: Documented the fix
```
Example
```
// Before (incorrect): binary calculation with decimal labels
1000000000.asReadableFileSize  // "0.9 GB" (1000000000 / 1024³)
```
```
// After (correct): decimal calculation with decimal labels  
1000000000.asReadableFileSize  // "1.0 GB" (1000000000 / 1000³)
File sizes now match Windows Explorer, macOS Finder, and standard file managers. A 1 GB file displays as "1.0 GB" instead of "0.9 GB", a 10 GB file as "10.0 GB" instead of "9.3 GB".
```