### PR TITLE
feat: add target for windows arm builds

### DIFF
--- a/app/rust_builder/cargokit/build_tool/lib/src/target.dart
+++ b/app/rust_builder/cargokit/build_tool/lib/src/target.dart
@@ -47,6 +47,10 @@ class Target {
       flutter: 'windows-x64',
     ),
     Target(
+      rust: 'aarch64-pc-windows-msvc',
+      flutter: 'windows-arm64',
+    ),
+    Target(
       rust: 'x86_64-unknown-linux-gnu',
       flutter: 'linux-x64',
     ),


### PR DESCRIPTION
Basically 2 things kept users from building their own Windows Arm64 copy of LocalSend:

- Upstream rhttp with no windows-arm64 target support, which can be solved in the following Pull Request

https://codeberg.org/Tienisto/rhttp/pulls/98
Of course the LocalSend code base should also bump rhttp version to sync upstream changes.

- app/rust_builder/cargokit with no windows-arm64 target support, which can be solved in this Pull Request
