### PR TITLE
fix: migrate to dart run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ You can help in translating this app to other languages!
 3. Optional: Re-run this app
    1. Run `cd app` to enter the app directory.
    2. Make sure you have [run](#run) this app once.
-   3. Update translations via `flutter pub run slang`
+   3. Update translations via `dart run slang`
    4. Run the app via `flutter run`
 4. Open a pull request
 

--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ flutter build windows
 **Local MSIX App**
 
 ```bash
-flutter pub run msix:create
+dart run msix:create
 ```
 
 **Store ready**
 
 ```bash
-flutter pub run msix:create --store
+dart run msix:create --store
 ```
 
 ### Linux

--- a/scripts/compile_linux_appimage.sh
+++ b/scripts/compile_linux_appimage.sh
@@ -20,7 +20,7 @@ alias flutter='submodules/flutter/bin/flutter'
 
 flutter clean
 flutter pub get
-flutter pub run build_runner build -d
+dart run build_runner build -d
 flutter build linux
 
 rm -rf AppDir

--- a/scripts/compile_windows_msix_store.ps1
+++ b/scripts/compile_windows_msix_store.ps1
@@ -5,7 +5,7 @@
 fvm flutter clean
 fvm flutter pub get
 fvm dart run build_runner build -d
-fvm flutter pub run msix:create --store
+fvm dart run msix:create --store
 
 Move-Item -Path build/windows/x64/runner/Release/localsend_app.msix -Destination LocalSend-XXX-windows-x86-64-store.msix
 


### PR DESCRIPTION
Add ON To: #2962 
Fixes: #2961 

I've checked offical docs for the changes I've listed them below and all of them recommend using `dart run` instead of `flutter pub run`
- [misx](https://pub.dev/packages/msix) 
- [slang](https://pub.dev/packages/slang)