### PR TITLE
fix: receive history missing entries on concurrent receives

### DIFF
--- a/app/lib/provider/receive_history_provider.dart
+++ b/app/lib/provider/receive_history_provider.dart
@@ -1,8 +1,7 @@
-import 'dart:async';
-
 import 'package:common/model/file_type.dart';
 import 'package:localsend_app/model/persistence/receive_history_entry.dart';
 import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:mutex/mutex.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 
 const _maxHistoryEntries = 30;
@@ -12,50 +11,21 @@ const _maxHistoryEntries = 30;
 /// The lock is acquired in `before()` and released in `after()` because Refena
 /// applies the state transition after `reduce()` returns. Locking only inside
 /// `reduce()` can allow the next action to observe the pre-transition state.
-///
-/// This lock is not re-entrant.
-class _AsyncLock {
-  Future<void> _tail = Future.value();
-
-  Future<_LockGuard> acquire() async {
-    final gate = Completer<void>();
-    final previous = _tail;
-    _tail = previous.then((_) => gate.future);
-    await previous;
-
-    return _LockGuard._(gate);
-  }
-}
-
-class _LockGuard {
-  final Completer<void> _gate;
-  bool _released = false;
-
-  _LockGuard._(this._gate);
-
-  void release() {
-    if (_released) {
-      return;
-    }
-    _released = true;
-    if (!_gate.isCompleted) {
-      _gate.complete();
-    }
-  }
-}
-
 abstract class _ReceiveHistoryWriteAction extends AsyncReduxAction<ReceiveHistoryService, List<ReceiveHistoryEntry>> {
-  _LockGuard? _guard;
+  bool _lockAcquired = false;
 
   @override
   Future<void> before() async {
-    _guard = await notifier._lock.acquire();
+    await notifier._lock.acquire();
+    _lockAcquired = true;
   }
 
   @override
   void after() {
-    _guard?.release();
-    _guard = null;
+    if (_lockAcquired) {
+      notifier._lock.release();
+      _lockAcquired = false;
+    }
   }
 }
 
@@ -67,7 +37,7 @@ final receiveHistoryProvider = ReduxProvider<ReceiveHistoryService, List<Receive
 
 class ReceiveHistoryService extends ReduxNotifier<List<ReceiveHistoryEntry>> {
   final PersistenceService _persistence;
-  final _AsyncLock _lock = _AsyncLock();
+  final Mutex _lock = Mutex();
 
   ReceiveHistoryService(this._persistence);
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -997,6 +997,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.5"
+  mutex:
+    dependency: "direct main"
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   nanoid2:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   # macos_dock_progress: 1.1.0
   mime: 1.0.6
   moform: 0.2.5
+  mutex: 3.1.0
   nanoid2: 2.0.1
   network_info_plus: 6.1.1
   open_dir: 0.0.2+1


### PR DESCRIPTION
## Summary
Fix a race where receive history could drop entries when multiple receives finish close together.

## Reproduction
1. Send two very small files (e.g. text) to a device at the same time.
2. Both received, but History shows only one.

## Fix
1. Serialize receive history writes.
2. Add regression test for concurrent adds.