### PR TITLE
feat: add x86_64 rpm package to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,95 @@ jobs:
           name: deb-arm-64-result
           path: ${{ steps.find_deb.outputs.deb_path }}
 
+  build_rpm_x86_64:
+    needs: build
+    runs-on: ubuntu-24.04
+    container: fedora:44
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: dnf install -y clang cmake gtk3-devel ninja-build libappindicator-gtk3-devel jq findutils which git patchelf rpm-build
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: "stable"
+
+      - name: Configure safe directory for Git
+        run: git config --global --add safe.directory "$FLUTTER_ROOT"
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: ${{ env.RUST_VERSION }}
+
+      - name: Check rust-toolchain.toml
+        working-directory: app
+        run: rustup show
+
+      - name: Enable dart_distributor
+        run: dart pub global activate flutter_distributor
+
+      # flutter_app_packager 0.6.5 has two bugs that prevent the rpm build from
+      # succeeding on modern Fedora:
+      #
+      # 1. rpm 4.20 (Fedora 41+) runs %install from a new
+      #    %{_builddir}/%{name}-%{version}-build/ subdirectory. The generated
+      #    spec uses relative paths like cp -r %{name}/* that were written
+      #    against the old layout where %install's CWD was BUILD/ itself, so the
+      #    cp now looks one level too deep and fails with "No such file or
+      #    directory". The fix is to prefix each copy source with ../ to reach
+      #    the real BUILD/ parent. (The obvious alternative,
+      #    %{_builddir}/%{name}/*, does not work because %{_builddir} itself was
+      #    redefined in rpm 4.20 to include the -build subdir.)
+      #
+      # 2. flutter_app_packager runs patchelf --set-rpath '$ORIGIN' on plugin
+      #    .so files, but gates it on the rpath containing "/home" (a workaround
+      #    for a specific flutter issue, see flutter/flutter#65400).
+      #    GitHub-hosted runners check out under /__w/..., so the gate never
+      #    triggers and the .so files ship with build-tree rpaths. rpm's
+      #    check-rpaths then rejects the package with "ERROR 0002: invalid
+      #    runpath". The fix is to always run patchelf regardless of the
+      #    original rpath.
+      #
+      # After editing the sources, re-activate flutter_distributor so its AOT
+      # snapshot is rebuilt against the patched dependency.
+      - name: Patch flutter_app_packager for rpm 4.20 and rpath fix
+        run: |
+          F=$(find $HOME/.pub-cache/hosted/pub.dev/flutter_app_packager-*/lib/src/makers/rpm/make_rpm_config.dart | head -1)
+          G=$(find $HOME/.pub-cache/hosted/pub.dev/flutter_app_packager-*/lib/src/makers/rpm/app_package_maker_rpm.dart | head -1)
+          sed -i "s|cp -r %{name}/\*|cp -r ../%{name}/*|; s|cp -r %{name}\.desktop|cp -r ../%{name}.desktop|; s|cp -r %{name}\.png|cp -r ../%{name}.png|; s|cp -r %{name}\*\.xml|cp -r ../%{name}*.xml|" "$F"
+          sed -i "s|if (processResult.stdout.toString().contains(.*/home.*)) {|if (true) {|" "$G"
+          dart pub global deactivate flutter_distributor
+          dart pub global activate flutter_distributor
+
+      - name: Build rpm package
+        working-directory: app
+        run: flutter_distributor package --platform linux --targets rpm
+
+      - name: Find rpm file
+        id: find_rpm
+        run: |
+          VERSION=${{ needs.build.outputs.version }}
+          RPM_PATH=$(find app/dist -name "localsend_app-$VERSION*-linux.rpm")
+          echo "rpm_path=$RPM_PATH" >> $GITHUB_OUTPUT
+
+      - name: Check if rpm file exists
+        id: check_file
+        run: |
+          if [[ ! -f "${{ steps.find_rpm.outputs.rpm_path }}" ]]; then
+            echo "File not found: ${{ steps.find_rpm.outputs.rpm_path }}"
+            exit 1
+          fi
+
+      - name: Upload rpm file
+        uses: actions/upload-artifact@v6
+        with:
+          name: rpm-x86-64-result
+          path: ${{ steps.find_rpm.outputs.rpm_path }}
+
   build_appimage_x86_64:
     needs: build
     runs-on: ubuntu-24.04
@@ -384,6 +473,7 @@ jobs:
       - build_tar_arm_64
       - build_deb_x86_64
       - build_deb_arm_64
+      - build_rpm_x86_64
       - build_appimage_x86_64
       - build_windows_zip_x86_64
     runs-on: ubuntu-24.04
@@ -525,6 +615,26 @@ jobs:
           asset_path: result.deb
           asset_name: LocalSend-${{ needs.build.outputs.version }}-linux-arm-64.deb
           asset_content_type: application/vnd.debian.binary-package
+
+      # RPM (x86_64)
+      - name: Download rpm file
+        uses: actions/download-artifact@v7
+        with:
+          name: rpm-x86-64-result
+          path: rpm-x86-64-result
+
+      - name: Copy rpm file to root
+        run: cp rpm-x86-64-result/*.rpm result.rpm
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.draft_release.outputs.upload_url }}
+          asset_path: result.rpm
+          asset_name: LocalSend-${{ needs.build.outputs.version }}-linux-x86-64.rpm
+          asset_content_type: application/x-rpm
 
       # APPIMAGE (x86_64)
       - name: Download AppImage file

--- a/.github/workflows/test_rpm.yml
+++ b/.github/workflows/test_rpm.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   FLUTTER_VERSION: "3.35.6"
+  RUST_VERSION: "1.84.1"
 
 jobs:
   build:
@@ -22,13 +23,14 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   build_rpm:
-    runs-on: ubuntu-latest
-    container: fedora:38
+    needs: build
+    runs-on: ubuntu-24.04
+    container: fedora:44
     steps:
       - uses: actions/checkout@v6
 
       - name: Install dependencies
-        run: sudo dnf install -y clang cmake gtk3-devel ninja-build libappindicator-gtk3-devel jq findutils which git patchelf rpm-build
+        run: dnf install -y clang cmake gtk3-devel ninja-build libappindicator-gtk3-devel jq findutils which git patchelf rpm-build
 
       - uses: subosito/flutter-action@v2
         with:
@@ -36,28 +38,57 @@ jobs:
           channel: "stable"
 
       - name: Configure safe directory for Git
-        run: git config --global --add safe.directory "/opt/hostedtoolcache/flutter/stable-${{ env.FLUTTER_VERSION }}-x64"
+        run: git config --global --add safe.directory "$FLUTTER_ROOT"
 
-#      - name: Configure safe directory for Git (pub-cache)
-#        run: git config --global --add safe.directory "/opt/hostedtoolcache/flutter/stable-${{ env.FLUTTER_VERSION }}-x64/.pub-cache"
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: ${{ env.RUST_VERSION }}
 
-      - name: Get flutter path
-        run: which flutter
-
-      - name: Get dart path
-        run: which dart
+      - name: Check rust-toolchain.toml
+        working-directory: app
+        run: rustup show
 
       - name: Enable dart_distributor
-        run: PUB_CACHE=/opt/hostedtoolcache/flutter/stable-${{ env.FLUTTER_VERSION }}-x64/.pub-cache dart pub global activate flutter_distributor
+        run: dart pub global activate flutter_distributor
 
-      - name: Debugging PATH and flutter_distributor
+      # flutter_app_packager 0.6.5 has two bugs that prevent the rpm build from
+      # succeeding on modern Fedora:
+      #
+      # 1. rpm 4.20 (Fedora 41+) runs %install from a new
+      #    %{_builddir}/%{name}-%{version}-build/ subdirectory. The generated
+      #    spec uses relative paths like cp -r %{name}/* that were written
+      #    against the old layout where %install's CWD was BUILD/ itself, so the
+      #    cp now looks one level too deep and fails with "No such file or
+      #    directory". The fix is to prefix each copy source with ../ to reach
+      #    the real BUILD/ parent. (The obvious alternative,
+      #    %{_builddir}/%{name}/*, does not work because %{_builddir} itself was
+      #    redefined in rpm 4.20 to include the -build subdir.)
+      #
+      # 2. flutter_app_packager runs patchelf --set-rpath '$ORIGIN' on plugin
+      #    .so files, but gates it on the rpath containing "/home" (a workaround
+      #    for a specific flutter issue, see flutter/flutter#65400).
+      #    GitHub-hosted runners check out under /__w/..., so the gate never
+      #    triggers and the .so files ship with build-tree rpaths. rpm's
+      #    check-rpaths then rejects the package with "ERROR 0002: invalid
+      #    runpath". The fix is to always run patchelf regardless of the
+      #    original rpath.
+      #
+      # After editing the sources, re-activate flutter_distributor so its AOT
+      # snapshot is rebuilt against the patched dependency.
+      - name: Patch flutter_app_packager for rpm 4.20 and rpath fix
         run: |
-          echo "PATH: $PATH"
-          command -v flutter_distributor || echo "flutter_distributor not found"
+          F=$(find $HOME/.pub-cache/hosted/pub.dev/flutter_app_packager-*/lib/src/makers/rpm/make_rpm_config.dart | head -1)
+          G=$(find $HOME/.pub-cache/hosted/pub.dev/flutter_app_packager-*/lib/src/makers/rpm/app_package_maker_rpm.dart | head -1)
+          sed -i "s|cp -r %{name}/\*|cp -r ../%{name}/*|; s|cp -r %{name}\.desktop|cp -r ../%{name}.desktop|; s|cp -r %{name}\.png|cp -r ../%{name}.png|; s|cp -r %{name}\*\.xml|cp -r ../%{name}*.xml|" "$F"
+          sed -i "s|if (processResult.stdout.toString().contains(.*/home.*)) {|if (true) {|" "$G"
+          dart pub global deactivate flutter_distributor
+          dart pub global activate flutter_distributor
 
       - name: Build rpm package
         working-directory: app
-        run: FLUTTER_ROOT=/opt/hostedtoolcache/flutter/stable-${{ env.FLUTTER_VERSION }}-x64 flutter_distributor package --platform linux --targets rpm
+        run: flutter_distributor package --platform linux --targets rpm
 
       - name: Find rpm file
         id: find_rpm


### PR DESCRIPTION
## Summary

LocalSend ships `.deb` Linux packages with each release but does not currently ship an RPM. This PR adds an x86_64 RPM to the release pipeline so each release uploads a `.rpm` asset alongside the existing Linux packages and fixes the previously broken `test_rpm` manual workflow so it builds successfully on modern Fedora.

## Changes

#### `.github/workflows/release.yml`

- Adds a new `build_rpm_x86_64` job that runs in a `fedora:43` container and uses `flutter_distributor package --platform linux --targets rpm`.
- Adds `build_rpm_x86_64` to the `needs:` array of the release publishing job.
- Downloads the `rpm-x86-64-result` artifact in the release publishing job and uploads it as a release asset named `LocalSend-${VERSION}-linux-x86-64.rpm` with MIME type `application/x-rpm`, mirroring the existing `deb` wiring.

#### `.github/workflows/test_rpm.yml`

- Bumps the container from `fedora:38` (EOL) to `fedora:43`.
- Adds `needs: build` so the job consumes the shared `version` output.
- Replaces the hard-coded `/opt/hostedtoolcache/flutter/stable-...` path with `$FLUTTER_ROOT`, which `subosito/flutter-action` sets to the correct location inside the container. This removes a brittle path assumption that had broken over time.
- Removes dead debugging steps (`which flutter`, `which dart`, `PATH` echo).
- Adds Rust toolchain setup (to match the `deb` job, since the app now links a Rust HTTP client).
- Drops `sudo` from the `dnf install` line, as Fedora container jobs already run as root on GitHub-hosted runners.

## Why the inline `sed` patches?

`flutter_app_packager` 0.6.5 has two bugs that prevent `rpmbuild` from completing on Fedora 41+. Both are patched in a dedicated step, documented with comments in the workflow. The short version:

1. RPM 4.20 (Fedora 41+) invokes `%install` from a new `%{_builddir}/%{name}-%{version}-build/` subdirectory. The spec template in `make_rpm_config.dart` uses relative paths like `cp -r %{name}/*` that were written against the old layout where `%install`'s CWD was `BUILD/` itself. The patched paths now prefix each source with `../` so they resolve to the real `BUILD/` parent. (Using `%{_builddir}/%{name}/*` doesn't work because `%{_builddir}` itself was redefined in RPM 4.20 to include the `-build` subdir.)
2. `flutter_app_packager` runs `patchelf --set-rpath '$ORIGIN'` on plugin `.so` files but gates it on the rpath containing `/home` (a workaround for flutter/flutter#65400). GitHub-hosted runners check out under `/__w/...`, so the gate never triggers and plugin `.so` files ship with build-tree rpaths. RPM `check-rpaths` then rejects the package with `ERROR 0002: invalid runpath`. The patch makes `patchelf` always run regardless of the original rpath.

After editing the sources, `flutter_distributor` is deactivated and reactivated so its AOT snapshot is rebuilt against the patched dependency.

Fixing these issues upstream is deliberately deferred to keep this PR focused on unblocking the RPM release. It would be desirable for someone who has the time and interest to follow up to fix the upstream packaging logic.

## Testing Done

- [x] Triggered the "Build RPM package" workflow manually (`workflow_dispatch`) and confirmed the artifact was produced and installable on Fedora 43.
- [x] Installed the produced `.rpm` in Fedora 43 and launched LocalSend.
- [x] Ran `rpm -qlp` on the artifact to sanity-check the file layout.

Fixes #1453
Fixes #3089