### PR TITLE
fix: resolve text and widget overflow in APK Picker page (#2973)

### DIFF
--- a/app/lib/pages/apk_picker_page.dart
+++ b/app/lib/pages/apk_picker_page.dart
@@ -222,9 +222,9 @@ class _ApkPickerPageState extends State<ApkPickerPage> with Refena {
                                   children: [
                                     Text(
                                       app.appName,
-                                      maxLines: 1,
-                                      overflow: TextOverflow.fade,
-                                      softWrap: false,
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis,
+                                      softWrap: true,
                                     ),
                                     Consumer(
                                       builder: (context, ref) {


### PR DESCRIPTION
# Description

This PR resolves issue #2973, where the **APK Picker page** UI would experience text and widget overflow errors when the device font or display size was set to **Large** or **Extra Large**.

## Changes
The following changes were made in `app/lib/pages/apk_picker_page.dart`:
- Changed `maxLines` from `1` to `2` for the application name to provide more space for longer names or larger font settings.
- Updated `overflow` from `TextOverflow.fade` to `TextOverflow.ellipsis` to better represent truncated text.
- Set `softWrap` to `true` to allow the text to wrap naturally instead of cutting off abruptly.

## Related Issue
Fixes #2973

## UI Impact
The app name in the APK picker list now correctly handles larger accessibility font settings by wrapping gracefully to a second line and using ellipsis when necessary, preventing visual overflow errors.

## Screenshots
Before:

https://github.com/user-attachments/assets/40b53445-375c-4577-b626-aaf0f57a0747



After:

https://github.com/user-attachments/assets/2f6fcda4-f180-4cfc-bbba-7a949b442845

