### PR TITLE
refactor: update deprecated flutter pub run to dart run

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build generated files
         working-directory: app
-        run: flutter pub run build_runner build -d
+        run: dart run build_runner build -d
 
       - name: Upload updated lib files with generated code
         uses: actions/upload-artifact@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ After you have installed [Flutter](https://flutter.dev), then you can start this
 ```shell
 cd app
 flutter pub get
-flutter pub run build_runner build -d
+dart run build_runner build -d
 flutter run
 ```
 

--- a/scripts/compile_android_apk.sh
+++ b/scripts/compile_android_apk.sh
@@ -24,7 +24,7 @@ git submodule update --init
 alias flutter='submodules/flutter/bin/flutter'
 flutter config --no-analytics
 flutter pub get
-flutter pub run build_runner build -d
+dart run build_runner build -d
 flutter build apk
 
 popd

--- a/scripts/compile_windows_msix_store.ps1
+++ b/scripts/compile_windows_msix_store.ps1
@@ -4,7 +4,7 @@
 
 fvm flutter clean
 fvm flutter pub get
-fvm flutter pub run build_runner build -d
+fvm dart run build_runner build -d
 fvm flutter pub run msix:create --store
 
 Move-Item -Path build/windows/x64/runner/Release/localsend_app.msix -Destination LocalSend-XXX-windows-x86-64-store.msix


### PR DESCRIPTION
### Description

This PR updates the recommended build and code-generation commands from `flutter pub run` to `dart run`.

As of recent Flutter/Dart releases, `flutter pub run` has been deprecated in favor of the unified `dart run` toolchain. In some environments, continuing to use the old syntax triggers a deprecation warning or fails to parse flags (like `--delete-conflicting-outputs` or `-d`) correctly.

Fixes: #2961 

### Changes

* **Documentation**: Updated `CONTRIBUTING.md` (and any other build guides) to reflect the modern command.
* **Build System**: Updated internal scripts/references to use:
* `dart run build_runner build -d` instead of `flutter pub run build_runner build -d`.
* `dart run msix:create` for Windows builds (where applicable).

### Why this is necessary

Using deprecated commands can lead to "Unhandled exception: Could not find an option or flag" errors in newer Flutter SDK versions, hindering the onboarding process for new contributors.