### PR TITLE
Fix: Allow multiple folders and files during one drag and drop

### DIFF
--- a/app/lib/pages/home_page.dart
+++ b/app/lib/pages/home_page.dart
@@ -84,20 +84,14 @@ class _HomePageState extends State<HomePage> with Refena {
         });
       },
       onDragDone: (event) async {
-        if (event.files.length == 1 && Directory(event.files.first.path).existsSync()) {
-          // user dropped a directory
-          await ref.redux(selectedSendingFilesProvider).dispatchAsync(AddDirectoryAction(event.files.first.path));
-        } else {
-          // user dropped one or more files
-          await ref
-              .redux(selectedSendingFilesProvider)
-              .dispatchAsync(
-                AddFilesAction(
-                  files: event.files,
-                  converter: CrossFileConverters.convertXFile,
-                ),
-              );
-        }
+        await ref
+            .redux(selectedSendingFilesProvider)
+            .dispatchAsync(
+              AddXFilesAction(
+                files: event.files,
+                converter: CrossFileConverters.convertXFile,
+              ),
+            );
         vm.changeTab(HomeTab.send);
       },
       child: ResponsiveBuilder(


### PR DESCRIPTION
**Platforms:**
Windows, Linux

**Problem:**
When attempting to transfer multiple files and folders via drag and drop, nothing happens. This issue was also previously reported at https://github.com/localsend/localsend/issues/2879.

**Solution:**
The condition in home_page.dart doesn't take into account that multiple folders, or, for example, a folder and a file, can be transferred. I added a separate handler for the XFile array, which -
1) For files - adds them
2) For folders - lists their contents and adds them