### PR TITLE
fix: improve Turkish and Azerbaijani translations

### DIFF
--- a/app/assets/i18n/az.json
+++ b/app/assets/i18n/az.json
@@ -115,14 +115,13 @@
       "title": "Qəbul et",
       "quickSave": "@:general.quickSave",
       "quickSaveFromFavorites": "@:general.quickSaveFromFavorites",
-      "autoFinish": "Avtomatik Bitirmə",
       "requirePin": "@:webSharePage.requirePin",
+      "autoFinish": "Avtomatik Bitirmə",
       "destination": "Qovluqda yadda saxla",
       "downloads": "(Yüklənənlər)",
       "saveToGallery": "Medianı qalereyada yadda saxla",
       "saveToHistory": "Tarixçədə yadda saxla"
     },
-    "advancedSettings": "Qabaqcıl parametrlər",
     "send": {
       "title": "Göndər",
       "shareViaLinkAutoAccept": "\"Keçid vasitəsilə paylaş\" rejimində sorğuları avtomatik qəbul et"
@@ -135,18 +134,18 @@
       "deviceType": "Cihazın tipi",
       "deviceModel": "Cihazın modeli",
       "port": "Port",
-      "discoveryTimeout": "Axtarışın zaman aşımı",
-      "useSystemName": "Sistemin adından istifadə et",
-      "generateRandomAlias": "Təsadüfi ad yarat",
-      "portWarning": "Fərdi portdan istifadə etdiyiniz üçün başqa cihazlar tərəfindən aşkarlanmaya bilərsiniz. (defolt: {defaultPort})",
-      "multicastGroup": "Multicast ünvanı",
-      "encryption": "Şifrələmə",
-      "multicastGroupWarning": "Fərdi multicast ünvanından istifadə etdiyiniz üçün başqa cihazlar tərəfindən aşkarlanmaya bilərsiniz. (defolt: {defaultMulticast})",
       "network": "Şəbəkə",
       "networkOptions": {
         "all": "Hamısı",
         "filtered": "Filtrlənmiş"
-      }
+      },
+      "discoveryTimeout": "Axtarışın zaman aşımı",
+      "useSystemName": "Sistemin adından istifadə et",
+      "generateRandomAlias": "Təsadüfi ad yarat",
+      "portWarning": "Fərdi portdan istifadə etdiyiniz üçün başqa cihazlar tərəfindən aşkarlanmaya bilərsiniz. (defolt: {defaultPort})",
+      "encryption": "Şifrələmə",
+      "multicastGroup": "Multicast ünvanı",
+      "multicastGroupWarning": "Fərdi multicast ünvanından istifadə etdiyiniz üçün başqa cihazlar tərəfindən aşkarlanmaya bilərsiniz. (defolt: {defaultMulticast})"
     },
     "other": {
       "title": "Digər",
@@ -154,78 +153,145 @@
       "donate": "İanə et",
       "privacyPolicy": "Məxfilik siyasəti",
       "termsOfUse": "İstifadə şərtləri"
+    },
+    "advancedSettings": "Qabaqcıl parametrlər"
+  },
+  "troubleshootPage": {
+    "title": "Problemləri həll etmə",
+    "subTitle": "Tətbiq gözlənildiyi kimi işləmir? Burada problemlərin ümumi həll yollarını tapa bilərsiniz.",
+    "solution": "Həll:",
+    "fixButton": "Avtomatik düzəlt",
+    "firewall": {
+      "symptom": "Bu cihaz digər cihazlara fayl göndərə bilər, lakin qəbul edə bilməz.",
+      "solution": "Bu, çox güman ki, firewall problemidir. Siz {port} portunda daxil olan bağlantılara (UDP və TCP) icazə verməklə bunu həll edə bilərsiniz.",
+      "openFirewall": "Şəbəkə ekranını (firewall) aç"
+    },
+    "noDiscovery": {
+      "symptom": "Bu cihaz digər cihazları aşkar edə bilməz.",
+      "solution": "Zəhmət olmasa, bütün cihazların eyni Wi-Fi şəbəkəsində olduğundan və eyni konfiqurasiyanı (port, multicast ünvanı, şifrələmə) paylaşdığından əmin olun. Hədəf cihazın IP ünvanını əl ilə yazmağı cəhd edə bilərsiniz. Əgər bu işə yararsa, gələcəkdə avtomatik aşkarlanması üçün bu cihazı sevimlilərə əlavə etməyi nəzərdən keçirin."
+    },
+    "noConnection": {
+      "symptom": "Hər iki cihaz bir-birini aşkarlaya bilmir və faylları paylaşa bilmir.",
+      "solution": "Problem hər iki tərəfdə də var? Əgər belədirsə, hər iki cihazın eyni Wi-Fi şəbəkəsində olduğundan və eyni konfiqurasiyanı (port, multicast ünvanı, şifrələmə) paylaşdığından əmin olmalısınız. Wi-Fi şəbəkəsi Access Point (AP) izolyasiyasına görə iştirakçılar arasında ünsiyyətə icazə verməyə bilər. Bu halda, bu seçim ruterdə söndürülməlidir."
     }
   },
+  "networkInterfacesPage": {
+    "title": "Şəbəkə interfeysləri",
+    "info": "Defolt olaraq, LocalSend bütün mövcud şəbəkə interfeyslərindən istifadə edir. Burada istənilməyən şəbəkələri istisna edə bilərsiniz. Dəyişiklikləri tətbiq etmək üçün serveri yenidən başlatmalısınız.",
+    "preview": "Önizlə",
+    "whitelist": "Ağ siyahı",
+    "blacklist": "Qara siyahı"
+  },
   "receiveHistoryPage": {
+    "title": "Tarixçə",
     "openFolder": "Qovluğu aç",
     "deleteHistory": "Tarixçəni sil",
-    "title": "Tarixçə",
+    "empty": "Tarixçə boşdur.",
     "entryActions": {
-      "deleteFromHistory": "Tarixçədən sil",
       "open": "Faylı aç",
       "showInFolder": "Qovluqda göstər",
-      "info": "Məlumat"
+      "info": "Məlumat",
+      "deleteFromHistory": "Tarixçədən sil"
+    }
+  },
+  "apkPickerPage": {
+    "title": "Tətbiqlər (APK)",
+    "excludeSystemApps": "Sistem tətbiqlərini istisna et",
+    "excludeAppsWithoutLaunchIntent": "Açıla bilməyən tətbiqləri istisna et",
+    "apps": "{n} tətbiq"
+  },
+  "selectedFilesPage": {
+    "deleteAll": "Hamısını sil"
+  },
+  "receivePage": {
+    "subTitle": {
+      "one": "sənə fayl göndərmək istəyir",
+      "other": "sənə {n} fayl göndərmək istəyir"
     },
-    "empty": "Tarixçə boşdur."
+    "subTitleMessage": "sənə mesaj göndərdi:",
+    "subTitleLink": "sənə keçid göndərdi:",
+    "canceled": "Göndərən bu sorğunu ləğv etdi."
+  },
+  "receiveOptionsPage": {
+    "title": "Seçimlər",
+    "destination": "@:settingsTab.receive.destination",
+    "appDirectory": "(LocalSend qovluğu)",
+    "saveToGallery": "@:settingsTab.receive.saveToGallery",
+    "saveToGalleryOff": "Qovluqlar olduğu üçün avtomatik söndürülür."
+  },
+  "sendPage": {
+    "waiting": "Qarşı tərəfdən cavab gözlənilir…",
+    "rejected": "Qəbul edən bu sorğudan imtina etdi.",
+    "tooManyAttempts": "@:web.tooManyAttempts",
+    "busy": "Qəbul edən başqa sorğu ilə məşğuldur."
+  },
+  "progressPage": {
+    "titleSending": "Fayllar göndərilir",
+    "titleReceiving": "Fayllar qəbul edilir",
+    "savedToGallery": "Qalereyada saxlanıldı",
+    "total": {
+      "title": {
+        "sending": "Ümumi proses ({time})",
+        "finishedError": "Proses xəta verərək dayandı",
+        "canceledSender": "Göndərən tərəfindən dayandırıldı",
+        "canceledReceiver": "Qəbul edən tərəfindən dayandırıldı"
+      },
+      "count": "Fayl: {curr} / {n}",
+      "size": "Ölçü: {curr} / {n}",
+      "speed": "Sürət: {speed}/s"
+    },
+    "remainingTime": {
+      "seconds": "{n}:{ss}",
+      "minutes": "{n}:{ss}",
+      "hours": "{h}s {m}d",
+      "days": "{d}g {h}s {m}d",
+      "@hours": "Saat üçün 's', dəqiqə üçün 'd' istifadə edin",
+      "@days": "Gün üçün 'g', saat üçün 's', dəqiqə üçün 'd' istifadə edin"
+    }
+  },
+  "webSharePage": {
+    "title": "Keçid vasitəsilə paylaş",
+    "loading": "Server aktivləşdirilir…",
+    "stopping": "Server dayandırılır…",
+    "error": "Serveri aktivləşdirərkən xəta baş verdi.",
+    "openLink": {
+      "one": "Bu keçidi brauzerdə aç:",
+      "other": "Bu keçidlərdən birini brauzerdə aç:"
+    },
+    "requests": "Sorğular",
+    "noRequests": "Hələ ki, heç bir sorğu yoxdur.",
+    "encryption": "@:settingsTab.network.encryption",
+    "autoAccept": "Sorğuları avtomatik qəbul et",
+    "requirePin": "PIN tələb et",
+    "pinHint": "Sizin PIN: \"{pin}\"",
+    "encryptionHint": "LocalSend özü imzalanmış sertifikatdan istifadə edir. Siz onu brauzerinizdə qəbul etməlisiniz.",
+    "pendingRequests": "Gözləyən sorğular: {n}"
+  },
+  "aboutPage": {
+    "title": "LocalSend haqqında",
+    "description": [
+      "LocalSend internet bağlantısına ehtiyac olmadan lokal şəbəkə üzərindən yaxınlıqdakı cihazlarla faylları və mesajları təhlükəsiz paylaşmağa imkan verən pulsuz, açıq mənbəli proqramdır.",
+      "Bu proqram Android, iOS, macOS, Windows və Linux sistemlərində mövcuddur. Bütün yükləmə variantlarını rəsmi saytda tapa bilərsiniz."
+    ],
+    "author": "Müəllif",
+    "contributors": "Töhfə verənlər",
+    "packagers": "Paketləyənlər",
+    "translators": "Tərcüməçilər"
+  },
+  "donationPage": {
+    "title": "İanə et",
+    "info": "LocalSend pulsuz, açıq mənbəlidir və heç bir reklam yoxdur. Proqramı bəyənirsinizsə, ianə ilə inkişafını dəstəkləyə bilərsiniz.",
+    "donate": "{amount} ianə et",
+    "thanks": "Çox təşəkkür edirəm!",
+    "restore": "Satın almaları bərpa et"
+  },
+  "changelogPage": {
+    "title": "Versiya jurnalı"
+  },
+  "aliasGenerator(ignoreMissing, ignoreGpt)": {
+    "@info": "Fərqli dillərdə fərqli sözlər ola bilər, 1:1 uyğun olmaya bilər"
   },
   "dialogs": {
-    "noFiles": {
-      "title": "Heç bir fayl seçilməyib",
-      "content": "Zəhmət olmasa, ən azı bir fayl seçin."
-    },
-    "fileInfo": {
-      "size": "Ölçüsü:",
-      "path": "Yol:",
-      "sender": "Göndərən:",
-      "title": "Fayl məlumatı",
-      "fileName": "Faylın adı:",
-      "time": "Vaxt:"
-    },
-    "qr": {
-      "title": "QR-kod"
-    },
-    "historyClearDialog": {
-      "content": "Bütün tarixçəni silmək istədiyinizə əminsiniz?",
-      "title": "Tarixçəni təmizlə"
-    },
-    "localNetworkUnauthorized": {
-      "title": "@:dialogs.noPermission.title",
-      "description": "LocalSend lokal şəbəkəni skan etmək icazəsi olmadan digər cihazları tapa bilmir. Zəhmət olmasa, parametrlərdən bu icazəni verin.",
-      "gotoSettings": "Parametrlər"
-    },
-    "quickSaveFromFavoritesNotice": {
-      "content": [
-        "Fayl sorğuları artıq sevimlilər siyahısındakı cihazlardan avtomatik qəbul edəcək.",
-        "Xəbərdarlıq! Hal-hazırda bu, tamamilə təhlükəsiz deyil, çünki sevimlilər siyahısındakı istənilən cihazın barmaq izinə sahib olan haker məhdudiyyətsiz sizə fayllar göndərə bilər.",
-        "Bununla belə, bu seçim lokal şəbəkədəki bütün istifadəçilərin sizə məhdudiyyətsiz fayllar göndərməsinə icazə verməkdən daha təhlükəsizdir."
-      ],
-      "title": "@:general.quickSaveFromFavorites"
-    },
-    "pin": {
-      "title": "PIN-i daxil et"
-    },
-    "sendModeHelp": {
-      "title": "Göndərmə rejimləri",
-      "single": "Faylları bir cihaza göndərir. Faylların ötürülməsi başa çatdıqdan sonra seçim silinəcək.",
-      "multiple": "Faylları birdən çox cihaza göndərir. Faylların ötürülməsi tamamlandıqdan sonra seçim silinməyəcək.",
-      "link": "LocalSend-i quraşdırmamış alıcılar linki brauzerlərində açaraq seçilmiş faylları endirə bilərlər."
-    },
-    "favoriteDialog": {
-      "addFavorite": "Əlavə et",
-      "title": "Sevimlilər",
-      "noFavorites": "Hələ ki, sevimli cihaz yoxdur."
-    },
-    "errorDialog": {
-      "title": "@:general.error"
-    },
-    "favoriteEditDialog": {
-      "titleAdd": "Sevimlilərə əlavə et",
-      "titleEdit": "Parametrlər",
-      "name": "Cihazın adı",
-      "auto": "(avtomatik)",
-      "ip": "IP ünvan",
-      "port": "Port"
-    },
     "addFile": {
       "title": "Seçilmişlərə əlavə et",
       "content": "Nə əlavə etmək istəyirsiniz?"
@@ -252,17 +318,54 @@
       "title": "Şifrələmə deaktiv edilib",
       "content": "Əlaqə artıq şifrələnməmiş HTTP protokolu vasitəsilə həyata keçirilir. HTTPS protokolundan istifadə etmək üçün şifrələməni yenidən aktiv edin."
     },
+    "errorDialog": {
+      "title": "@:general.error"
+    },
+    "favoriteDialog": {
+      "title": "Sevimlilər",
+      "noFavorites": "Hələ ki, sevimli cihaz yoxdur.",
+      "addFavorite": "Əlavə et"
+    },
     "favoriteDeleteDialog": {
       "title": "Sevimlilərdən sil",
       "content": "Həqiqətən də \"{name}\" cihazını sevimlilərdən silmək istəyirsiniz?"
+    },
+    "favoriteEditDialog": {
+      "titleAdd": "Sevimlilərə əlavə et",
+      "titleEdit": "Parametrlər",
+      "name": "Cihazın adı",
+      "auto": "(avtomatik)",
+      "ip": "IP ünvan",
+      "port": "Port"
+    },
+    "fileInfo": {
+      "title": "Fayl məlumatı",
+      "fileName": "Faylın adı:",
+      "path": "Yol:",
+      "size": "Ölçüsü:",
+      "sender": "Göndərən:",
+      "time": "Vaxt:"
     },
     "fileNameInput": {
       "title": "Faylın adını daxil et",
       "original": "Orijinal: {original}"
     },
+    "historyClearDialog": {
+      "title": "Tarixçəni təmizlə",
+      "content": "Bütün tarixçəni silmək istədiyinizə əminsiniz?"
+    },
+    "localNetworkUnauthorized": {
+      "title": "@:dialogs.noPermission.title",
+      "description": "LocalSend lokal şəbəkəni skan etmək icazəsi olmadan digər cihazları tapa bilmir. Zəhmət olmasa, parametrlərdən bu icazəni verin.",
+      "gotoSettings": "Parametrlər"
+    },
     "messageInput": {
       "title": "Mesaj yaz",
       "multiline": "Çoxsətirli"
+    },
+    "noFiles": {
+      "title": "Heç bir fayl seçilməyib",
+      "content": "Zəhmət olmasa, ən azı bir fayl seçin."
     },
     "noPermission": {
       "title": "İcazə yoxdur",
@@ -271,6 +374,9 @@
     "notAvailableOnPlatform": {
       "title": "Mövcud deyil",
       "content": "Bu funksiya sadəcə burada mövcuddur:"
+    },
+    "qr": {
+      "title": "QR-kod"
     },
     "quickActions": {
       "title": "Sürətli hərəkətlər",
@@ -284,74 +390,67 @@
       "title": "@:general.quickSave",
       "content": "Fayl sorğuları artıq avtomatik qəbul ediləcək. Nəzərə alın ki, lokal şəbəkədəki hər kəs sizə fayl göndərə bilər."
     },
+    "quickSaveFromFavoritesNotice": {
+      "title": "@:general.quickSaveFromFavorites",
+      "content": [
+        "Fayl sorğuları artıq sevimlilər siyahısındakı cihazlardan avtomatik qəbul edəcək.",
+        "Xəbərdarlıq! Hal-hazırda bu, tamamilə təhlükəsiz deyil, çünkü sevimlilər siyahısındakı istənilən cihazın barmaq izinə sahib olan haker məhdudiyyətsiz sizə fayllar göndərə bilər.",
+        "Bununla belə, bu seçim lokal şəbəkədəki bütün istifadəçilərin sizə məhdudiyyətsiz fayllar göndərməsinə icazə verməkdən daha təhlükəsizdir."
+      ]
+    },
+    "pin": {
+      "title": "PIN-i daxil et"
+    },
+    "sendModeHelp": {
+      "title": "Göndərmə rejimləri",
+      "single": "Faylları bir cihaza göndərir. Faylların ötürülməsi başa çatdıqdan sonra seçim silinəcək.",
+      "multiple": "Faylları birdən çox cihaza göndərir. Faylların ötürülməsi tamamlandıqdan sonra seçim silinməyəcək.",
+      "link": "LocalSend-i quraşdırmamış alıcılar linki brauzerlərində açaraq seçilmiş faylları endirə bilərlər."
+    },
     "zoom": {
       "title": "URL"
     }
   },
-  "troubleshootPage": {
-    "title": "Problemləri həll etmə",
-    "noDiscovery": {
-      "solution": "Zəhmət olmasa, bütün cihazların eyni Wi-Fi şəbəkəsində olduğundan və eyni konfiqurasiyanı (port, multicast ünvanı, şifrələmə) paylaşdığından əmin olun. Hədəf cihazın IP ünvanını əl ilə yazmağı cəhd edə bilərsiniz. Əgər bu işə yararsa, gələcəkdə avtomatik aşkarlanması üçün bu cihazı sevimlilərə əlavə etməyi nəzərdən keçirin.",
-      "symptom": "Bu cihaz digər cihazları aşkar edə bilməz."
-    },
-    "subTitle": "Tətbiq gözlənildiyi kimi işləmir? Burada problemlərin ümumi həll yollarını tapa bilərsiniz.",
-    "firewall": {
-      "symptom": "Bu cihaz digər cihazlara fayl göndərə bilər, lakin qəbul edə bilməz.",
-      "solution": "Bu, çox güman ki, firewall problemidir. Siz {port} portunda daxil olan bağlantılara (UDP və TCP) icazə verməklə bunu həll edə bilərsiniz.",
-      "openFirewall": "Şəbəkə ekranını (firewall) aç"
-    },
-    "noConnection": {
-      "solution": "Problem hər iki tərəfdə də var? Əgər belədirsə, hər iki cihazın eyni Wi-Fi şəbəkəsində olduğundan və eyni konfiqurasiyanı (port, multicast ünvanı, şifrələmə) paylaşdığından əmin olmalısınız. Wi-Fi şəbəkəsi Access Point (AP) izolyasiyasına görə iştirakçılar arasında ünsiyyətə icazə verməyə bilər. Bu halda, bu seçim ruterdə söndürülməlidir.",
-      "symptom": "Hər iki cihaz bir-birini aşkarlaya bilmir və faylları paylaşa bilmir."
-    },
-    "solution": "Həll:",
-    "fixButton": "Avtomatik düzəlt"
+  "sanitization": {
+    "empty": "Fayl adı boş ola bilməz",
+    "invalid": "Fayl adında etibarsız simvollar ola bilməz"
   },
-  "webSharePage": {
-    "stopping": "Server dayandırılır…",
-    "pendingRequests": "Gözləyən sorğular: {n}",
-    "loading": "Server aktivləşdirilir…",
-    "error": "Serveri aktivləşdirərkən xəta baş verdi.",
-    "openLink": {
-      "one": "Bu keçidi brauzerdə aç:",
-      "other": "Bu keçidlərdən birini brauzerdə aç:"
-    },
-    "title": "Keçid vasitəsilə paylaş",
-    "requests": "Sorğular",
-    "noRequests": "Hələ ki, heç bir sorğu yoxdur.",
-    "encryption": "@:settingsTab.network.encryption",
-    "autoAccept": "Sorğuları avtomatik qəbul et",
-    "requirePin": "PIN tələb et",
-    "pinHint": "Sizin PIN: \"{pin}\"",
-    "encryptionHint": "LocalSend özü imzalanmış sertifikatdan istifadə edir. Siz onu brauzerinizdə qəbul etməlisiniz."
+  "tray": {
+    "@info": "Apple təlimatları \"bağla\" ifadələri ilə bağlı çox ciddidir.",
+    "open": "@:general.open",
+    "close": "LocalSend-dən çıx",
+    "closeWindows": "Çıxış"
   },
-  "networkInterfacesPage": {
-    "info": "Defolt olaraq, LocalSend bütün mövcud şəbəkə interfeyslərindən istifadə edir. Burada istənilməyən şəbəkələri istisna edə bilərsiniz. Dəyişiklikləri tətbiq etmək üçün serveri yenidən başlatmalısınız.",
-    "whitelist": "Ağ siyahı",
-    "blacklist": "Qara siyahı",
-    "title": "Şəbəkə interfeysləri",
-    "preview": "Önizlə"
+  "web": {
+    "waiting": "@:sendPage.waiting",
+    "enterPin": "PIN-i daxil et",
+    "invalidPin": "Səhv PIN",
+    "tooManyAttempts": "Çoxsaylı cəhd",
+    "rejected": "Rədd edildi",
+    "files": "Fayllar",
+    "fileName": "Fayl adı",
+    "size": "Ölçü"
   },
   "assetPicker": {
-    "accessiblePathName": "Əlçatan fayllar",
-    "sTypeAudioLabel": "Audio",
+    "@info": "Android və iPhone üçün Media seçim aləti üçün tərcümələr",
+    "confirm": "Təsdiqlə",
+    "cancel": "İmtina",
+    "edit": "Düzəliş et",
+    "gifIndicator": "GIF",
     "loadFailed": "Yükləmə uğursuz oldu",
-    "accessLimitedAssets": "Məhdud icazə ilə davam et",
+    "original": "Orijinal",
     "preview": "Önizləmə",
     "select": "Seç",
     "emptyList": "Boş siyahı",
     "unSupportedAssetType": "Dəstəklənməyən fayl tipi.",
     "unableToAccessAll": "Cihazdakı bütün fayllara daxil olmaq mümkün deyil",
     "viewingLimitedAssetsTip": "Yalnız proqram üçün əlçatan olan fayl və albomlara bax.",
-    "@info": "Android və iPhone üçün Media seçim aləti üçün tərcümələr",
-    "confirm": "Təsdiqlə",
-    "cancel": "İmtina",
-    "edit": "Düzəliş et",
-    "gifIndicator": "GIF",
-    "original": "Orijinal",
     "changeAccessibleLimitedAssets": "Əlçatan faylları yeniləmək üçün kliklə",
     "accessAllTip": "Tətbiq cihazdakı yalnız bəzi fayllara daxil ola bilər. Sistem parametrlərinə gedin və tətbiqin cihazdakı bütün mediaya daxil olmasına icazə verin.",
     "goToSystemSettings": "Sistem parametrlərinə get",
+    "accessLimitedAssets": "Məhdud icazə ilə davam et",
+    "accessiblePathName": "Əlçatan fayllar",
+    "sTypeAudioLabel": "Audio",
     "sTypeImageLabel": "Şəkil",
     "sTypeVideoLabel": "Video",
     "sTypeOtherLabel": "Digər media",
@@ -362,96 +461,5 @@
     "sActionUseCameraHint": "kamera istifadə et",
     "sNameDurationLabel": "müddət",
     "sUnitAssetCountLabel": "say"
-  },
-  "sendPage": {
-    "rejected": "Qəbul edən bu sorğudan imtina etdi.",
-    "waiting": "Qarşı tərəfdən cavab gözlənilir…",
-    "tooManyAttempts": "@:web.tooManyAttempts",
-    "busy": "Qəbul edən başqa sorğu ilə məşğuldur."
-  },
-  "web": {
-    "fileName": "Fayl adı",
-    "files": "Fayllar",
-    "waiting": "@:sendPage.waiting",
-    "enterPin": "PIN-i daxil et",
-    "invalidPin": "Səhv PIN",
-    "tooManyAttempts": "Çoxsaylı cəhd",
-    "rejected": "Rədd edildi",
-    "size": "Ölçü"
-  },
-  "tray": {
-    "closeWindows": "Çıxış",
-    "@info": "Apple təlimatları \"bağla\" ifadələri ilə bağlı çox ciddidir.",
-    "open": "@:general.open",
-    "close": "LocalSend-dən çıx"
-  },
-  "apkPickerPage": {
-    "apps": "{n} tətbiq",
-    "title": "Tətbiqlər (APK)",
-    "excludeSystemApps": "Sistem tətbiqlərini istisna et",
-    "excludeAppsWithoutLaunchIntent": "Açıla bilməyən tətbiqləri istisna et"
-  },
-  "receivePage": {
-    "subTitleLink": "sənə keçid göndərdi:",
-    "canceled": "Göndərən bu sorğunu ləğv etdi.",
-    "subTitle": {
-      "one": "sənə fayl göndərmək istəyir",
-      "other": "sənə {n} fayl göndərmək istəyir"
-    },
-    "subTitleMessage": "sənə mesaj göndərdi:"
-  },
-  "receiveOptionsPage": {
-    "title": "Seçimlər",
-    "destination": "@:settingsTab.receive.destination",
-    "appDirectory": "(LocalSend qovluğu)",
-    "saveToGallery": "@:settingsTab.receive.saveToGallery",
-    "saveToGalleryOff": "Qovluqlar olduğu üçün avtomatik söndürülür."
-  },
-  "progressPage": {
-    "total": {
-      "title": {
-        "canceledSender": "Göndərən tərəfindən dayandırıldı",
-        "sending": "Ümumi proses ({time})",
-        "finishedError": "Proses xəta verərək dayandı",
-        "canceledReceiver": "Qəbul edən tərəfindən dayandırıldı"
-      },
-      "count": "Fayl: {curr} / {n}",
-      "size": "Ölçü: {curr} / {n}",
-      "speed": "Sürət: {speed}/s"
-    },
-    "titleSending": "Fayllar göndərilir",
-    "titleReceiving": "Fayllar qəbul edilir",
-    "savedToGallery": "Qalereyada saxlanıldı"
-  },
-  "donationPage": {
-    "info": "LocalSend pulsuz, açıq mənbəlidir və heç bir reklam yoxdur. Proqramı bəyənirsinizsə, ianə ilə inkişafını dəstəkləyə bilərsiniz.",
-    "title": "İanə et",
-    "donate": "{amount} ianə et",
-    "thanks": "Çox təşəkkür edirəm!",
-    "restore": "Satın almaları bərpa et"
-  },
-  "selectedFilesPage": {
-    "deleteAll": "Hamısını sil"
-  },
-  "aboutPage": {
-    "description": [
-      "LocalSend internet bağlantısına ehtiyac olmadan lokal şəbəkə üzərindən yaxınlıqdakı cihazlarla faylları və mesajları təhlükəsiz paylaşmağa imkan verən pulsuz, açıq mənbəli proqramdır.",
-      "Bu proqram Android, iOS, macOS, Windows və Linux sistemlərində mövcuddur. Bütün yükləmə variantlarını rəsmi saytda tapa bilərsiniz."
-    ],
-    "author": "Müəllif",
-    "contributors": "Töhfə verənlər",
-    "title": "LocalSend haqqında",
-    "packagers": "Paketləyənlər",
-    "translators": "Tərcüməçilər"
-  },
-  "changelogPage": {
-    "title": "Versiya jurnalı"
-  },
-  "aliasGenerator(ignoreMissing, ignoreGpt)": {
-    "@info": "Fərqli dillərdə fərqli sözlər ola bilər, 1:1 uyğun olmaya bilər"
-  },
-  "sanitization": {
-    "empty": "Fayl adı boş ola bilməz",
-    "invalid": "Fayl adında etibarsız simvollar ola bilməz"
   }
 }

--- a/app/assets/i18n/tr.json
+++ b/app/assets/i18n/tr.json
@@ -28,7 +28,7 @@
     "open": "Aç",
     "queue": "Sıra",
     "quickSave": "Hızlı kaydetme",
-    "quickSaveFromFavorites": "Favoriler",
+    "quickSaveFromFavorites": "\"Favoriler\" için Hızlı Kaydet",
     "renamed": "Yeniden adlandırıldı",
     "reset": "Sıfırla",
     "restart": "Yeniden başlat",
@@ -46,7 +46,7 @@
     "infoBox": {
       "ip": "IP:",
       "port": "Port:",
-      "alias": "Takma isminiz:"
+      "alias": "Cihaz adı:"
     },
     "quickSave": {
       "off": "@:general.off",
@@ -103,9 +103,9 @@
       "languageOptions": {
         "system": "Sistem dili"
       },
-      "saveWindowPlacement": "Çıkış: Burayı Kaydet",
+      "saveWindowPlacement": "Çıkıştan sonra pencere konumunu kaydet",
       "saveWindowPlacementWindows": "Çıkıştan sonra pencere konumunu kaydet",
-      "minimizeToTray": "Çıkış: Simge durumuna küçült",
+      "minimizeToTray": "Kapatırken sistem tepsisine/menü çubuğuna küçült",
       "launchAtStartup": "Giriş yapıldıktan sonra otomatik başlat",
       "launchMinimized": "Otomatik başlatma: Gizli Başlatma",
       "showInContextMenu": "LocalSend'i bağlam menüsünde göster",
@@ -114,13 +114,13 @@
     "receive": {
       "title": "Alım",
       "quickSave": "@:general.quickSave",
+      "quickSaveFromFavorites": "@:general.quickSaveFromFavorites",
       "requirePin": "@:webSharePage.requirePin",
       "autoFinish": "Otomatik bitir",
       "destination": "Hedef klasör",
       "downloads": "(İndirilenler)",
       "saveToGallery": "Medyayı galeriye kaydet",
-      "saveToHistory": "Geçmişe kaydet",
-      "quickSaveFromFavorites": "@:general.quickSaveFromFavorites"
+      "saveToHistory": "Geçmişe kaydet"
     },
     "send": {
       "title": "Gönder",
@@ -130,22 +130,22 @@
       "title": "Ağ",
       "needRestart": "Ayarları uygulamak için sunucuyu yeniden başlatınız!",
       "server": "Sunucu",
-      "alias": "Takma isminiz",
+      "alias": "Cihaz adı",
       "deviceType": "Cihaz tipi",
       "deviceModel": "Cihaz modeli",
       "port": "Port",
-      "discoveryTimeout": "Arama zaman aşımına uğradı",
-      "portWarning": "Kişiselleştirilmiş bir port kullanıyorsanız ağınızdaki diğer cihazlar tarafından bulunamayabilirsiniz. (varsayılan: {defaultPort})",
-      "encryption": "Şifreleme",
-      "multicastGroup": "Çoklu yayın",
-      "multicastGroupWarning": "Özel çoklu yayın adresini kullandığınız için diğer cihazlar tarafından algılanamayabilirsiniz.(varsayılan: {defaultMulticast})",
       "network": "Ağ",
       "networkOptions": {
         "all": "Tümü",
         "filtered": "Filtrelenmiş"
       },
+      "discoveryTimeout": "Arama zaman aşımına uğradı",
       "useSystemName": "Sistem adını kullan",
-      "generateRandomAlias": "Rastgele takma ad oluştur"
+      "generateRandomAlias": "Rastgele takma ad oluştur",
+      "portWarning": "Kişiselleştirilmiş bir port kullanıyorsanız ağınızdaki diğer cihazlar tarafından bulunamayabilirsiniz. (varsayılan: {defaultPort})",
+      "encryption": "Şifreleme",
+      "multicastGroup": "Çoklu yayın",
+      "multicastGroupWarning": "Özel çoklu yayın adresini kullandığınız için diğer cihazlar tarafından algılanamayabilirsiniz.(varsayılan: {defaultMulticast})"
     },
     "other": {
       "title": "Diğer",
@@ -175,9 +175,16 @@
       "solution": "Sorun her iki tarafta da var mı? O zaman her iki cihazın da aynı WiFi ağında olduğundan ve aynı yapılandırmayı (bağlantı noktası, çoklu yayın adresi, şifreleme) paylaştığından emin olmanız gerekir. WiFi, katılımcılar arasında iletişime izin vermeyebilir. Bu durumda, bu seçenek yönlendiricide etkinleştirilmelidir."
     }
   },
+  "networkInterfacesPage": {
+    "title": "Ağ Arayüzleri",
+    "info": "Varsayılan olarak, LocalSend mevcut olan tüm ağları kullanır. Burada istenmeyen ağları engelleyebilirsiniz. Değişikliklerin uygulanması için sunucuyu yeniden başlatmanız gerekir.",
+    "preview": "Önizle",
+    "whitelist": "Beyaz liste",
+    "blacklist": "Kara liste"
+  },
   "receiveHistoryPage": {
     "title": "Geçmiş",
-    "openFolder": "Dosyayı aç",
+    "openFolder": "Klasörü aç",
     "deleteHistory": "Geçmişi sil",
     "empty": "Geçmiş yok.",
     "entryActions": {
@@ -235,11 +242,11 @@
     },
     "remainingTime": {
       "seconds": "{n}:{ss}",
-      "@days": "Günler için 'g', saatler için 's' ve dakikalar için 'd' kullanın",
-      "@hours": "Saat kısaltması için 's', dakika kısaltması için 'd' kullanın",
       "minutes": "{n}:{ss}",
       "hours": "{h}s {m}d",
-      "days": "{d}g {h}s {m}d"
+      "days": "{d}g {h}s {m}d",
+      "@hours": "Saat kısaltması için 's', dakika kısaltması için 'd' kullanın",
+      "@days": "Günler için 'g', saatler için 's' ve dakikalar için 'd' kullanın"
     }
   },
   "webSharePage": {
@@ -289,6 +296,10 @@
       "title": "Seçime ekle",
       "content": "Ne eklemek istiyorsunuz ?"
     },
+    "openFile": {
+      "title": "Dosya Aç",
+      "content": "Alınan dosyayı açmak istiyor musunuz?"
+    },
     "addressInput": {
       "title": "Adresi giriniz",
       "hashtag": "Hashtag",
@@ -321,8 +332,8 @@
     },
     "favoriteEditDialog": {
       "titleAdd": "Favorilere ekle",
-      "titleEdit": "Düzenle",
-      "name": "Takma ad",
+      "titleEdit": "Ayarlar",
+      "name": "Cihaz adı",
       "auto": "(otomatik)",
       "ip": "IP Adresi",
       "port": "Port"
@@ -379,6 +390,14 @@
       "title": "@:general.quickSave",
       "content": "Dosya gönderim istekleri otomatik olarak gerçekleşir. Yerel ağınızdaki herkesin size dosya gönderebileceğinin farkında olunuz."
     },
+    "quickSaveFromFavoritesNotice": {
+      "title": "@:general.quickSaveFromFavorites",
+      "content": [
+        "Favoriler listenizdeki cihazların paylaşım istekleri otomatik olarak kabul edilecektir.",
+        "Uyarı! Şu an, bu tamamen güvenli değildir çünkü favoriler listenizdeki herhangi bir cihazın parmak izine sahip olan hackerlar sınırlama olmadan size dosyalar gönderebilir.",
+        "Ancak, bu seçenek yinede ağdaki tüm kullanıcıların size sınırlandırma olmadan dosya göndermesine izin vermekten daha güvenlidir."
+      ]
+    },
     "pin": {
       "title": "PIN girin"
     },
@@ -390,18 +409,6 @@
     },
     "zoom": {
       "title": "URL"
-    },
-    "openFile": {
-      "title": "Dosya Aç",
-      "content": "Alınan dosyayı açmak istiyor musunuz?"
-    },
-    "quickSaveFromFavoritesNotice": {
-      "title": "@:general.quickSaveFromFavorites",
-      "content": [
-        "Favoriler listenizdeki cihazların paylaşım istekleri otomatik olarak kabul edilecektir.",
-        "Uyarı! Şu an, bu tamamen güvenli değildir çünkü favoriler listenizdeki herhangi bir cihazın parmak izine sahip olan hackerlar sınırlama olmadan size dosyalar gönderebilir.",
-        "Ancak, bu seçenek yinede ağdaki tüm kullanıcıların size sınırlandırma olmadan dosya göndermesine izin vermekten daha güvenlidir."
-      ]
     }
   },
   "sanitization": {
@@ -426,7 +433,7 @@
   },
   "assetPicker": {
     "@info": "Translations for the Media selection tool for Android and Iphone",
-    "confirm": "Onay",
+    "confirm": "Onayla",
     "cancel": "İptal",
     "edit": "Düzenle",
     "gifIndicator": "GIF",
@@ -448,18 +455,11 @@
     "sTypeVideoLabel": "Video",
     "sTypeOtherLabel": "Diğer medya",
     "sActionPlayHint": "oynat",
-    "sActionPreviewHint": "Ön izleme",
+    "sActionPreviewHint": "ön izleme",
     "sActionSelectHint": "seç",
     "sActionSwitchPathLabel": "dosya uzantısını değiştir",
-    "sActionUseCameraHint": "Kamera kullan",
+    "sActionUseCameraHint": "kamera kullan",
     "sNameDurationLabel": "süre",
     "sUnitAssetCountLabel": "sayım"
-  },
-  "networkInterfacesPage": {
-    "title": "Ağ Arayüzleri",
-    "preview": "Önizle",
-    "whitelist": "Beyaz liste",
-    "blacklist": "Kara liste",
-    "info": "Varsayılan olarak, LocalSend mevcut olan tüm ağları kullanır. Burada istenmeyen ağları engelleyebilirsiniz. Değişikliklerin uygulanması için sunucuyu yeniden başlatmanız gerekir."
   }
 }


### PR DESCRIPTION
While going through the Turkish and Azerbaijani translation files, 
I noticed a few inaccurate translations and some missing keys. 
Here's what I fixed:

Turkish (tr):
- settingsTab.network.alias: "Takma isminiz" - "Cihaz adı"
- settingsTab.general.saveWindowPlacement: "Çıkış: Burayı Kaydet" - "Çıkıştan sonra pencere konumunu kaydet"
- settingsTab.general.minimizeToTray: "Çıkış: Simge durumuna küçült" - "Kapatırken sistem tepsisine/menü çubuğuna küçült"
- receiveHistoryPage.openFolder: "Dosyayı aç" - "Klasörü aç"
- dialogs.favoriteEditDialog.titleEdit: "Düzenle" - "Ayarlar"
- dialogs.favoriteEditDialog.name: "Takma ad" - "Cihaz adı"
- assetPicker.confirm: "Onay" - "Onayla"

Azerbaijani (az):
- progressPage.remainingTime was completely missing, added the full section
- Aligned key order with en.json
- Minor consistency fixes