### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Extract version from pubspec.yaml
         id: pubspec_version
         run: |

--- a/.github/workflows/compile_apk.yml
+++ b/.github/workflows/compile_apk.yml
@@ -15,7 +15,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Remove proprietary dependencies
         run: sh scripts/remove_proprietary_dependencies.sh
@@ -52,7 +52,7 @@ jobs:
         run: mkdir secrets && echo $ENCODED_STRING | base64 -di > secrets/android-keystore.jks
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -77,7 +77,7 @@ jobs:
         run: flutter build apk --split-per-abi
 
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: apk-result
           path: |

--- a/.github/workflows/compile_arm64_appimage.yml
+++ b/.github/workflows/compile_arm64_appimage.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -28,7 +28,7 @@ jobs:
     runs-on: [self-hosted, linux, arm64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -66,7 +66,7 @@ jobs:
           recipe: ./AppImageBuilder.yml
 
       - name: Upload AppImage file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: appimage-arm-64-result
           path: ./*.AppImage

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -14,7 +14,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -37,7 +37,7 @@ jobs:
         run: flutter pub run build_runner build -d
 
       - name: Upload updated lib files with generated code
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lib-files
           path: ./app/lib/*
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download generated files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: lib-files
           path: app/lib
@@ -95,7 +95,7 @@ jobs:
           recipe: ./app/AppImageBuilder.yml
 
       - name: Upload AppImage file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: appimage-result
           path: ./app/*.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Remove proprietary dependencies
         run: sh scripts/remove_proprietary_dependencies.sh
@@ -52,7 +52,7 @@ jobs:
         run: mkdir secrets && echo $ENCODED_STRING | base64 -di > secrets/android-keystore.jks
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -81,7 +81,7 @@ jobs:
         run: flutter build apk --split-per-abi
 
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: apk-result
           path: |
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -130,7 +130,7 @@ jobs:
           tar -czvf ../../../../../result.tar.gz *
 
       - name: Upload tar.gz archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tar-gz-x86-64-result
           path: ./app/*.tar.gz
@@ -142,7 +142,7 @@ jobs:
     runs-on: [ self-hosted, linux, arm64 ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -163,7 +163,7 @@ jobs:
           tar -czvf ../../../../../result.tar.gz *
 
       - name: Upload tar.gz archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tar-gz-arm-64-result
           path: ./app/*.tar.gz
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -221,7 +221,7 @@ jobs:
           fi
 
       - name: Upload deb file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: deb-x86-64-result
           path: ${{ steps.find_deb.outputs.deb_path }}
@@ -233,7 +233,7 @@ jobs:
     runs-on: [ self-hosted, linux, arm64 ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -263,7 +263,7 @@ jobs:
           fi
 
       - name: Upload deb file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: deb-arm-64-result
           path: ${{ steps.find_deb.outputs.deb_path }}
@@ -273,7 +273,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -326,7 +326,7 @@ jobs:
           recipe: ./AppImageBuilder.yml
 
       - name: Upload AppImage file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: appimage-x86-64-result
           path: ./*.AppImage
@@ -340,7 +340,7 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:
@@ -371,7 +371,7 @@ jobs:
         run: Compress-Archive -Path build/windows/x64/runner/Release/* -DestinationPath LocalSend.zip
 
       - name: Upload zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-zip-x86-64-result
           path: app/LocalSend.zip
@@ -389,7 +389,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Draft release
         id: draft_release
@@ -402,7 +402,7 @@ jobs:
 
       # APK
       - name: Download apk file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: apk-result
           path: apk-result
@@ -442,7 +442,7 @@ jobs:
 
       # TAR.GZ (x86_64)
       - name: Download tar.gz file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: tar-gz-x86-64-result
           path: tar-gz-x86-64-result
@@ -465,7 +465,7 @@ jobs:
 
       # TAR.GZ (arm_64)
       - name: Download tar.gz file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: tar-gz-arm-64-result
           path: tar-gz-arm-64-result
@@ -488,7 +488,7 @@ jobs:
 
       # DEB (x86_64)
       - name: Download deb file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: deb-x86-64-result
           path: deb-x86-64-result
@@ -508,7 +508,7 @@ jobs:
 
       # DEB (arm_64)
       - name: Download deb file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: deb-arm-64-result
           path: deb-arm-64-result
@@ -528,7 +528,7 @@ jobs:
 
       # APPIMAGE (x86_64)
       - name: Download AppImage file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: appimage-x86-64-result
           path: appimage-x86-64-result
@@ -556,7 +556,7 @@ jobs:
 
       # WINDOWS ZIP (x86_64)
       - name: Download windows zip file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows-zip-x86-64-result
           path: windows-zip-x86-64-result

--- a/.github/workflows/test_arm64_deb.yml
+++ b/.github/workflows/test_arm64_deb.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -28,7 +28,7 @@ jobs:
     runs-on: [self-hosted, linux, arm64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -69,7 +69,7 @@ jobs:
           ar rcs ../${{ steps.find_deb.outputs.deb_path }} debian-binary control.tar.xz data.tar.xz
 
       - name: Upload deb file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: deb-arm-64-result
           path: ${{ steps.find_deb.outputs.deb_path }}

--- a/.github/workflows/test_arm64_tar.yml
+++ b/.github/workflows/test_arm64_tar.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -28,7 +28,7 @@ jobs:
     runs-on: [self-hosted, linux, arm64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -49,7 +49,7 @@ jobs:
           tar -czvf ../../../../../result.tar.gz *
 
       - name: Upload tar.gz archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tar-gz-arm-64-result
           path: ./app/*.tar.gz

--- a/.github/workflows/test_rpm.yml
+++ b/.github/workflows/test_rpm.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:38
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: sudo dnf install -y clang cmake gtk3-devel ninja-build libappindicator-gtk3-devel jq findutils which git patchelf rpm-build
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Upload rpm file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rpm-result
           path: ${{ steps.find_rpm.outputs.rpm_path }}

--- a/.github/workflows/test_zip.yml
+++ b/.github/workflows/test_zip.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from pubspec.yaml
         id: get_version
@@ -30,7 +30,7 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:
@@ -61,7 +61,7 @@ jobs:
         run: Compress-Archive -Path build/windows/x64/runner/Release/* -DestinationPath LocalSend.zip
 
       - name: Upload zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-zip-x86-64-result
           path: app/LocalSend.zip


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test_rpm.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test_arm64_tar.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/compile_apk.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/compile_arm64_appimage.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/compile_apk.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test_rpm.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/compile_apk.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/linux_build.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test_zip.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test_arm64_deb.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/release.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test_arm64_deb.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test_zip.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/compile_arm64_appimage.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/linux_build.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/linux_build.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test_arm64_tar.yml`
