### PR TITLE
iOS: avoid transfer interruption on device lock

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:localsend_app/util/ui/dynamic_colors.dart';
 import 'package:localsend_app/widget/watcher/life_cycle_watcher.dart';
 import 'package:localsend_app/widget/watcher/shortcut_watcher.dart';
 import 'package:localsend_app/widget/watcher/tray_watcher.dart';
+import 'package:localsend_app/widget/watcher/transfer_wakelock_watcher.dart';
 import 'package:localsend_app/widget/watcher/window_watcher.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
@@ -64,21 +65,23 @@ class LocalSendApp extends StatelessWidget {
                 break;
             }
           },
-          child: ShortcutWatcher(
-            child: MaterialApp(
-              title: t.appName,
-              locale: TranslationProvider.of(context).flutterLocale,
-              supportedLocales: AppLocaleUtils.supportedLocales,
-              localizationsDelegates: GlobalMaterialLocalizations.delegates,
-              debugShowCheckedModeBanner: false,
-              theme: getTheme(colorMode, Brightness.light, dynamicColors),
-              darkTheme: getTheme(colorMode, Brightness.dark, dynamicColors),
-              themeMode: colorMode == ColorMode.oled ? ThemeMode.dark : themeMode,
-              navigatorKey: Routerino.navigatorKey,
-              home: RouterinoHome(
-                builder: () => const HomePage(
-                  initialTab: HomeTab.receive,
-                  appStart: true,
+          child: TransferWakelockWatcher(
+            child: ShortcutWatcher(
+              child: MaterialApp(
+                title: t.appName,
+                locale: TranslationProvider.of(context).flutterLocale,
+                supportedLocales: AppLocaleUtils.supportedLocales,
+                localizationsDelegates: GlobalMaterialLocalizations.delegates,
+                debugShowCheckedModeBanner: false,
+                theme: getTheme(colorMode, Brightness.light, dynamicColors),
+                darkTheme: getTheme(colorMode, Brightness.dark, dynamicColors),
+                themeMode: colorMode == ColorMode.oled ? ThemeMode.dark : themeMode,
+                navigatorKey: Routerino.navigatorKey,
+                home: RouterinoHome(
+                  builder: () => const HomePage(
+                    initialTab: HomeTab.receive,
+                    appStart: true,
+                  ),
                 ),
               ),
             ),

--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -319,6 +319,7 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
   }
 
   Future<void> _sendLoop(Ref ref, String sessionId, Device target, Map<String, SendingFile> files) async {
+    _logger.info('Transfer started (send) sessionId=$sessionId files=${files.length}');
     state = state.updateSession(
       sessionId: sessionId,
       state: (s) => s?.copyWith(startTime: DateTime.now().millisecondsSinceEpoch),
@@ -360,13 +361,13 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     }
 
     if (state[sessionId]!.status != SessionStatus.sending) {
-      _logger.info('Transfer was canceled.');
+      _logger.info('Transfer ended early (send) sessionId=$sessionId status=${sessionState.status}');
     } else {
       final hasError = sessionState.files.values.any((file) => file.status == FileStatus.failed);
       if (!hasError && sessionState.background == true) {
         // close session because everything is fine and it is in background
         closeSession(sessionId);
-        _logger.info('Transfer finished and session removed.');
+        _logger.info('Transfer finished and session removed (send) sessionId=$sessionId');
       } else {
         // keep session alive when there are errors or currently in foreground
         state = state.updateSession(
@@ -378,9 +379,9 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
         );
 
         if (hasError) {
-          _logger.info('Transfer finished with errors.');
+          _logger.info('Transfer finished with errors (send) sessionId=$sessionId');
         } else {
-          _logger.info('Transfer finished successfully.');
+          _logger.info('Transfer finished successfully (send) sessionId=$sessionId');
         }
       }
     }
@@ -517,6 +518,7 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     if (sessionState == null) {
       return;
     }
+    _logger.info('Transfer canceled by sender (send) sessionId=$sessionId');
     final remoteSessionId = sessionState.remoteSessionId;
 
     _cancelRunningRequests(sessionState);
@@ -541,6 +543,7 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     if (sessionState == null) {
       return;
     }
+    _logger.info('Transfer canceled by receiver (send) sessionId=$sessionId');
     _cancelRunningRequests(sessionState);
 
     state = state.updateSession(

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -478,6 +478,7 @@ class ReceiveController {
       return await request.respondJson(403, message: 'Invalid token');
     }
 
+    _logger.info('Transfer started (receive) sessionId=${receiveState.sessionId} fileId=$fileId');
     // begin of actual file transfer
     server.setState(
       (oldState) => oldState?.copyWith(
@@ -626,7 +627,7 @@ class ReceiveController {
           }
         });
       }
-      _logger.info('Received all files.');
+      _logger.info('Transfer finished successfully (receive) sessionId=${session.sessionId}');
     }
 
     return server.getState().session?.files[fileId]?.status == FileStatus.finished
@@ -796,6 +797,7 @@ class ReceiveController {
       // the server is not running
       return;
     }
+    _logger.info('Transfer canceled by receiver (receive) sessionId=${session.sessionId}');
 
     // notify sender
     try {
@@ -831,6 +833,7 @@ void _cancelBySender(ServerUtils server) {
   if (receiveSession == null) {
     return;
   }
+  _logger.info('Transfer canceled by sender (receive) sessionId=${receiveSession.sessionId}');
 
   if (receiveSession.status == SessionStatus.waiting) {
     // received cancel during accept/decline

--- a/app/lib/util/wakelock/transfer_wakelock_controller.dart
+++ b/app/lib/util/wakelock/transfer_wakelock_controller.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import 'wakelock_service.dart';
+
+final _logger = Logger('TransferWakelock');
+
+class TransferWakelockController {
+  final WakeLockService _service;
+  final bool _enabledForPlatform;
+
+  int _activeTransfers = 0;
+  bool _wakelockEnabled = false;
+  bool _disposed = false;
+
+  TransferWakelockController({
+    required WakeLockService service,
+    required bool enabledForPlatform,
+  }) : _service = service,
+       _enabledForPlatform = enabledForPlatform;
+
+  void setActiveTransfers(int count) {
+    if (_disposed) {
+      return;
+    }
+
+    final normalized = count < 0 ? 0 : count;
+    if (normalized == _activeTransfers) {
+      return;
+    }
+
+    _activeTransfers = normalized;
+    _sync();
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+
+    if (_enabledForPlatform && _wakelockEnabled) {
+      _logger.info('Disabling wakelock on dispose.');
+      _wakelockEnabled = false;
+      await _service.disable();
+    }
+  }
+
+  void _sync() {
+    if (!_enabledForPlatform) {
+      return;
+    }
+
+    final shouldEnable = _activeTransfers > 0;
+    if (shouldEnable == _wakelockEnabled) {
+      return;
+    }
+
+    _wakelockEnabled = shouldEnable;
+    if (shouldEnable) {
+      _logger.info('Enabling wakelock (activeTransfers=$_activeTransfers).');
+      unawaited(_service.enable());
+    } else {
+      _logger.info('Disabling wakelock (activeTransfers=$_activeTransfers).');
+      unawaited(_service.disable());
+    }
+  }
+}

--- a/app/lib/util/wakelock/wakelock_service.dart
+++ b/app/lib/util/wakelock/wakelock_service.dart
@@ -1,0 +1,18 @@
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+abstract class WakeLockService {
+  Future<void> enable();
+  Future<void> disable();
+}
+
+class WakelockPlusService implements WakeLockService {
+  @override
+  Future<void> enable() {
+    return WakelockPlus.enable();
+  }
+
+  @override
+  Future<void> disable() {
+    return WakelockPlus.disable();
+  }
+}

--- a/app/lib/widget/watcher/life_cycle_watcher.dart
+++ b/app/lib/widget/watcher/life_cycle_watcher.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('Lifecycle');
 
 class LifeCycleWatcher extends StatefulWidget {
   final Widget child;
@@ -30,6 +33,7 @@ class _LifeCycleWatcherState extends State<LifeCycleWatcher> with WidgetsBinding
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    _logger.info('App lifecycle changed: $state');
     widget.onChangedState(state);
   }
 }

--- a/app/lib/widget/watcher/transfer_wakelock_watcher.dart
+++ b/app/lib/widget/watcher/transfer_wakelock_watcher.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:common/model/session_status.dart';
+import 'package:flutter/material.dart';
+import 'package:localsend_app/provider/network/send_provider.dart';
+import 'package:localsend_app/provider/network/server/server_provider.dart';
+import 'package:localsend_app/util/native/platform_check.dart';
+import 'package:localsend_app/util/wakelock/transfer_wakelock_controller.dart';
+import 'package:localsend_app/util/wakelock/wakelock_service.dart';
+import 'package:logging/logging.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+final _logger = Logger('TransferWakelockWatcher');
+
+class TransferWakelockWatcher extends StatefulWidget {
+  final Widget child;
+
+  const TransferWakelockWatcher({
+    required this.child,
+    super.key,
+  });
+
+  @override
+  State<TransferWakelockWatcher> createState() => _TransferWakelockWatcherState();
+}
+
+class _TransferWakelockWatcherState extends State<TransferWakelockWatcher> with Refena {
+  late final TransferWakelockController _controller;
+  int _lastActiveTransfers = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TransferWakelockController(
+      service: WakelockPlusService(),
+      enabledForPlatform: checkPlatform([TargetPlatform.iOS]),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sendSessions = ref.watch(sendProvider);
+    final serverState = ref.watch(serverProvider);
+
+    final activeTransfers = _countActiveTransfers(sendSessions, serverState);
+    if (activeTransfers != _lastActiveTransfers) {
+      _lastActiveTransfers = activeTransfers;
+      _logger.info('Active transfers changed: $activeTransfers');
+    }
+    _controller.setActiveTransfers(activeTransfers);
+
+    return widget.child;
+  }
+
+  @override
+  void dispose() {
+    unawaited(_controller.dispose());
+    super.dispose();
+  }
+}
+
+int _countActiveTransfers(Map<String, SendSessionState> sendSessions, ServerState? serverState) {
+  final activeSend = sendSessions.values.where((session) => session.status == SessionStatus.sending).length;
+  final activeReceive = serverState?.session?.status == SessionStatus.sending ? 1 : 0;
+  return activeSend + activeReceive;
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -969,10 +969,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -1703,26 +1703,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/app/test/unit/util/transfer_wakelock_controller_test.dart
+++ b/app/test/unit/util/transfer_wakelock_controller_test.dart
@@ -1,0 +1,77 @@
+import 'package:localsend_app/util/wakelock/transfer_wakelock_controller.dart';
+import 'package:localsend_app/util/wakelock/wakelock_service.dart';
+import 'package:test/test.dart';
+
+class FakeWakeLockService implements WakeLockService {
+  int enableCalls = 0;
+  int disableCalls = 0;
+
+  @override
+  Future<void> enable() async {
+    enableCalls += 1;
+  }
+
+  @override
+  Future<void> disable() async {
+    disableCalls += 1;
+  }
+}
+
+void main() {
+  test('enables only once when transfers start', () {
+    final service = FakeWakeLockService();
+    final controller = TransferWakelockController(
+      service: service,
+      enabledForPlatform: true,
+    );
+
+    controller.setActiveTransfers(1);
+    controller.setActiveTransfers(2);
+
+    expect(service.enableCalls, 1);
+    expect(service.disableCalls, 0);
+  });
+
+  test('disables when last transfer ends', () {
+    final service = FakeWakeLockService();
+    final controller = TransferWakelockController(
+      service: service,
+      enabledForPlatform: true,
+    );
+
+    controller.setActiveTransfers(1);
+    controller.setActiveTransfers(0);
+
+    expect(service.enableCalls, 1);
+    expect(service.disableCalls, 1);
+  });
+
+  test('disables on dispose when active', () async {
+    final service = FakeWakeLockService();
+    final controller = TransferWakelockController(
+      service: service,
+      enabledForPlatform: true,
+    );
+
+    controller.setActiveTransfers(1);
+    await controller.dispose();
+
+    expect(service.enableCalls, 1);
+    expect(service.disableCalls, 1);
+  });
+
+  test('does not disable again on dispose when already idle', () async {
+    final service = FakeWakeLockService();
+    final controller = TransferWakelockController(
+      service: service,
+      enabledForPlatform: true,
+    );
+
+    controller.setActiveTransfers(1);
+    controller.setActiveTransfers(0);
+    await controller.dispose();
+
+    expect(service.enableCalls, 1);
+    expect(service.disableCalls, 1);
+  });
+}


### PR DESCRIPTION
## Problem

On iOS, active transfers can **cancel or fail when the device auto-locks**, as the app may be suspended while the screen is locked.

---

## Solution

- Keep the screen awake **only while at least one transfer is active**
- Automatically release the wakelock when a transfer **completes, fails, or is canceled**
- Apply the behavior **only on iOS** to avoid unintended changes on other platforms

---

## Testing

- `flutter test` — **passed**
- Added **unit tests** for the wakelock controller:
  - enables on first active transfer
  - disables when the last transfer ends

---

## Notes / Non-Goals

- This change **does not implement background networking on iOS**
- The fix is intentionally scoped to a **temporary wakelock during active transfers**, in line with iOS platform constraints
