### PR TITLE
fixed AppImage version

### DIFF
--- a/scripts/compile_linux_appimage.sh
+++ b/scripts/compile_linux_appimage.sh
@@ -28,6 +28,10 @@ rm -rf appimage-build
 
 mkdir AppDir
 cp -r build/linux/x64/release/bundle/* AppDir
+
+APP_VERSION=$(grep '^version:' app/pubspec.yaml | sed 's/version: //; s/+.*//')
+sed -i "s/version: latest/version: $APP_VERSION/" scripts/appimage/AppImageBuilder_x86_64.yml
+
 appimage-builder
 sudo chmod +x LocalSend-latest-x86_64.AppImage
 


### PR DESCRIPTION
This PR should:
- Fix https://github.com/localsend/localsend/issues/2978
- Fix https://github.com/localsend/localsend/issues/2019 
- Fix https://github.com/localsend/localsend/issues/2851 (maybe, im not sure).

The Version of the compiled AppImage is not correct, it is always shown as "latest".
I fixed this with a small change in scripts/compile_linux_appimage.sh.
Now the script gets the actual version from pubspec.yaml and writes it into the temporary builder yml file.
This Solution does include absolutely no additional work for the Devs.

I tested the snippet on my Local Machine.
