### PR TITLE
fix(linux): defer hideToTray to post-frame callback to fix Wayland race condition

### DIFF
--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -131,11 +131,13 @@ Future<RefenaContainer> preInit(List<String> args) async {
 
     doWhenWindowReady(() {
       if (startHidden) {
-        unawaited(hideToTray());
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          unawaited(hideToTray());
+        });
       } else {
         unawaited(showFromTray());
       }
-    });
+        });
 
     if (defaultTargetPlatform == TargetPlatform.macOS) {
       await setupStatusBar();
@@ -236,7 +238,7 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
             args: files,
           ),
         );
-      });
+          });
 
       // handle dropped strings
       pendingStringsStream.listen((pendingStrings) {
@@ -244,7 +246,7 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
           ref.redux(selectedSendingFilesProvider).dispatch(AddMessageAction(message: string));
         }
         ref.redux(homePageControllerProvider).dispatch(ChangeTabAction(HomeTab.send));
-      });
+          });
 
       await setupMethodCallHandler();
     } else {
@@ -282,7 +284,7 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
           payload: payload,
         ),
       );
-    });
+        });
   }
 
   if (appStart && !hasInitialShare && (checkPlatformWithGallery() || checkPlatformCanReceiveShareIntent())) {


### PR DESCRIPTION
## Problem

On Wayland (e.g. COSMIC desktop on Fedora 43), `doWhenWindowReady` fires before Refena is fully initialized, causing a `LateInitializationError` in `hideToTray`:

```
LateInitializationError: Field 'defaultRef' has not been initialized
#0 hideToTray (package:localsend_app/util/native/tray_helper.dart)
```

This results in the app crashing and restarting, opening in the foreground instead of hiding to the system tray on startup, despite `--hidden` being passed.

## Fix

Defer the `hideToTray` call to `addPostFrameCallback`, which ensures the first frame has been rendered and Refena is fully initialized before attempting to hide the window.

## Testing

Tested on Fedora 43 COSMIC Atomic (Wayland) with a local build. The app now correctly starts hidden in the system tray without crashing.

Fixes #2790