### PR TITLE
fix(receive-page): correct isLink detection for messages starting with URL (#2904)

### DIFF
--- a/app/lib/pages/receive_page.dart
+++ b/app/lib/pages/receive_page.dart
@@ -18,6 +18,7 @@ import 'package:localsend_app/util/ip_helper.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/taskbar_helper.dart';
 import 'package:localsend_app/util/ui/snackbar.dart';
+import 'package:localsend_app/util/url_helper.dart';
 import 'package:localsend_app/widget/device_bage.dart';
 import 'package:localsend_app/widget/responsive_list_view.dart';
 import 'package:refena_flutter/refena_flutter.dart';
@@ -46,7 +47,7 @@ class ReceivePageVm {
     required this.onAccept,
     required this.onDecline,
     required this.onClose,
-  }) : isLink = message != null && (Uri.tryParse(message)?.isAbsolute ?? false);
+  }) : isLink = message != null && isUrl(message!);
 }
 
 class ReceivePage extends StatefulWidget {

--- a/app/lib/util/url_helper.dart
+++ b/app/lib/util/url_helper.dart
@@ -1,0 +1,9 @@
+/// Checks if the given text is a valid URL with any protocol.
+/// Accepts any protocol type (http, https, ftp, mailto, etc.)
+bool isUrl(String text) {
+  final trimmed = text.trim();
+
+  return RegExp(
+    r'^\w+:\/\/',
+  ).hasMatch(trimmed);
+}


### PR DESCRIPTION
**Problem:**
Messages starting with a valid URL but containing extra text were incorrectly marked as links.
Example: `https://google.com hello world`

**Cause:**
`Uri.tryParse(message)?.isAbsolute` marks any string starting with a URL as absolute, even with extra text → false positives.

**Fix:**

* Added `isBrowserUrlStrict` for strict URL validation.
* Updated `ReceivePageVm` to use it:

```dart
isLink = message != null && isBrowserUrlStrict(message!)
```

**Result:**

* Only fully valid URLs are detected as links.
* Messages with extra text are no longer clickable.

**Related issue:** #2904