### PR TITLE
fix: guard RefenaScope.defaultRef access in tray helper (#2927)

### DIFF
--- a/app/lib/util/native/tray_helper.dart
+++ b/app/lib/util/native/tray_helper.dart
@@ -72,7 +72,11 @@ Future<void> hideToTray() async {
   }
 
   // Disable animations
-  RefenaScope.defaultRef.notifier(sleepProvider).setState((_) => true);
+  try {
+    RefenaScope.defaultRef.notifier(sleepProvider).setState((_) => true);
+  } catch (e) {
+    _logger.warning('Failed to update sleep state (Refena not yet initialized)', e);
+  }
 }
 
 Future<void> showFromTray() async {
@@ -86,7 +90,11 @@ Future<void> showFromTray() async {
   }
 
   // Enable animations
-  RefenaScope.defaultRef.notifier(sleepProvider).setState((_) => false);
+  try {
+    RefenaScope.defaultRef.notifier(sleepProvider).setState((_) => false);
+  } catch (e) {
+    _logger.warning('Failed to update sleep state (Refena not yet initialized)', e);
+  }
 }
 
 Future<void> destroyTray() async {


### PR DESCRIPTION
## Problem

When LocalSend is configured to autostart hidden in system tray (Linux/Wayland/Gnome), 
[hideToTray()](cci:1://file:///c:/Users/da983/%E6%96%B0%E5%BB%BA%E6%96%87%E4%BB%B6%E5%A4%B9%20%2810%29/localsend/app/lib/util/native/tray_helper.dart:65:0-79:1) is called via `doWhenWindowReady` before `RefenaScope.defaultRef` is 
initialized, causing `LateInitializationError` and a crash.

## Root Cause

In `preInit()` (`config/init.dart`), the `doWhenWindowReady` callback is registered at 
line 132, but `RefenaContainer` is created later at line 147, and `RefenaScope.defaultRef` 
is only set when `RefenaScope.withContainer` is mounted in the widget tree via `runApp()`.

If the native window becomes ready before the widget tree is built, [hideToTray()](cci:1://file:///c:/Users/da983/%E6%96%B0%E5%BB%BA%E6%96%87%E4%BB%B6%E5%A4%B9%20%2810%29/localsend/app/lib/util/native/tray_helper.dart:65:0-79:1) 
accesses the uninitialized `defaultRef` → crash.

## Fix

Wrapped `RefenaScope.defaultRef` access in [hideToTray()](cci:1://file:///c:/Users/da983/%E6%96%B0%E5%BB%BA%E6%96%87%E4%BB%B6%E5%A4%B9%20%2810%29/localsend/app/lib/util/native/tray_helper.dart:65:0-79:1) and [showFromTray()](cci:1://file:///c:/Users/da983/%E6%96%B0%E5%BB%BA%E6%96%87%E4%BB%B6%E5%A4%B9%20%2810%29/localsend/app/lib/util/native/tray_helper.dart:81:0-97:1) with 
try-catch. This is safe because:

- `sleepProvider` is already initialized with the correct `startHidden` value via 
  `overrideWithInitialState` in `preInit()`
- The window hide/show operations (`windowManager.hide/show`) are unaffected
- A warning log is emitted if the catch triggers, aiding future debugging

## Error from issue
