### PR TITLE
fix: align dialog actions for RTL languages

### DIFF
--- a/app/lib/widget/dialogs/open_file_dialog.dart
+++ b/app/lib/widget/dialogs/open_file_dialog.dart
@@ -76,6 +76,7 @@ class _OpenFileDialogState extends State<OpenFileDialog> {
     return AlertDialog(
       title: Text(t.dialogs.openFile.title),
       content: Text(t.dialogs.openFile.content),
+      actionsAlignment: MainAxisAlignment.end,
       actions: [
         TextButton(
           onPressed: () async {


### PR DESCRIPTION
Fixes #2955

## Problem
Dialog buttons are not RTL-aligned when app language is set to Arabic.
The actions in `OpenFileDialog` always appear LTR regardless of locale.

## Solution
Added `actionsAlignment: MainAxisAlignment.end` to AlertDialog
which automatically respects the text direction of the current locale.