### PR TITLE
fix: clean up upload isolate task lifecycle

### DIFF
--- a/common/lib/src/isolate/child/upload_isolate.dart
+++ b/common/lib/src/isolate/child/upload_isolate.dart
@@ -65,6 +65,40 @@ abstract class UriContentStreamResolver {
 
 UriContentStreamResolver? _uriContentStreamResolver;
 
+@visibleForTesting
+Future<void> executeHttpUploadTask({
+  required int taskId,
+  required Map<int, CustomCancelToken> cancelTokens,
+  required Future<void> Function(CustomCancelToken cancelToken) upload,
+  required void Function(IsolateTaskStreamResult<double>) sendToMain,
+}) async {
+  final cancelToken = CustomCancelToken();
+  cancelTokens[taskId] = cancelToken;
+
+  try {
+    await upload(cancelToken);
+    sendToMain(IsolateTaskStreamResult.done(
+      id: taskId,
+    ));
+  } catch (e) {
+    sendToMain(IsolateTaskStreamResult.error(
+      id: taskId,
+      error: e.toString(),
+    ));
+  } finally {
+    cancelTokens.remove(taskId);
+  }
+}
+
+@visibleForTesting
+void cancelHttpUploadTask({
+  required int taskId,
+  required Map<int, CustomCancelToken> cancelTokens,
+}) {
+  final cancelToken = cancelTokens.remove(taskId);
+  cancelToken?.cancel();
+}
+
 @internal
 Future<void> setupHttpUploadIsolate(
   Stream<SendToIsolateData<IsolateTask<BaseHttpUploadTask>>> receiveFromMain,
@@ -90,9 +124,10 @@ Future<void> setupHttpUploadIsolate(
           uploadTask = task;
           break;
         case HttpUploadCancelTask task:
-          final cancelToken = ref.read(_cancelTokenProvider)[task.taskId];
-          cancelToken?.cancel();
-          ref.read(_cancelTokenProvider).remove(task.taskId);
+          cancelHttpUploadTask(
+            taskId: task.taskId,
+            cancelTokens: ref.read(_cancelTokenProvider),
+          );
           return;
       }
 
@@ -105,34 +140,29 @@ Future<void> setupHttpUploadIsolate(
       final (streamController, subscription) = fileStream?.digested() ?? (null, null);
 
       try {
-        final cancelToken = CustomCancelToken();
-        ref.read(_cancelTokenProvider).putIfAbsent(task.id, () => cancelToken);
-
-        await ref.read(httpUploadProvider).upload(
-              stream: streamController?.stream ?? Stream.fromIterable([uploadTask.fileBytes!]),
-              contentLength: uploadTask.fileSize,
-              contentType: uploadTask.mime,
-              target: uploadTask.device,
-              remoteSessionId: uploadTask.remoteSessionId,
-              fileId: uploadTask.fileId,
-              token: uploadTask.remoteFileToken,
-              onSendProgress: (progress) {
-                sendToMain(IsolateTaskStreamResult.event(
-                  id: task.id,
-                  data: progress,
-                ));
-              },
-              cancelToken: cancelToken,
-            );
-
-        sendToMain(IsolateTaskStreamResult.done(
-          id: task.id,
-        ));
-      } catch (e) {
-        sendToMain(IsolateTaskStreamResult.error(
-          id: task.id,
-          error: e.toString(),
-        ));
+        await executeHttpUploadTask(
+          taskId: task.id,
+          cancelTokens: ref.read(_cancelTokenProvider),
+          upload: (cancelToken) {
+            return ref.read(httpUploadProvider).upload(
+                  stream: streamController?.stream ?? Stream.fromIterable([uploadTask.fileBytes!]),
+                  contentLength: uploadTask.fileSize,
+                  contentType: uploadTask.mime,
+                  target: uploadTask.device,
+                  remoteSessionId: uploadTask.remoteSessionId,
+                  fileId: uploadTask.fileId,
+                  token: uploadTask.remoteFileToken,
+                  onSendProgress: (progress) {
+                    sendToMain(IsolateTaskStreamResult.event(
+                      id: task.id,
+                      data: progress,
+                    ));
+                  },
+                  cancelToken: cancelToken,
+                );
+          },
+          sendToMain: sendToMain,
+        );
       } finally {
         // Close the stream if it is still open
         // ignore: unawaited_futures

--- a/common/lib/src/isolate/parent/actions.dart
+++ b/common/lib/src/isolate/parent/actions.dart
@@ -8,6 +8,7 @@ import 'package:common/src/isolate/dto/isolate_task.dart';
 import 'package:common/src/isolate/dto/isolate_task_result.dart';
 import 'package:common/src/isolate/dto/send_to_isolate_data.dart';
 import 'package:common/src/isolate/parent/parent_isolate_provider.dart';
+import 'package:common/src/isolate/parent/task_stream_adapter.dart';
 import 'package:common/src/util/id_provider.dart';
 import 'package:common/src/util/isolate_helper.dart';
 import 'package:refena/refena.dart';
@@ -235,22 +236,8 @@ Stream<R> _convertResponseToStream<R, T>({
   required int taskId,
   required IsolateConnector<IsolateTaskStreamResult<R>, SendToIsolateData<IsolateTask<T>>> connection,
 }) {
-  final controller = StreamController<R>();
-  late StreamSubscription subscription;
-  subscription = connection.receiveFromIsolate.listen((result) {
-    if (result.id == taskId) {
-      if (result.data != null) {
-        controller.add(result.data as R);
-      } else if (result.done) {
-        if (result.error != null) {
-          controller.addError(result.error!);
-        } else {
-          subscription.cancel(); // ignore: discarded_futures
-          controller.close(); // ignore: discarded_futures
-        }
-      }
-    }
-  });
-
-  return controller.stream;
+  return adaptIsolateTaskStream(
+    taskId: taskId,
+    connection: connection,
+  );
 }

--- a/common/lib/src/isolate/parent/task_stream_adapter.dart
+++ b/common/lib/src/isolate/parent/task_stream_adapter.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:common/src/isolate/dto/isolate_task_result.dart';
+import 'package:common/src/util/isolate_helper.dart';
+
+Stream<R> adaptIsolateTaskStream<R, S>({
+  required int taskId,
+  required IsolateConnector<IsolateTaskStreamResult<R>, S> connection,
+}) {
+  late final StreamController<R> controller;
+  late final StreamSubscription<IsolateTaskStreamResult<R>> subscription;
+  var terminated = false;
+
+  Future<void> terminate({Object? error, StackTrace? stackTrace}) async {
+    if (terminated) {
+      return;
+    }
+
+    terminated = true;
+    if (error != null) {
+      controller.addError(error, stackTrace);
+    }
+
+    await subscription.cancel();
+    await controller.close();
+  }
+
+  controller = StreamController<R>(
+    onCancel: () => terminate(),
+  );
+
+  subscription = connection.receiveFromIsolate.listen((result) {
+    if (terminated || result.id != taskId) {
+      return;
+    }
+
+    final data = result.data;
+    if (data != null) {
+      controller.add(data);
+      return;
+    }
+
+    if (!result.done) {
+      return;
+    }
+
+    if (result.error != null) {
+      unawaited(terminate(error: result.error));
+    } else {
+      unawaited(terminate());
+    }
+  });
+
+  return controller.stream;
+}

--- a/common/test/src/isolate/child/upload_isolate_test.dart
+++ b/common/test/src/isolate/child/upload_isolate_test.dart
@@ -1,0 +1,68 @@
+import 'package:common/isolate.dart';
+import 'package:common/src/isolate/child/upload_isolate.dart';
+import 'package:common/src/isolate/dto/isolate_task_result.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('removes cancel tokens after successful uploads', () async {
+    final cancelTokens = <int, CustomCancelToken>{};
+    final results = <IsolateTaskStreamResult<double>>[];
+    CustomCancelToken? registeredToken;
+
+    await executeHttpUploadTask(
+      taskId: 1,
+      cancelTokens: cancelTokens,
+      upload: (cancelToken) async {
+        registeredToken = cancelToken;
+        expect(cancelTokens[1], same(cancelToken));
+      },
+      sendToMain: results.add,
+    );
+
+    expect(registeredToken, isNotNull);
+    expect(cancelTokens, isEmpty);
+    expect(results, hasLength(1));
+    expect(results.single.id, 1);
+    expect(results.single.done, isTrue);
+    expect(results.single.error, isNull);
+  });
+
+  test('removes cancel tokens after failed uploads', () async {
+    final cancelTokens = <int, CustomCancelToken>{};
+    final results = <IsolateTaskStreamResult<double>>[];
+
+    await executeHttpUploadTask(
+      taskId: 2,
+      cancelTokens: cancelTokens,
+      upload: (_) async {
+        throw StateError('boom');
+      },
+      sendToMain: results.add,
+    );
+
+    expect(cancelTokens, isEmpty);
+    expect(results, hasLength(1));
+    expect(results.single.id, 2);
+    expect(results.single.done, isTrue);
+    expect(results.single.error, 'Bad state: boom');
+  });
+
+  test('cancels and removes registered upload tasks', () {
+    final cancelTokens = <int, CustomCancelToken>{};
+    final cancelToken = CustomCancelToken();
+    var canceled = false;
+
+    cancelToken.setCancel(() {
+      canceled = true;
+    });
+    cancelTokens[3] = cancelToken;
+
+    cancelHttpUploadTask(
+      taskId: 3,
+      cancelTokens: cancelTokens,
+    );
+
+    expect(canceled, isTrue);
+    expect(cancelTokens, isEmpty);
+  });
+}

--- a/common/test/src/isolate/parent/task_stream_adapter_test.dart
+++ b/common/test/src/isolate/parent/task_stream_adapter_test.dart
@@ -1,0 +1,80 @@
+import 'dart:isolate';
+
+import 'package:common/src/isolate/dto/isolate_task_result.dart';
+import 'package:common/src/isolate/parent/task_stream_adapter.dart';
+import 'package:common/src/util/isolate_helper.dart';
+import 'package:test/test.dart';
+
+Future<void> _taskEmitter(
+  Stream<String> receiveFromMain,
+  void Function(IsolateTaskStreamResult<double>) sendToMain,
+  int _,
+) async {
+  await for (final command in receiveFromMain) {
+    switch (command) {
+      case 'success':
+        sendToMain(IsolateTaskStreamResult.event(id: 1, data: 0.25));
+        sendToMain(IsolateTaskStreamResult.done(id: 1));
+        break;
+      case 'error':
+        sendToMain(IsolateTaskStreamResult.error(id: 2, error: 'boom'));
+        break;
+      case 'duplicate-terminal':
+        sendToMain(IsolateTaskStreamResult.error(id: 3, error: 'boom'));
+        sendToMain(IsolateTaskStreamResult.done(id: 3));
+        sendToMain(IsolateTaskStreamResult.error(id: 3, error: 'later'));
+        break;
+    }
+  }
+}
+
+Future<IsolateConnector<IsolateTaskStreamResult<double>, String>> _startConnection() {
+  return startIsolate<IsolateTaskStreamResult<double>, String, int>(
+    task: _taskEmitter,
+    param: 0,
+  );
+}
+
+void main() {
+  test('forwards data events and closes on completion', () async {
+    final connection = await _startConnection();
+    addTearDown(() => connection.isolate.kill(priority: Isolate.immediate));
+
+    final stream = adaptIsolateTaskStream<double, String>(
+      taskId: 1,
+      connection: connection,
+    );
+
+    connection.sendToIsolate('success');
+
+    await expectLater(stream, emitsInOrder([0.25, emitsDone]));
+  });
+
+  test('emits terminal errors and closes the stream', () async {
+    final connection = await _startConnection();
+    addTearDown(() => connection.isolate.kill(priority: Isolate.immediate));
+
+    final stream = adaptIsolateTaskStream<double, String>(
+      taskId: 2,
+      connection: connection,
+    );
+
+    connection.sendToIsolate('error');
+
+    await expectLater(stream, emitsInOrder([emitsError('boom'), emitsDone]));
+  });
+
+  test('ignores duplicate terminal events', () async {
+    final connection = await _startConnection();
+    addTearDown(() => connection.isolate.kill(priority: Isolate.immediate));
+
+    final stream = adaptIsolateTaskStream<double, String>(
+      taskId: 3,
+      connection: connection,
+    );
+
+    connection.sendToIsolate('duplicate-terminal');
+
+    await expectLater(stream, emitsInOrder([emitsError('boom'), emitsDone]));
+  });
+}


### PR DESCRIPTION
## Summary
- clean up parent isolate stream subscriptions after terminal errors
- always remove upload cancel tokens on success, failure, and explicit cancellation
- add focused unit coverage for the stream adapter and upload token lifecycle

## Scope
- Keeps the `remoteSessionId` regression out of this PR because #2987 already covers that bug and now includes regression tests.
- Defers upload concurrency tuning and the broader throughput investigation to a separate follow-up.

## Testing
- Added tests for:
  - normal stream completion
  - terminal error completion
  - duplicate terminal signal safety
  - successful upload token cleanup
  - failed upload token cleanup
  - explicit cancel token cleanup
- Validated locally in `common` from a clean Windows checkout:
  - `dart pub get`
  - `dart analyze`
  - `dart test`
- In `app`, `flutter pub get` failed under Flutter `3.41.6` because of dependency resolution (`mockito 5.5.0` vs `flutter_test`-pinned `matcher` / `test_api`), which appears unrelated to this PR.