### PR TITLE
feat: Add post-receive hook / external command after file save (#3041)

### DIFF
--- a/app/assets/i18n/_missing_translations_en.json
+++ b/app/assets/i18n/_missing_translations_en.json
@@ -1,0 +1,17 @@
+{
+  "settingsTab": {
+    "receive": {
+      "postReceiveHook": "Post-receive Hook",
+      "postReceiveHookEnable": "Enable post-receive hook",
+      "postReceiveHookCommand": "Hook command",
+      "postReceiveHookVariables": "Available environment variables:",
+      "postReceiveHookVarPath": "Full path to saved file",
+      "postReceiveHookVarName": "Original file name from sender",
+      "postReceiveHookVarAlias": "Sender device alias",
+      "postReceiveHookVarSize": "File size in bytes",
+      "postReceiveHookVarType": "File type (image, video, etc.)",
+      "postReceiveHookVarGallery": "Whether saved to gallery (true/false)",
+      "postReceiveHookWarning": "Warning: Commands run with app privileges. Only use trusted scripts."
+    }
+  }
+}

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -9,59 +9,61 @@ part 'settings_state.mapper.dart';
 
 @MappableClass()
 class SettingsState with SettingsStateMappable {
-  final String showToken; // the token to show / maximize the window because only one instance is allowed
-  final String alias;
-  final ThemeMode theme;
-  final ColorMode colorMode;
-  final AppLocale? locale;
-  final int port;
-  final List<String>? networkWhitelist; // null = disabled
-  final List<String>? networkBlacklist; // null = disabled
-  final String multicastGroup;
-  final String? destination; // null = default
-  final bool saveToGallery; // only Android, iOS
-  final bool saveToHistory;
-  final bool quickSave; // automatically accept file requests
-  final bool quickSaveFromFavorites; // automatically accept file requests from favorites
-  final String? receivePin; // null = disabled
-  final bool autoFinish; // automatically finish sessions
-  final bool minimizeToTray; // minimize to tray instead of exiting the app
-  final bool https;
-  final SendMode sendMode;
-  final bool saveWindowPlacement;
-  final bool enableAnimations;
-  final DeviceType? deviceType;
-  final String? deviceModel;
-  final bool shareViaLinkAutoAccept;
-  final int discoveryTimeout;
-  final bool advancedSettings;
+ final String showToken; // the token to show / maximize the window because only one instance is allowed
+ final String alias;
+ final ThemeMode theme;
+ final ColorMode colorMode;
+ final AppLocale? locale;
+ final int port;
+ final List<String>? networkWhitelist; // null = disabled
+ final List<String>? networkBlacklist; // null = disabled
+ final String multicastGroup;
+ final String? destination; // null = default
+ final bool saveToGallery; // only Android, iOS
+ final bool saveToHistory;
+ final bool quickSave; // automatically accept file requests
+ final bool quickSaveFromFavorites; // automatically accept file requests from favorites
+ final String? receivePin; // null = disabled
+ final bool autoFinish; // automatically finish sessions
+ final bool minimizeToTray; // minimize to tray instead of exiting the app
+ final bool https;
+ final SendMode sendMode;
+ final bool saveWindowPlacement;
+ final bool enableAnimations;
+ final DeviceType? deviceType;
+ final String? deviceModel;
+ final bool shareViaLinkAutoAccept;
+ final int discoveryTimeout;
+ final bool advancedSettings;
+ final String? postReceiveHook; // null = disabled
 
-  const SettingsState({
-    required this.showToken,
-    required this.alias,
-    required this.theme,
-    required this.colorMode,
-    required this.locale,
-    required this.port,
-    required this.networkWhitelist,
-    required this.networkBlacklist,
-    required this.multicastGroup,
-    required this.destination,
-    required this.saveToGallery,
-    required this.saveToHistory,
-    required this.quickSave,
-    required this.quickSaveFromFavorites,
-    required this.receivePin,
-    required this.autoFinish,
-    required this.minimizeToTray,
-    required this.https,
-    required this.sendMode,
-    required this.saveWindowPlacement,
-    required this.enableAnimations,
-    required this.deviceType,
-    required this.deviceModel,
-    required this.shareViaLinkAutoAccept,
-    required this.discoveryTimeout,
-    required this.advancedSettings,
-  });
+ const SettingsState({
+ required this.showToken,
+ required this.alias,
+ required this.theme,
+ required this.colorMode,
+ required this.locale,
+ required this.port,
+ required this.networkWhitelist,
+ required this.networkBlacklist,
+ required this.multicastGroup,
+ required this.destination,
+ required this.saveToGallery,
+ required this.saveToHistory,
+ required this.quickSave,
+ required this.quickSaveFromFavorites,
+ required this.receivePin,
+ required this.autoFinish,
+ required this.minimizeToTray,
+ required this.https,
+ required this.sendMode,
+ required this.saveWindowPlacement,
+ required this.enableAnimations,
+ required this.deviceType,
+ required this.deviceModel,
+ required this.shareViaLinkAutoAccept,
+ required this.discoveryTimeout,
+ required this.advancedSettings,
+ required this.postReceiveHook,
+ });
 }

--- a/app/lib/pages/tabs/receive_tab.dart
+++ b/app/lib/pages/tabs/receive_tab.dart
@@ -14,244 +14,284 @@ import 'package:localsend_app/widget/custom_icon_button.dart';
 import 'package:localsend_app/widget/local_send_logo.dart';
 import 'package:localsend_app/widget/responsive_list_view.dart';
 import 'package:localsend_app/widget/rotating_widget.dart';
+import 'package:localsend_app/widget/dialogs/post_receive_hook_dialog.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
 
 enum _QuickSaveMode {
-  off,
-  favorites,
-  on,
+ off,
+ favorites,
+ on,
 }
 
 class ReceiveTab extends StatelessWidget {
-  const ReceiveTab();
+ const ReceiveTab();
 
-  @override
-  Widget build(BuildContext context) {
-    final vm = context.watch(receiveTabVmProvider);
+ @override
+ Widget build(BuildContext context) {
+ final vm = context.watch(receiveTabVmProvider);
 
-    return Stack(
-      children: [
-        checkPlatform([TargetPlatform.macOS])
-            ? SizedBox(height: 50, child: MoveWindow())
-            : SizedBox(height: 0, width: 0), // makes the top part that's not occupied by another widget draggable
-        Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: ResponsiveListView.defaultMaxWidth),
-            child: Padding(
-              padding: const EdgeInsets.all(30),
-              child: ColumnListView(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        InitialFadeTransition(
-                          duration: const Duration(milliseconds: 300),
-                          delay: const Duration(milliseconds: 200),
-                          child: Consumer(
-                            builder: (context, ref) {
-                              final animations = ref.watch(animationProvider);
-                              final activeTab = ref.watch(homePageControllerProvider.select((state) => state.currentTab));
-                              return RotatingWidget(
-                                duration: const Duration(seconds: 15),
-                                spinning: vm.serverState != null && animations && activeTab == HomeTab.receive,
-                                child: const LocalSendLogo(withText: false),
-                              );
-                            },
-                          ),
-                        ),
-                        FittedBox(
-                          fit: BoxFit.scaleDown,
-                          child: Text(vm.serverState?.alias ?? vm.aliasSettings, style: const TextStyle(fontSize: 48)),
-                        ),
-                        InitialFadeTransition(
-                          duration: const Duration(milliseconds: 300),
-                          delay: const Duration(milliseconds: 500),
-                          child: Text(
-                            vm.serverState == null ? t.general.offline : vm.localIps.map((ip) => '#${ip.visualId}').toSet().join(' '),
-                            style: const TextStyle(fontSize: 24),
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 10),
-                    child: Center(
-                      child: Column(
-                        children: [
-                          Text(t.general.quickSave),
-                          const SizedBox(height: 10),
-                          SegmentedButton<_QuickSaveMode>(
-                            multiSelectionEnabled: false,
-                            emptySelectionAllowed: false,
-                            showSelectedIcon: false,
-                            onSelectionChanged: (selection) async {
-                              if (selection.contains(_QuickSaveMode.off)) {
-                                await vm.onSetQuickSave(context, false);
-                                if (context.mounted) {
-                                  await vm.onSetQuickSaveFromFavorites(context, false);
-                                }
-                              } else if (selection.contains(_QuickSaveMode.favorites)) {
-                                await vm.onSetQuickSave(context, false);
-                                if (context.mounted) {
-                                  await vm.onSetQuickSaveFromFavorites(context, true);
-                                }
-                              } else if (selection.contains(_QuickSaveMode.on)) {
-                                await vm.onSetQuickSaveFromFavorites(context, false);
-                                if (context.mounted) {
-                                  await vm.onSetQuickSave(context, true);
-                                }
-                              }
-                            },
-                            selected: {
-                              if (!vm.quickSaveSettings && !vm.quickSaveFromFavoritesSettings) _QuickSaveMode.off,
-                              if (vm.quickSaveFromFavoritesSettings) _QuickSaveMode.favorites,
-                              if (vm.quickSaveSettings) _QuickSaveMode.on,
-                            },
-                            segments: [
-                              ButtonSegment(
-                                value: _QuickSaveMode.off,
-                                label: Text(t.receiveTab.quickSave.off),
-                              ),
-                              ButtonSegment(
-                                value: _QuickSaveMode.favorites,
-                                label: Text(t.receiveTab.quickSave.favorites),
-                              ),
-                              ButtonSegment(
-                                value: _QuickSaveMode.on,
-                                label: Text(t.receiveTab.quickSave.on),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 15),
-                ],
-              ),
-            ),
-          ),
-        ),
-        _InfoBox(vm),
-        _CornerButtons(
-          showAdvanced: vm.showAdvanced,
-          showHistoryButton: vm.showHistoryButton,
-          toggleAdvanced: vm.toggleAdvanced,
-        ),
-      ],
-    );
-  }
+ return Stack(
+ children: [
+ checkPlatform([TargetPlatform.macOS])
+ ? SizedBox(height: 50, child: MoveWindow())
+ : SizedBox(height: 0, width: 0), // makes the top part that's not occupied by another widget draggable
+ Center(
+ child: ConstrainedBox(
+ constraints: const BoxConstraints(maxWidth: ResponsiveListView.defaultMaxWidth),
+ child: Padding(
+ padding: const EdgeInsets.all(30),
+ child: ColumnListView(
+ crossAxisAlignment: CrossAxisAlignment.stretch,
+ children: [
+ Expanded(
+ child: Column(
+ mainAxisAlignment: MainAxisAlignment.center,
+ children: [
+ InitialFadeTransition(
+ duration: const Duration(milliseconds: 300),
+ delay: const Duration(milliseconds: 200),
+ child: Consumer(
+ builder: (context, ref) {
+ final animations = ref.watch(animationProvider);
+ final activeTab = ref.watch(homePageControllerProvider.select((state) => state.currentTab));
+ return RotatingWidget(
+ duration: const Duration(seconds: 15),
+ spinning: vm.serverState != null && animations && activeTab == HomeTab.receive,
+ child: const LocalSendLogo(withText: false),
+ );
+ },
+ ),
+ ),
+ FittedBox(
+ fit: BoxFit.scaleDown,
+ child: Text(vm.serverState?.alias ?? vm.aliasSettings, style: const TextStyle(fontSize: 48)),
+ ),
+ InitialFadeTransition(
+ duration: const Duration(milliseconds: 300),
+ delay: const Duration(milliseconds: 500),
+ child: Text(
+ vm.serverState == null ? t.general.offline : vm.localIps.map((ip) => '#${ip.visualId}').toSet().join(' '),
+ style: const TextStyle(fontSize: 24),
+ textAlign: TextAlign.center,
+ ),
+ ),
+ ],
+ ),
+ ),
+ Padding(
+ padding: const EdgeInsets.only(top: 10),
+ child: Center(
+ child: Column(
+ children: [
+ Text(t.general.quickSave),
+ const SizedBox(height: 10),
+ SegmentedButton<_QuickSaveMode>(
+ multiSelectionEnabled: false,
+ emptySelectionAllowed: false,
+ showSelectedIcon: false,
+ onSelectionChanged: (selection) async {
+ if (selection.contains(_QuickSaveMode.off)) {
+ await vm.onSetQuickSave(context, false);
+ if (context.mounted) {
+ await vm.onSetQuickSaveFromFavorites(context, false);
+ }
+ } else if (selection.contains(_QuickSaveMode.favorites)) {
+ await vm.onSetQuickSave(context, false);
+ if (context.mounted) {
+ await vm.onSetQuickSaveFromFavorites(context, true);
+ }
+ } else if (selection.contains(_QuickSaveMode.on)) {
+ await vm.onSetQuickSaveFromFavorites(context, false);
+ if (context.mounted) {
+ await vm.onSetQuickSave(context, true);
+ }
+ }
+ },
+ selected: {
+ if (!vm.quickSaveSettings && !vm.quickSaveFromFavoritesSettings) _QuickSaveMode.off,
+ if (vm.quickSaveFromFavoritesSettings) _QuickSaveMode.favorites,
+ if (vm.quickSaveSettings) _QuickSaveMode.on,
+ },
+ segments: [
+ ButtonSegment(
+ value: _QuickSaveMode.off,
+ label: Text(t.receiveTab.quickSave.off),
+ ),
+ ButtonSegment(
+ value: _QuickSaveMode.favorites,
+ label: Text(t.receiveTab.quickSave.favorites),
+ ),
+ ButtonSegment(
+ value: _QuickSaveMode.on,
+ label: Text(t.receiveTab.quickSave.on),
+ ),
+ ],
+ ),
+ ],
+ ),
+ ),
+ ),
+ const SizedBox(height: 15),
+ ],
+ ),
+ ),
+ ),
+ ),
+ _InfoBox(vm),
+ _CornerButtons(
+ showAdvanced: vm.showAdvanced,
+ showHistoryButton: vm.showHistoryButton,
+ toggleAdvanced: vm.toggleAdvanced,
+ ),
+ ],
+ );
+ }
 }
 
 class _CornerButtons extends StatelessWidget {
-  final bool showAdvanced;
-  final bool showHistoryButton;
-  final Future<void> Function() toggleAdvanced;
+ final bool showAdvanced;
+ final bool showHistoryButton;
+ final Future<void> Function() toggleAdvanced;
 
-  const _CornerButtons({
-    required this.showAdvanced,
-    required this.showHistoryButton,
-    required this.toggleAdvanced,
-  });
+ const _CornerButtons({
+ required this.showAdvanced,
+ required this.showHistoryButton,
+ required this.toggleAdvanced,
+ });
 
-  @override
-  Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.topRight,
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            if (!showAdvanced)
-              AnimatedOpacity(
-                opacity: showHistoryButton ? 1 : 0,
-                duration: const Duration(milliseconds: 200),
-                child: CustomIconButton(
-                  onPressed: () async {
-                    await context.push(() => const ReceiveHistoryPage());
-                  },
-                  child: const Icon(Icons.history),
-                ),
-              ),
-            CustomIconButton(
-              key: const ValueKey('info-btn'),
-              onPressed: toggleAdvanced,
-              child: const Icon(Icons.info),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+ @override
+ Widget build(BuildContext context) {
+ return Align(
+ alignment: Alignment.topRight,
+ child: Padding(
+ padding: const EdgeInsets.all(20),
+ child: Row(
+ mainAxisAlignment: MainAxisAlignment.end,
+ children: [
+ if (!showAdvanced)
+ AnimatedOpacity(
+ opacity: showHistoryButton ? 1 : 0,
+ duration: const Duration(milliseconds: 200),
+ child: CustomIconButton(
+ onPressed: () async {
+ await context.push(() => const ReceiveHistoryPage());
+ },
+ child: const Icon(Icons.history),
+ ),
+ ),
+ CustomIconButton(
+ key: const ValueKey('info-btn'),
+ onPressed: toggleAdvanced,
+ child: const Icon(Icons.info),
+ ),
+ ],
+ ),
+ ),
+ );
+ }
 }
 
 class _InfoBox extends StatelessWidget {
-  final ReceiveTabVm vm;
+ final ReceiveTabVm vm;
 
-  const _InfoBox(this.vm);
+ const _InfoBox(this.vm);
 
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedCrossFade(
-      crossFadeState: vm.showAdvanced ? CrossFadeState.showSecond : CrossFadeState.showFirst,
-      duration: const Duration(milliseconds: 200),
-      firstChild: Container(),
-      secondChild: Align(
-        alignment: Alignment.topRight,
-        child: Padding(
-          padding: const EdgeInsets.all(15),
-          child: Card(
-            child: Padding(
-              padding: const EdgeInsets.all(15),
-              child: Table(
-                columnWidths: const {
-                  0: IntrinsicColumnWidth(),
-                  1: IntrinsicColumnWidth(),
-                  2: IntrinsicColumnWidth(),
-                },
-                children: [
-                  TableRow(
-                    children: [
-                      Text(t.receiveTab.infoBox.alias),
-                      const SizedBox(width: 10),
-                      Padding(
-                        padding: const EdgeInsets.only(right: 30),
-                        child: SelectableText(vm.serverState?.alias ?? '-'),
-                      ),
-                    ],
-                  ),
-                  TableRow(
-                    children: [
-                      Text(t.receiveTab.infoBox.ip),
-                      const SizedBox(width: 10),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          if (vm.localIps.isEmpty) Text(t.general.unknown),
-                          ...vm.localIps.map((ip) => SelectableText(ip)),
-                        ],
-                      ),
-                    ],
-                  ),
-                  TableRow(
-                    children: [
-                      Text(t.receiveTab.infoBox.port),
-                      const SizedBox(width: 10),
-                      SelectableText(vm.serverState?.port.toString() ?? '-'),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+ @override
+ Widget build(BuildContext context) {
+ final ref = context.ref;
+ return AnimatedCrossFade(
+ crossFadeState: vm.showAdvanced ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+ duration: const Duration(milliseconds: 200),
+ firstChild: Container(),
+ secondChild: Align(
+ alignment: Alignment.topRight,
+ child: Padding(
+ padding: const EdgeInsets.all(15),
+ child: Card(
+ child: Padding(
+ padding: const EdgeInsets.all(15),
+ child: Table(
+ columnWidths: const {
+ 0: IntrinsicColumnWidth(),
+ 1: IntrinsicColumnWidth(),
+ 2: IntrinsicColumnWidth(),
+ },
+ children: [
+ TableRow(
+ children: [
+ Text(t.receiveTab.infoBox.alias),
+ const SizedBox(width: 10),
+ Padding(
+ padding: const EdgeInsets.only(right: 30),
+ child: SelectableText(vm.serverState?.alias ?? '-'),
+ ),
+ ],
+ ),
+ TableRow(
+ children: [
+ Text(t.receiveTab.infoBox.ip),
+ const SizedBox(width: 10),
+ Column(
+ crossAxisAlignment: CrossAxisAlignment.start,
+ children: [
+ if (vm.localIps.isEmpty) Text(t.general.unknown),
+ ...vm.localIps.map((ip) => SelectableText(ip)),
+ ],
+ ),
+ ],
+ ),
+ TableRow(
+ children: [
+ Text(t.receiveTab.infoBox.port),
+ const SizedBox(width: 10),
+ SelectableText(vm.serverState?.port.toString() ?? '-'),
+ ],
+ ),
+ TableRow(
+ children: [
+ Text(t.settingsTab.receive.postReceiveHook),
+ const SizedBox(width: 10),
+ Expanded(
+ child: Row(
+ children: [
+ Expanded(
+ child: Consumer(
+ builder: (context, ref) {
+ final hook = ref.watch(settingsProvider.select((s) => s.postReceiveHook));
+ return Text(
+ hook?.isNotEmpty == true ? t.general.on : t.general.off,
+ style: TextStyle(
+ color: hook?.isNotEmpty == true 
+ ? Theme.of(context).colorScheme.primary 
+ : Theme.of(context).colorScheme.onSurfaceVariant,
+ ),
+ );
+ },
+ ),
+ ),
+ const SizedBox(width: 8),
+ CustomIconButton(
+ onPressed: () async {
+ final currentHook = ref.read(settingsProvider).postReceiveHook;
+ final result = await PostReceiveHookDialog.open(context, initialCommand: currentHook);
+ if (result != null && context.mounted) {
+ await ref.notifier(settingsProvider).setPostReceiveHook(result.isEmpty ? null : result);
+ }
+ },
+ child: const Icon(Icons.edit, size: 18),
+ ),
+ ],
+ ),
+ ),
+ ],
+ ),
+ ],
+ ),
+ ),
+ ),
+ ),
+ ),
+ );
+ }
 }

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -41,6 +41,7 @@ import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/native/directories.dart';
 import 'package:localsend_app/util/native/file_saver.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
+import 'package:localsend_app/util/native/post_receive_hook.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
 import 'package:localsend_app/util/rust.dart';
 import 'package:localsend_app/util/simple_server.dart';
@@ -58,825 +59,661 @@ final _logger = Logger('ReceiveController');
 
 /// Handles all requests for receiving files.
 class ReceiveController {
-  final ServerUtils server;
-
-  ReceiveController(this.server);
-
-  /// Installs all routes for receiving files.
-  void installRoutes({
-    required SimpleServerRouteBuilder router,
-    required String alias,
-    required int port,
-    required bool https,
-    required String fingerprint,
-    required String showToken,
-  }) {
-    router.get(ApiRoute.info.v1, (HttpRequest request) async {
-      return await _infoHandler(request: request, alias: alias, fingerprint: fingerprint);
-    });
-
-    router.get(ApiRoute.info.v2, (HttpRequest request) async {
-      return await _infoHandler(request: request, alias: alias, fingerprint: fingerprint);
-    });
-
-    // An upgraded version of /info
-    router.post(ApiRoute.register.v1, (HttpRequest request) async {
-      return await _registerHandler(request: request, alias: alias, port: port, https: https, fingerprint: fingerprint);
-    });
-
-    router.post(ApiRoute.register.v2, (HttpRequest request) async {
-      return await _registerHandler(request: request, alias: alias, port: port, https: https, fingerprint: fingerprint);
-    });
-
-    router.post(ApiRoute.prepareUpload.v1, (HttpRequest request) async {
-      return await _prepareUploadHandler(request: request, port: port, https: https, v2: false);
-    });
-
-    router.post(ApiRoute.prepareUpload.v2, (HttpRequest request) async {
-      return await _prepareUploadHandler(request: request, port: port, https: https, v2: true);
-    });
-
-    router.post(ApiRoute.upload.v1, (HttpRequest request) async {
-      return await _uploadHandler(request: request, v2: false);
-    });
-
-    router.post(ApiRoute.upload.v2, (HttpRequest request) async {
-      return await _uploadHandler(request: request, v2: true);
-    });
-
-    router.post(ApiRoute.cancel.v1, (HttpRequest request) async {
-      return await _cancelHandler(request: request, v2: false);
-    });
-
-    router.post(ApiRoute.cancel.v2, (HttpRequest request) async {
-      return await _cancelHandler(request: request, v2: true);
-    });
-
-    router.post(ApiRoute.show.v1, (HttpRequest request) async {
-      return await _showHandler(request: request, showToken: showToken);
-    });
-
-    router.post(ApiRoute.show.v2, (HttpRequest request) async {
-      return await _showHandler(request: request, showToken: showToken);
-    });
-  }
-
-  Future<void> _infoHandler({
-    required HttpRequest request,
-    required String alias,
-    required String fingerprint,
-  }) async {
-    final senderFingerprint = request.uri.queryParameters['fingerprint'];
-    if (senderFingerprint == fingerprint) {
-      // "I talked to myself lol"
-      return await request.respondJson(412, message: 'Self-discovered');
-    }
-
-    final deviceInfo = server.ref.read(deviceInfoProvider);
-
-    final dto = InfoDto(
-      alias: alias,
-      version: protocolVersion,
-      deviceModel: deviceInfo.deviceModel,
-      deviceType: deviceInfo.deviceType,
-      fingerprint: fingerprint,
-      download: server.getState().webSendState != null,
-    );
-
-    return await request.respondJson(200, body: dto.toJson());
-  }
-
-  Future<void> _registerHandler({
-    required HttpRequest request,
-    required String alias,
-    required String fingerprint,
-    required int port,
-    required bool https,
-  }) async {
-    final payload = await request.readAsString();
-    final RegisterDto requestDto;
-    try {
-      requestDto = RegisterDto.fromJson(jsonDecode(payload));
-    } catch (e) {
-      return await request.respondJson(400, message: 'Request body malformed');
-    }
-
-    if (requestDto.fingerprint == fingerprint) {
-      // "I talked to myself lol"
-      return await request.respondJson(412, message: 'Self-discovered');
-    }
-
-    // Save device information
-    await server.ref
-        .redux(nearbyDevicesProvider)
-        .dispatchAsync(RegisterDeviceAction(requestDto.toDevice(request.ip, port, https, HttpDiscovery(ip: request.ip))));
-    server.ref.notifier(discoveryLoggerProvider).addLog('[DISCOVER/TCP] Received "/register" HTTP request: ${requestDto.alias} (${request.ip})');
-
-    final deviceInfo = server.ref.read(deviceInfoProvider);
-
-    final responseDto = InfoDto(
-      alias: alias,
-      version: protocolVersion,
-      deviceModel: deviceInfo.deviceModel,
-      deviceType: deviceInfo.deviceType,
-      fingerprint: fingerprint,
-      download: server.getState().webSendState != null,
-    );
-
-    return await request.respondJson(200, body: responseDto.toJson());
-  }
-
-  Future<void> _prepareUploadHandler({
-    required HttpRequest request,
-    required int port,
-    required bool https,
-    required bool v2,
-  }) async {
-    if (server.getState().session != null) {
-      // block incoming requests when we are already in a session
-      return await request.respondJson(409, message: 'Blocked by another session');
-    }
-
-    final pinCorrect = await checkPin(
-      server: server,
-      pin: server.ref.read(settingsProvider).receivePin,
-      pinAttempts: server.getState().pinAttempts,
-      request: request,
-    );
-    if (!pinCorrect) {
-      return;
-    }
-
-    final PrepareUploadRequestDto dto;
-    try {
-      final payload = await request.readAsString();
-      dto = PrepareUploadRequestDto.fromJson(jsonDecode(payload));
-    } catch (e) {
-      return await request.respondJson(400, message: 'Request body malformed');
-    }
-
-    if (dto.files.isEmpty) {
-      // block empty requests (at least one file is required)
-      return await request.respondJson(400, message: 'Request must contain at least one file');
-    }
-
-    final settings = server.ref.read(settingsProvider);
-    final destinationDir = settings.destination ?? await getDefaultDestinationDirectory();
-    final cacheDir = await getCacheDirectory();
-    final sessionId = _uuid.v4();
-
-    _logger.info('Session Id: $sessionId');
-    _logger.info('Destination Directory: $destinationDir');
-
-    final streamController = StreamController<Map<String, String>?>();
-    server.setState(
-      (oldState) => oldState?.copyWith(
-        session: ReceiveSessionState(
-          sessionId: sessionId,
-          status: SessionStatus.waiting,
-          sender: dto.info.toDevice(request.ip, port, https, null),
-          senderAlias: server.ref.read(favoritesProvider).firstWhereOrNull((e) => e.fingerprint == dto.info.fingerprint)?.alias ?? dto.info.alias,
-          files: {
-            for (final file in dto.files.values)
-              file.id: ReceivingFile(
-                file: file,
-                status: FileStatus.queue,
-                token: null,
-                desiredName: null,
-                path: null,
-                savedToGallery: false,
-                errorMessage: null,
-              ),
-          },
-          startTime: null,
-          endTime: null,
-          destinationDirectory: destinationDir,
-          cacheDirectory: cacheDir,
-          saveToGallery: checkPlatformWithGallery() && settings.saveToGallery && dto.files.values.every((f) => !f.fileName.contains('/')),
-          createdDirectories: {},
-          responseHandler: streamController,
-        ),
-      ),
-    );
-
-    bool quickSave = settings.quickSave && server.getState().session?.message == null;
-    final quickSaveFromFavorites = settings.quickSaveFromFavorites && server.getState().session?.message == null;
-    if (quickSaveFromFavorites) {
-      final bool isFavorite = server.ref.read(favoritesProvider).any((e) => e.fingerprint == dto.info.fingerprint);
-      if (isFavorite) {
-        quickSave = true;
-      }
-    }
-    final Map<String, String>? selection;
-    if (quickSave) {
-      // accept all files
-      selection = {
-        for (final f in dto.files.values) f.id: f.fileName,
-      };
-    } else {
-      if (checkPlatformHasTray() && (await windowManager.isMinimized() || !(await windowManager.isVisible()) || !(await windowManager.isFocused()))) {
-        await showFromTray();
-      }
-
-      final message = server.getState().session?.message;
-      if (message != null) {
-        // Message already received
-        await server.ref
-            .redux(receiveHistoryProvider)
-            .dispatchAsync(
-              AddHistoryEntryAction(
-                entryId: const Uuid().v4(),
-                fileName: message,
-                fileType: FileType.text,
-                path: null,
-                savedToGallery: false,
-                isMessage: true,
-                fileSize: utf8.encode(message).length,
-                senderAlias: server.getState().session!.senderAlias,
-                timestamp: DateTime.now().toUtc(),
-              ),
-            );
-      }
-
-      final receiveProvider = ViewProvider((ref) {
-        final session = ref.watch(serverProvider.select((state) => state?.session));
-        return ReceivePageVm(
-          status: session?.status,
-          sender: session?.sender ?? Device.empty,
-          showSenderInfo: true,
-          files: session?.files.values.map((f) => f.file).toList() ?? [],
-          message: message,
-          onAccept: () async {
-            if (message != null) {
-              // accept nothing
-              ref.notifier(serverProvider).acceptFileRequest({});
-              return;
-            }
-
-            final sessionId = ref.read(serverProvider)?.session?.sessionId;
-            if (sessionId == null) {
-              return;
-            }
-
-            final selectedFiles = ref.read(selectedReceivingFilesProvider);
-            ref.notifier(serverProvider).acceptFileRequest(selectedFiles);
-
-            await Routerino.context.pushAndRemoveUntilImmediately(
-              removeUntil: ReceivePage,
-              builder: () => ProgressPage(
-                showAppBar: false,
-                closeSessionOnClose: true,
-                sessionId: sessionId,
-              ),
-            );
-          },
-          onDecline: () {
-            ref.notifier(serverProvider).declineFileRequest();
-          },
-          onClose: () {
-            ref.notifier(serverProvider).closeSession();
-          },
-        );
-      });
-
-      // ignore: use_build_context_synchronously, unawaited_futures
-      Routerino.context.push(() => ReceivePage(receiveProvider));
-
-      // Delayed response (waiting for user's decision)
-      selection = await streamController.stream.first;
-    }
-
-    if (server.getState().session == null) {
-      // somehow this state is already disposed
-      return await request.respondJson(500, message: 'Server is in invalid state');
-    }
-
-    if (selection == null) {
-      closeSession();
-      return await request.respondJson(403, message: 'File request declined by recipient');
-    }
-
-    if (selection.isEmpty) {
-      // nothing selected, send this to sender and close session
-      // This usually happens for message transfers
-      closeSession();
-      return await request.respondJson(204);
-    }
-
-    server.setState(
-      (oldState) {
-        final receiveState = oldState!.session!;
-        return oldState.copyWith(
-          session: receiveState.copyWith(
-            status: SessionStatus.sending,
-            files: Map.fromEntries(
-              receiveState.files.values.map((entry) {
-                final desiredName = selection![entry.file.id];
-                return MapEntry(
-                  entry.file.id,
-                  ReceivingFile(
-                    file: entry.file,
-                    status: desiredName != null ? FileStatus.queue : FileStatus.skipped,
-                    token: desiredName != null ? _uuid.v4() : null,
-                    desiredName: desiredName,
-                    path: null,
-                    savedToGallery: false,
-                    errorMessage: null,
-                  ),
-                );
-              }),
-            ),
-            responseHandler: null,
-          ),
-        );
-      },
-    );
-
-    if (quickSave) {
-      // ignore: use_build_context_synchronously, unawaited_futures
-      Routerino.context.pushImmediately(
-        () => ProgressPage(
-          showAppBar: false,
-          closeSessionOnClose: true,
-          sessionId: sessionId,
-        ),
-      );
-    }
-
-    final files = {
-      for (final file in server.getState().session!.files.values.where((f) => f.token != null)) file.file.id: file.token,
-    };
-
-    if (checkPlatform([TargetPlatform.android, TargetPlatform.iOS])) {
-      if (checkPlatform([TargetPlatform.android]) && !server.getState().session!.destinationDirectory.startsWith('/storage/emulated/0/Download')) {
-        // Android requires more permission to save files outside of the Download directory
-        try {
-          final result = await Permission.storage.request();
-          _logger.info('storage permission: $result');
-        } catch (e) {
-          _logger.warning('Could not request storage permission', e);
-        }
-      }
-      try {
-        await Permission.storage.request();
-      } catch (e) {
-        _logger.warning('Could not request storage permission', e);
-      }
-    }
-
-    if (v2) {
-      return await request.respondJson(
-        200,
-        body: PrepareUploadResponseDto(
-          sessionId: sessionId,
-          files: files.cast(),
-        ).toJson(),
-      );
-    }
-
-    return await request.respondJson(200, body: files);
-  }
-
-  Future<void> _uploadHandler({
-    required HttpRequest request,
-    required bool v2,
-  }) async {
-    final receiveState = server.getState().session;
-    if (receiveState == null) {
-      return await request.respondJson(409, message: 'No session');
-    }
-
-    if (request.ip != receiveState.sender.ip) {
-      _logger.warning('Invalid ip address: ${request.ip} (expected: ${receiveState.sender.ip})');
-      return await request.respondJson(403, message: 'Invalid IP address: ${request.ip}');
-    }
-
-    const allowedStates = {SessionStatus.sending, SessionStatus.finishedWithErrors};
-    if (!allowedStates.contains(receiveState.status)) {
-      _logger.warning('Wrong state: ${receiveState.status}');
-      return await request.respondJson(409, message: 'Recipient is in wrong state');
-    }
-
-    final fileId = request.uri.queryParameters['fileId'];
-    final token = request.uri.queryParameters['token'];
-    final sessionId = request.uri.queryParameters['sessionId'];
-    if (fileId == null || token == null || (v2 && sessionId == null)) {
-      // reject because of missing parameters
-      _logger.warning('Missing parameters: fileId=$fileId, token=$token, sessionId=$sessionId');
-      return await request.respondJson(400, message: 'Missing parameters');
-    }
-
-    if (v2 && sessionId != receiveState.sessionId) {
-      // reject because of wrong session id
-      _logger.warning('Wrong session id: $sessionId (expected: ${receiveState.sessionId})');
-      return await request.respondJson(403, message: 'Invalid session id');
-    }
-
-    final receivingFile = receiveState.files[fileId];
-    if (receivingFile == null || receivingFile.token != token) {
-      // reject because there is no file or token does not match
-      _logger.warning('Wrong fileId: $fileId (expected: ${receivingFile?.file.id})');
-      return await request.respondJson(403, message: 'Invalid token');
-    }
-
-    // begin of actual file transfer
-    server.setState(
-      (oldState) => oldState?.copyWith(
-        session: receiveState.copyWith(
-          files: {...receiveState.files}
-            ..update(
-              fileId,
-              (_) => receivingFile.copyWith(
-                status: FileStatus.sending,
-              ),
-            ),
-          startTime: receiveState.startTime ?? DateTime.now().millisecondsSinceEpoch,
-          status: SessionStatus.sending, // in case it was finishedWithErrors and user retries a failed file
-        ),
-      ),
-    );
-    final fileType = receivingFile.file.fileType;
-    final shouldSaveToGallery = receiveState.saveToGallery && (fileType == FileType.image || fileType == FileType.video);
-
-    String? filePath;
-    bool savedToGallery = false;
-    try {
-      _logger.info('Saving ${receivingFile.file.fileName}');
-
-      (savedToGallery, filePath) = await saveFile(
-        destinationDirectory: receiveState.destinationDirectory,
-        fileName: receivingFile.desiredName!,
-        saveToGallery: shouldSaveToGallery,
-        isImage: fileType == FileType.image,
-        stream: request,
-        onProgress: (savedBytes) {
-          if (receivingFile.file.size != 0) {
-            server.ref
-                .notifier(progressProvider)
-                .setProgress(
-                  sessionId: receiveState.sessionId,
-                  fileId: fileId,
-                  progress: savedBytes / receivingFile.file.size,
-                );
-          }
-        },
-        lastModified: receivingFile.file.metadata?.lastModified,
-        lastAccessed: receivingFile.file.metadata?.lastAccessed,
-        androidSdkInt: server.ref.read(deviceInfoProvider).androidSdkInt,
-        createdDirectories: receiveState.createdDirectories,
-      );
-      if (server.getState().session == null || !allowedStates.contains(server.getState().session!.status)) {
-        return await request.respondJson(500, message: 'Server is in invalid state');
-      }
-      server.setState(
-        (oldState) => oldState?.copyWith(
-          session: oldState.session?.fileFinished(
-            fileId: fileId,
-            status: FileStatus.finished,
-            path: filePath,
-            savedToGallery: savedToGallery,
-            errorMessage: null,
-          ),
-        ),
-      );
-
-      // Track it in history
-      await server.ref
-          .redux(receiveHistoryProvider)
-          .dispatchAsync(
-            AddHistoryEntryAction(
-              entryId: fileId,
-              fileName: receivingFile.desiredName!,
-              fileType: receivingFile.file.fileType,
-              path: filePath,
-              savedToGallery: savedToGallery,
-              isMessage: false,
-              fileSize: receivingFile.file.size,
-              senderAlias: receiveState.senderAlias,
-              timestamp: DateTime.now().toUtc(),
-            ),
-          );
-
-      _logger.info('Saved ${receivingFile.file.fileName}.');
-    } catch (e, st) {
-      server.setState(
-        (oldState) => oldState?.copyWith(
-          session: oldState.session?.fileFinished(
-            fileId: fileId,
-            status: FileStatus.failed,
-            path: null,
-            savedToGallery: false,
-            errorMessage: e.toString(),
-          ),
-        ),
-      );
-      _logger.severe('Failed to save file', e, st);
-    }
-
-    server.ref
-        .notifier(progressProvider)
-        .setProgress(
-          sessionId: receiveState.sessionId,
-          fileId: fileId,
-          progress: 1,
-        );
-
-    final session = server.getState().session;
-    if (session == null) {
-      return await request.respondJson(500, message: 'Server is in invalid state');
-    }
-
-    if (allowedStates.contains(session.status) && session.files.values.map((e) => e.status).isFinishedOrError) {
-      final hasError = session.files.values.any((f) => f.status == FileStatus.failed);
-      server.setState(
-        (oldState) => oldState?.copyWith(
-          session: oldState.session!.copyWith(
-            status: hasError ? SessionStatus.finishedWithErrors : SessionStatus.finished,
-            endTime: DateTime.now().millisecondsSinceEpoch,
-          ),
-        ),
-      );
-      final settings = server.ref.read(settingsProvider);
-      bool quickSave = settings.quickSave && server.getState().session?.message == null;
-      final quickSaveFromFavorites = settings.quickSaveFromFavorites && server.getState().session?.message == null;
-      if (quickSaveFromFavorites) {
-        // dto is not defined here. I must check sender fingerprint
-        final bool isFavorite = server.ref.read(favoritesProvider).any((e) => e.fingerprint == session.sender.fingerprint);
-        if (isFavorite) {
-          quickSave = true;
-        }
-      }
-      if (quickSave) {
-        // close the session **after** return of the response
-        Future.delayed(Duration.zero, () {
-          closeSession();
-          _logger.info('Closing session');
-
-          // ignore: use_build_context_synchronously, discarded_futures
-          Routerino.context.pushRootImmediately(() => const HomePage(initialTab: HomeTab.receive, appStart: false));
-
-          // open the dialog to open file instantly
-          if (filePath != null && filePath.isNotEmpty) {
-            // ignore: discarded_futures
-            OpenFileDialog.open(
-              Routerino.context, // ignore: use_build_context_synchronously
-              filePath: filePath,
-              fileType: fileType,
-              openGallery: savedToGallery,
-            );
-          }
-        });
-      }
-      _logger.info('Received all files.');
-    }
-
-    return server.getState().session?.files[fileId]?.status == FileStatus.finished
-        ? await request.respondJson(200)
-        : await request.respondJson(500, message: 'Could not save file. Check receiving device for more information.');
-  }
-
-  Future<void> _cancelHandler({
-    required HttpRequest request,
-    required bool v2,
-  }) async {
-    final receiveSession = server.getState().session;
-    if (receiveSession != null) {
-      // We are currently receiving files.
-
-      if (!v2 && receiveSession.sender.version != '1.0') {
-        // disallow v1 cancel for active v2 sessions
-        return await request.respondJson(403, message: 'No permission');
-      }
-
-      if (receiveSession.sender.ip != request.ip) {
-        return await request.respondJson(403, message: 'No permission');
-      }
-
-      // require session id for v2
-      // don't require it when during waiting state
-      if (v2 && receiveSession.status != SessionStatus.waiting) {
-        final sessionId = request.uri.queryParameters['sessionId'];
-        if (sessionId != receiveSession.sessionId) {
-          return await request.respondJson(403, message: 'No permission');
-        }
-      }
-
-      // check if valid state
-      final currentStatus = receiveSession.status;
-      if (currentStatus != SessionStatus.waiting && currentStatus != SessionStatus.sending) {
-        return await request.respondJson(403, message: 'No permission');
-      }
-
-      _cancelBySender(server);
-      return await request.respondJson(200);
-    } else {
-      // We are not receiving files so we may be sending files.
-
-      final sessionId = request.uri.queryParameters['sessionId'];
-      final sendSessions = server.ref.read(sendProvider);
-      final SendSessionState sendState;
-      if (v2) {
-        // In v2, we require sessionId.
-
-        final selectedSession = sendSessions.values.firstWhereOrNull((s) => s.remoteSessionId == sessionId);
-        if (selectedSession == null) {
-          return await request.respondJson(403, message: 'No permission');
-        }
-
-        sendState = selectedSession;
-      } else {
-        // In v1, we are a little bit more tolerant.
-        // Let's assume the sessionId if only one send session exist
-
-        final onlySession = sendSessions.values.singleOrNull;
-        if (onlySession == null) {
-          return await request.respondJson(403, message: 'No permission');
-        }
-
-        sendState = onlySession;
-      }
-
-      if (sendState.target.ip != request.ip) {
-        return await request.respondJson(403, message: 'No permission');
-      }
-
-      // check if valid state
-      if (sendState.status != SessionStatus.sending) {
-        return await request.respondJson(403, message: 'No permission');
-      }
-
-      server.ref
-          .notifier(sendProvider)
-          .cancelSessionByReceiver(
-            sendState.sessionId,
-          );
-      return await request.respondJson(200);
-    }
-  }
-
-  Future<void> _showHandler({
-    required HttpRequest request,
-    required String showToken,
-  }) async {
-    final senderToken = request.uri.queryParameters['token'];
-    if (senderToken == showToken && checkPlatformIsDesktop()) {
-      // ignore: unawaited_futures
-      showFromTray().catchError((e) {
-        // don't wait for it
-        _logger.severe('Failed to show from tray', e);
-      });
-
-      // ignore: unawaited_futures
-      request.readAsString().then((body) async {
-        if (body.isEmpty) {
-          return;
-        }
-
-        final Map<String, dynamic> jsonBody = jsonDecode(body);
-        final List<String> args = (jsonBody['args'] as List?)?.cast<String>() ?? <String>[];
-        final filesAdded = await server.ref.redux(selectedSendingFilesProvider).dispatchAsyncTakeResult(LoadSelectionFromArgsAction(args));
-        if (filesAdded) {
-          server.ref.redux(homePageControllerProvider).dispatch(ChangeTabAction(HomeTab.send));
-        }
-      });
-
-      return await request.respondJson(200);
-    }
-
-    return await request.respondJson(403, message: 'Invalid token');
-  }
-
-  void acceptFileRequest(Map<String, String> fileNameMap) {
-    final controller = server.getState().session?.responseHandler;
-    if (controller == null || controller.isClosed) {
-      return;
-    }
-
-    controller.add(fileNameMap);
-    controller.close(); // ignore: discarded_futures
-  }
-
-  void declineFileRequest() {
-    final controller = server.getState().session?.responseHandler;
-    if (controller == null || controller.isClosed) {
-      return;
-    }
-
-    controller.add(null);
-    controller.close(); // ignore: discarded_futures
-  }
-
-  /// Updates the destination directory for the current session.
-  void setSessionDestinationDir(String destinationDirectory) {
-    server.setState(
-      (oldState) => oldState?.copyWith(
-        session: oldState.session?.copyWith(
-          destinationDirectory: destinationDirectory.replaceAll('\\', '/'),
-        ),
-      ),
-    );
-  }
-
-  /// Updates the "saveToGallery" setting for the current session.
-  void setSessionSaveToGallery(bool saveToGallery) {
-    server.setState(
-      (oldState) => oldState?.copyWith(
-        session: oldState.session?.copyWith(
-          saveToGallery: saveToGallery,
-        ),
-      ),
-    );
-  }
-
-  /// In addition to [closeSession], this method also
-  /// - cancels incoming requests (TODO)
-  /// - notifies the sender that the session has been canceled
-  void cancelSession() async {
-    final session = server.getStateOrNull()?.session;
-    if (session == null) {
-      // the server is not running
-      return;
-    }
-
-    // notify sender
-    final target = session.sender;
-    try {
-      server.ref
-          .read(httpProvider)
-          .v2
-          // ignore: unawaited_futures
-          .cancel(
-            protocol: target.getProtocolType(),
-            ip: target.ip!,
-            port: target.port,
-            sessionId: session.sessionId,
-          );
-    } catch (e) {
-      _logger.warning('Failed to notify sender', e);
-    }
-
-    closeSession();
-
-    // TODO: cancel incoming requests (https://github.com/dart-lang/shelf/issues/319)
-    // restartServer(alias: tempState.alias, port: tempState.port);
-  }
-
-  void closeSession() {
-    final sessionId = server.getStateOrNull()?.session?.sessionId;
-    if (sessionId == null) {
-      return;
-    }
-
-    server.setState(
-      (oldState) => oldState?.copyWith(
-        session: null,
-      ),
-    );
-    server.ref.notifier(progressProvider).removeSession(sessionId);
-  }
-}
-
-void _cancelBySender(ServerUtils server) {
-  final receiveSession = server.getState().session;
-  if (receiveSession == null) {
-    return;
-  }
-
-  if (receiveSession.status == SessionStatus.waiting) {
-    // received cancel during accept/decline
-    // pop just in case if user is in [ReceiveOptionsPage]
-    Routerino.context.popUntil(ReceivePage);
-  }
-
-  server.setState(
-    (oldState) => oldState?.copyWith(
-      session: oldState.session?.copyWith(
-        status: SessionStatus.canceledBySender,
-        endTime: DateTime.now().millisecondsSinceEpoch,
-      ),
-    ),
-  );
-}
-
-extension on ReceiveSessionState {
-  ReceiveSessionState fileFinished({
-    required String fileId,
-    required FileStatus status,
-    required String? path,
-    required bool savedToGallery,
-    required String? errorMessage,
-  }) {
-    return copyWith(
-      files: {...files}
-        ..update(
-          fileId,
-          (file) => file.copyWith(
-            status: status,
-            path: path,
-            savedToGallery: savedToGallery,
-            errorMessage: errorMessage,
-          ),
-        ),
-    );
-  }
+ final ServerUtils server;
+
+ ReceiveController(this.server);
+
+ /// Installs all routes for receiving files.
+ void installRoutes({
+ required SimpleServerRouteBuilder router,
+ required String alias,
+ required int port,
+ required bool https,
+ required String fingerprint,
+ required String showToken,
+ }) {
+ router.get(ApiRoute.info.v1, (HttpRequest request) async {
+ return await _infoHandler(request: request, alias: alias, fingerprint: fingerprint);
+ });
+
+ router.get(ApiRoute.info.v2, (HttpRequest request) async {
+ return await _infoHandler(request: request, alias: alias, fingerprint: fingerprint);
+ });
+
+ // An upgraded version of /info
+ router.post(ApiRoute.register.v1, (HttpRequest request) async {
+ return await _registerHandler(request: request, alias: alias, port: port, https: https, fingerprint: fingerprint);
+ });
+
+ router.post(ApiRoute.register.v2, (HttpRequest request) async {
+ return await _registerHandler(request: request, alias: alias, port: port, https: https, fingerprint: fingerprint);
+ });
+
+ router.post(ApiRoute.prepareUpload.v1, (HttpRequest request) async {
+ return await _prepareUploadHandler(request: request, port: port, https: https, v2: false);
+ });
+
+ router.post(ApiRoute.prepareUpload.v2, (HttpRequest request) async {
+ return await _prepareUploadHandler(request: request, port: port, https: https, v2: true);
+ });
+
+ router.post(ApiRoute.upload.v1, (HttpRequest request) async {
+ return await _uploadHandler(request: request, v2: false);
+ });
+
+ router.post(ApiRoute.upload.v2, (HttpRequest request) async {
+ return await _uploadHandler(request: request, v2: true);
+ });
+
+ router.post(ApiRoute.cancel.v1, (HttpRequest request) async {
+ return await _cancelHandler(request: request, v2: false);
+ });
+
+ router.post(ApiRoute.cancel.v2, (HttpRequest request) async {
+ return await _cancelHandler(request: request, v2: true);
+ });
+
+ router.post(ApiRoute.show.v1, (HttpRequest request) async {
+ return await _showHandler(request: request, showToken: showToken);
+ });
+
+ router.post(ApiRoute.show.v2, (HttpRequest request) async {
+ return await _showHandler(request: request, showToken: showToken);
+ });
+ }
+
+ Future<void> _infoHandler({
+ required HttpRequest request,
+ required String alias,
+ required String fingerprint,
+ }) async {
+ final senderFingerprint = request.uri.queryParameters['fingerprint'];
+ if (senderFingerprint == fingerprint) {
+ // "I talked to myself lol"
+ return await request.respondJson(412, message: 'Self-discovered');
+ }
+
+ final deviceInfo = server.ref.read(deviceInfoProvider);
+
+ final dto = InfoDto(
+ alias: alias,
+ version: protocolVersion,
+ deviceModel: deviceInfo.deviceModel,
+ deviceType: deviceInfo.deviceType,
+ fingerprint: fingerprint,
+ download: server.getState().webSendState != null,
+ );
+
+ return await request.respondJson(200, body: dto.toJson());
+ }
+
+ Future<void> _registerHandler({
+ required HttpRequest request,
+ required String alias,
+ required String fingerprint,
+ required int port,
+ required bool https,
+ }) async {
+ final payload = await request.readAsString();
+ final RegisterDto requestDto;
+ try {
+ requestDto = RegisterDto.fromJson(jsonDecode(payload));
+ } catch (e) {
+ return await request.respondJson(400, message: 'Request body malformed');
+ }
+
+ if (requestDto.fingerprint == fingerprint) {
+ // "I talked to myself lol"
+ return await request.respondJson(412, message: 'Self-discovered');
+ }
+
+ // Save device information
+ await server.ref
+ .redux(nearbyDevicesProvider)
+ .dispatchAsync(RegisterDeviceAction(requestDto.toDevice(request.ip, port, https, HttpDiscovery(ip: request.ip))));
+ server.ref.notifier(discoveryLoggerProvider).addLog('[DISCOVER/TCP] Received "/register" HTTP request: ${requestDto.alias} (${request.ip})');
+
+ final deviceInfo = server.ref.read(deviceInfoProvider);
+
+ final responseDto = InfoDto(
+ alias: alias,
+ version: protocolVersion,
+ deviceModel: deviceInfo.deviceModel,
+ deviceType: deviceInfo.deviceType,
+ fingerprint: fingerprint,
+ download: server.getState().webSendState != null,
+ );
+
+ return await request.respondJson(200, body: responseDto.toJson());
+ }
+
+ Future<void> _prepareUploadHandler({
+ required HttpRequest request,
+ required int port,
+ required bool https,
+ required bool v2,
+ }) async {
+ if (server.getState().session != null) {
+ // block incoming requests when we are already in a session
+ return await request.respondJson(409, message: 'Blocked by another session');
+ }
+
+ final pinCorrect = await checkPin(
+ server: server,
+ pin: server.ref.read(settingsProvider).receivePin,
+ pinAttempts: server.getState().pinAttempts,
+ request: request,
+ );
+ if (!pinCorrect) {
+ return;
+ }
+
+ final PrepareUploadRequestDto dto;
+ try {
+ final payload = await request.readAsString();
+ dto = PrepareUploadRequestDto.fromJson(jsonDecode(payload));
+ } catch (e) {
+ return await request.respondJson(400, message: 'Request body malformed');
+ }
+
+ if (dto.files.isEmpty) {
+ // block empty requests (at least one file is required)
+ return await request.respondJson(400, message: 'Request must contain at least one file');
+ }
+
+ final settings = server.ref.read(settingsProvider);
+ final destinationDir = settings.destination ?? await getDefaultDestinationDirectory();
+ final cacheDir = await getCacheDirectory();
+ final sessionId = _uuid.v4();
+
+ _logger.info('Session Id: $sessionId');
+ _logger.info('Destination Directory: $destinationDir');
+
+ final streamController = StreamController<Map<String, String>?>();
+ server.setState(
+ (oldState) => oldState?.copyWith(
+ session: ReceiveSessionState(
+ sessionId: sessionId,
+ status: SessionStatus.waiting,
+ sender: dto.info.toDevice(request.ip, port, https, null),
+ senderAlias: server.ref.read(favoritesProvider).firstWhereOrNull((e) => e.fingerprint == dto.info.fingerprint)?.alias ?? dto.info.alias,
+ files: {
+ for (final file in dto.files.values)
+ file.id: ReceivingFile(
+ file: file,
+ status: FileStatus.queue,
+ token: null,
+ desiredName: null,
+ path: null,
+ savedToGallery: false,
+ errorMessage: null,
+ ),
+ },
+ startTime: null,
+ endTime: null,
+ destinationDirectory: destinationDir,
+ cacheDirectory: cacheDir,
+ saveToGallery: checkPlatformWithGallery() && settings.saveToGallery && dto.files.values.every((f) => !f.fileName.contains('/')),
+ createdDirectories: {},
+ responseHandler: streamController,
+ ),
+ ),
+ );
+
+ bool quickSave = settings.quickSave && server.getState().session?.message == null;
+ final quickSaveFromFavorites = settings.quickSaveFromFavorites && server.getState().session?.message == null;
+ if (quickSaveFromFavorites) {
+ final bool isFavorite = server.ref.read(favoritesProvider).any((e) => e.fingerprint == dto.info.fingerprint);
+ if (isFavorite) {
+ quickSave = true;
+ }
+ }
+ final Map<String, String>? selection;
+ if (quickSave) {
+ // accept all files
+ selection = {
+ for (final f in dto.files.values) f.id: f.fileName,
+ };
+ } else {
+ if (checkPlatformHasTray() && (await windowManager.isMinimized() || !(await windowManager.isVisible()) || !(await windowManager.isFocused()))) {
+ await showFromTray();
+ }
+
+ final message = server.getState().session?.message;
+ if (message != null) {
+ // Message already received
+ await server.ref
+ .redux(receiveHistoryProvider)
+ .dispatchAsync(
+ AddHistoryEntryAction(
+ entryId: const Uuid().v4(),
+ fileName: message,
+ fileType: FileType.text,
+ path: null,
+ savedToGallery: false,
+ isMessage: true,
+ fileSize: utf8.encode(message).length,
+ senderAlias: server.getState().session!.senderAlias,
+ timestamp: DateTime.now().toUtc(),
+ ),
+ );
+ }
+
+ final receiveProvider = ViewProvider((ref) {
+ final session = ref.watch(serverProvider.select((state) => state?.session));
+ return ReceivePageVm(
+ status: session?.status,
+ sender: session?.sender ?? Device.empty,
+ showSenderInfo: true,
+ files: session?.files.values.map((f) => f.file).toList() ?? [],
+ message: message,
+ onAccept: () async {
+ if (message != null) {
+ // accept nothing
+ ref.notifier(serverProvider).acceptFileRequest({});
+ return;
+ }
+
+ final sessionId = ref.read(serverProvider)?.session?.sessionId;
+ if (sessionId == null) {
+ return;
+ }
+
+ final selectedFiles = ref.read(selectedReceivingFilesProvider);
+ ref.notifier(serverProvider).acceptFileRequest(selectedFiles);
+
+ await Routerino.context.pushAndRemoveUntilImmediately(
+ removeUntil: ReceivePage,
+ builder: () => ProgressPage(
+ showAppBar: false,
+ closeSessionOnClose: true,
+ sessionId: sessionId,
+ ),
+ );
+ },
+ onDecline: () {
+ ref.notifier(serverProvider).declineFileRequest();
+ },
+ onClose: () {
+ ref.notifier(serverProvider).closeSession();
+ },
+ );
+ });
+
+ // ignore: use_build_context_synchronously, unawaited_futures
+ Routerino.context.push(() => ReceivePage(receiveProvider));
+
+ // Delayed response (waiting for user's decision)
+ selection = await streamController.stream.first;
+ }
+
+ if (server.getState().session == null) {
+ // somehow this state is already disposed
+ return await request.respondJson(500, message: 'Server is in invalid state');
+ }
+
+ if (selection == null) {
+ closeSession();
+ return await request.respondJson(403, message: 'File request declined by recipient');
+ }
+
+ if (selection.isEmpty) {
+ // nothing selected, send this to sender and close session
+ // This usually happens for message transfers
+ closeSession();
+ return await request.respondJson(204);
+ }
+
+ server.setState(
+ (oldState) {
+ final receiveState = oldState!.session!;
+ return oldState.copyWith(
+ session: receiveState.copyWith(
+ status: SessionStatus.sending,
+ files: Map.fromEntries(
+ receiveState.files.values.map((entry) {
+ final desiredName = selection![entry.file.id];
+ return MapEntry(
+ entry.file.id,
+ ReceivingFile(
+ file: entry.file,
+ status: desiredName != null ? FileStatus.queue : FileStatus.skipped,
+ token: desiredName != null ? _uuid.v4() : null,
+ desiredName: desiredName,
+ path: null,
+ savedToGallery: false,
+ errorMessage: null,
+ ),
+ );
+ }),
+ ),
+ responseHandler: null,
+ ),
+ );
+ },
+ );
+
+ if (quickSave) {
+ // ignore: use_build_context_synchronously, unawaited_futures
+ Routerino.context.pushImmediately(
+ () => ProgressPage(
+ showAppBar: false,
+ closeSessionOnClose: true,
+ sessionId: sessionId,
+ ),
+ );
+ }
+
+ final files = {
+ for (final file in server.getState().session!.files.values.where((f) => f.token != null)) file.file.id: file.token,
+ };
+
+ if (checkPlatform([TargetPlatform.android, TargetPlatform.iOS])) {
+ if (checkPlatform([TargetPlatform.android]) && !server.getState().session!.destinationDirectory.startsWith('/storage/emulated/0/Download')) {
+ // Android requires more permission to save files outside of the Download directory
+ try {
+ final result = await Permission.storage.request();
+ _logger.info('storage permission: $result');
+ } catch (e) {
+ _logger.warning('Could not request storage permission', e);
+ }
+ }
+ try {
+ await Permission.storage.request();
+ } catch (e) {
+ _logger.warning('Could not request storage permission', e);
+ }
+ }
+
+ if (v2) {
+ return await request.respondJson(
+ 200,
+ body: PrepareUploadResponseDto(
+ sessionId: sessionId,
+ files: files.cast(),
+ ).toJson(),
+ );
+ }
+
+ return await request.respondJson(200, body: files);
+ }
+
+ Future<void> _uploadHandler({
+ required HttpRequest request,
+ required bool v2,
+ }) async {
+ final receiveState = server.getState().session;
+ if (receiveState == null) {
+ return await request.respondJson(409, message: 'No session');
+ }
+
+ if (request.ip != receiveState.sender.ip) {
+ _logger.warning('Invalid ip address: ${request.ip} (expected: ${receiveState.sender.ip})');
+ return await request.respondJson(403, message: 'Invalid IP address: ${request.ip}');
+ }
+
+ const allowedStates = {SessionStatus.sending, SessionStatus.finishedWithErrors};
+ if (!allowedStates.contains(receiveState.status)) {
+ _logger.warning('Wrong state: ${receiveState.status}');
+ return await request.respondJson(409, message: 'Recipient is in wrong state');
+ }
+
+ final fileId = request.uri.queryParameters['fileId'];
+ final token = request.uri.queryParameters['token'];
+ final sessionId = request.uri.queryParameters['sessionId'];
+ if (fileId == null || token == null || (v2 && sessionId == null)) {
+ // reject because of missing parameters
+ _logger.warning('Missing parameters: fileId=$fileId, token=$token, sessionId=$sessionId');
+ return await request.respondJson(400, message: 'Missing parameters');
+ }
+
+ if (v2 && sessionId != receiveState.sessionId) {
+ // reject because of wrong session id
+ _logger.warning('Wrong session id: $sessionId (expected: ${receiveState.sessionId})');
+ return await request.respondJson(403, message: 'Invalid session id');
+ }
+
+ final receivingFile = receiveState.files[fileId];
+ if (receivingFile == null || receivingFile.token != token) {
+ // reject because there is no file or token does not match
+ _logger.warning('Wrong fileId: $fileId (expected: ${receivingFile?.file.id})');
+ return await request.respondJson(403, message: 'Invalid token');
+ }
+
+ // begin of actual file transfer
+ server.setState(
+ (oldState) => oldState?.copyWith(
+ session: receiveState.copyWith(
+ files: {...receiveState.files}
+ ..update(
+ fileId,
+ (_) => receivingFile.copyWith(
+ status: FileStatus.sending,
+ ),
+ ),
+ startTime: receiveState.startTime ?? DateTime.now().millisecondsSinceEpoch,
+ status: SessionStatus.sending, // in case it was finishedWithErrors and user retries a failed file
+ ),
+ ),
+ );
+ final fileType = receivingFile.file.fileType;
+ final shouldSaveToGallery = receiveState.saveToGallery && (fileType == FileType.image || fileType == FileType.video);
+
+ String? filePath;
+ bool savedToGallery = false;
+ try {
+ _logger.info('Saving ${receivingFile.file.fileName}');
+
+ (savedToGallery, filePath) = await saveFile(
+ destinationDirectory: receiveState.destinationDirectory,
+ fileName: receivingFile.desiredName!,
+ saveToGallery: shouldSaveToGallery,
+ isImage: fileType == FileType.image,
+ stream: request,
+ onProgress: (savedBytes) {
+ if (receivingFile.file.size != 0) {
+ server.ref
+ .notifier(progressProvider)
+ .setProgress(
+ sessionId: receiveState.sessionId,
+ fileId: fileId,
+ progress: savedBytes / receivingFile.file.size,
+ );
+ }
+ },
+ lastModified: receivingFile.file.metadata?.lastModified,
+ lastAccessed: receivingFile.file.metadata?.lastAccessed,
+ androidSdkInt: server.ref.read(deviceInfoProvider).androidSdkInt,
+ createdDirectories: receiveState.createdDirectories,
+ );
+ if (server.getState().session == null || !allowedStates.contains(server.getState().session!.status)) {
+ return await request.respondJson(500, message: 'Server is in invalid state');
+ }
+ server.setState(
+ (oldState) => oldState?.copyWith(
+ session: oldState.session?.fileFinished(
+ fileId: fileId,
+ status: FileStatus.finished,
+ path: filePath,
+ savedToGallery: savedToGallery,
+ errorMessage: null,
+ ),
+ ),
+ );
+
+ // Track it in history
+ await server.ref
+ .redux(receiveHistoryProvider)
+ .dispatchAsync(
+ AddHistoryEntryAction(
+ entryId: fileId,
+ fileName: receivingFile.desiredName!,
+ fileType: receivingFile.file.fileType,
+ path: filePath,
+ savedToGallery: savedToGallery,
+ isMessage: false,
+ fileSize: receivingFile.file.size,
+ senderAlias: receiveState.senderAlias,
+ timestamp: DateTime.now().toUtc(),
+ ),
+ );
+
+ // Execute post-receive hook if configured
+ final hookCommand = server.ref.read(settingsProvider).postReceiveHook;
+ if (hookCommand != null && hookCommand.trim().isNotEmpty && filePath != null) {
+ // Run hook asynchronously so it doesn't block the response
+ unawaited(
+ PostReceiveHook(hookCommand).execute(
+ filePath: filePath,
+ originalFileName: receivingFile.file.fileName,
+ senderAlias: receiveState.senderAlias,
+ fileSize: receivingFile.file.size,
+ fileType: fileType,
+ savedToGallery: savedToGallery,
+ ),
+ );
+ }
+
+ _logger.info('Saved ${receivingFile.file.fileName}.');
+ } catch (e, st) {
+ server.setState(
+ (oldState) => oldState?.copyWith(
+ session: oldState.session?.fileFinished(
+ fileId: fileId,
+ status: FileStatus.failed,
+ path: null,
+ savedToGallery: false,
+ errorMessage: e.toString(),
+ ),
+ ),
+ );
+ _logger.severe('Failed to save file', e, st);
+ }
+
+ server.ref
+ .notifier(progressProvider)
+ .setProgress(
+ sessionId: receiveState.sessionId,
+ fileId: fileId,
+ progress: 1,
+ );
+
+ final session = server.getState().session;
+ if (session == null) {
+ return await request.respondJson(500, message: 'Server is in invalid state');
+ }
+
+ if (allowedStates.contains(session.status) && session.files.values.map((e) => e.status).isFinishedOrError) {
+ final hasError = session.files.values.any((f) => f.status == FileStatus.failed);
+ server.setState(
+ (oldState) => oldState?.copyWith(
+ session: oldState.session!.copyWith(
+ status: hasError ? SessionStatus.finishedWithErrors : SessionStatus.finished,
+ endTime: DateTime.now().millisecondsSinceEpoch,
+ ),
+ ),
+ );
+ final settings = server.ref.read(settingsProvider);
+ bool quickSave = settings.quickSave && server.getState().session?.message == null;
+ final quickSaveFromFavorites = settings.quickSaveFromFavorites && server.getState().session?.message == null;
+ if (quickSaveFromFavorites) {
+ // dto is not defined here. I must check sender fingerprint
+ final bool isFavorite = server.ref.read(favoritesProvider).any((e) => e.fingerprint == session.sender.fingerprint);
+ if (isFavorite) {
+ quickSave = true;
+ }
+ }
+ if (quickSave) {
+ // close the session **after** return of the response
+ Future.delayed(Duration.zero, () {
+ closeSession();
+ _logger.info('Closing session');
+
+ // ignore: use_build_context_synchronously, discarded_futures
+ Routerino.context.pushRootImmediately(() => const HomePage(initialTab: HomeTab.receive, appStart: false));
+
+ // open the dialog to open file instantly
+ if (filePath != null && filePath.isNotEmpty) {
+ // ignore: discarded_futures
+ OpenFileDialog.open(
+ Routerino.context, // ignore: use_build_context_synchronously
+ filePath: filePath,
+ fileType: fileType,
+ openGallery: savedToGallery,
+ );
+ }
+ });
+ }
+ _logger.info('Received all files.');
+ }
+
+ return server.getState().session?.files[fileId]?.status == FileStatus.finished
+ ? await request.respondJson(200)
+ : await request.respondJson(500, message: 'Could not save file. Check receiving device for more information.');
+ }
+
+ Future<void> _cancelHandler({
+ required HttpRequest request,
+ required bool v2,
+ }) async {
+ final session = server.getState().session;
+ if (session == null) {
+ return await request.respondJson(409, message: 'No session');
+ }
+
+ if (request.ip != session.sender.ip) {
+ _logger.warning('Invalid ip address: ${request.ip} (expected: ${session.sender.ip})');
+ return await request.respondJson(403, message: 'Invalid IP address: ${request.ip}');
+ }
+
+ const allowedStates = {SessionStatus.sending, SessionStatus.finishedWithErrors};
+ if (!allowedStates.contains(session.status)) {
+ _logger.warning('Wrong state: ${session.status}');
+ return await request.respondJson(409, message: 'Recipient is in wrong state');
+ }
+
+ final fileId = request.uri.queryParameters['fileId'];
+ if (fileId == null) {
+ return await request.respondJson(400, message: 'Missing parameters');
+ }
+
+ final receivingFile = session.files[fileId];
+ if (receivingFile == null) {
+ _logger.warning('Wrong fileId: $fileId');
+ return await request.respondJson(403, message: 'Invalid file id');
+ }
+
+ server.setState(
+ (oldState) => oldState?.copyWith(
+ session: session.copyWith(
+ files: {...session.files}
+ ..update(
+ fileId,
+ (value) => value.copyWith(
+ status: FileStatus.cancelled,
+ ),
+ ),
+ ),
+ ),
+ );
+
+ return await request.respondJson(200);
+ }
+
+ Future<void> _showHandler({
+ required HttpRequest request,
+ required String showToken,
+ }) async {
+ final token = request.uri.queryParameters['token'];
+ if (token == null || token != showToken) {
+ return await request.respondJson(403, message: 'Invalid token');
+ }
+
+ await showFromTray();
+ return await request.respondJson(200);
+ }
+
+ void closeSession() {
+ server.setState((state) => state?.copyWith(session: null));
+ }
 }

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -32,13 +32,13 @@ part 'persistence_provider_migrations.dart';
 final _logger = Logger('PersistenceService');
 
 String get _windowsFile {
-  final appData = Platform.environment['APPDATA'];
-  return '$appData\\LocalSend\\settings.json';
+ final appData = Platform.environment['APPDATA'];
+ return '$appData\\LocalSend\\settings.json';
 }
 
 String get _windowsLegacyFile {
-  final appData = Platform.environment['APPDATA'];
-  return '$appData\\org.localsend\\localsend_app\\shared_preferences.json';
+ final appData = Platform.environment['APPDATA'];
+ return '$appData\\org.localsend\\localsend_app\\shared_preferences.json';
 }
 
 // Version of the storage
@@ -90,463 +90,476 @@ const _deviceType = 'ls_device_type';
 const _deviceModel = 'ls_device_model';
 const _shareViaLinkAutoAccept = 'ls_share_via_link_auto_accept';
 const _advancedSettingsKey = 'ls_advanced_settings';
+const _postReceiveHook = 'ls_post_receive_hook';
 
 final persistenceProvider = Provider<PersistenceService>((ref) {
-  throw Exception('persistenceProvider not initialized');
+ throw Exception('persistenceProvider not initialized');
 });
 
 /// This service abstracts the persistence layer.
 class PersistenceService {
-  final SharedPreferences _prefs;
-  final bool isFirstAppStart;
-
-  PersistenceService._(this._prefs, this.isFirstAppStart);
-
-  static Future<PersistenceService> initialize({
-    required bool supportsDynamicColors,
-  }) async {
-    SharedPreferences prefs;
-
-    final portableStore = SharedPreferencesPortable();
-    bool usingLegacyStore = false;
-    if (checkPlatform(const [TargetPlatform.windows, TargetPlatform.linux, TargetPlatform.macOS]) && portableStore.exists()) {
-      _logger.info('Using portable settings.');
-      SharedPreferencesStorePlatform.instance = portableStore;
-    } else if (defaultTargetPlatform == TargetPlatform.windows) {
-      final legacyStore = SharedPreferencesFile(filePath: _windowsLegacyFile);
-      if (legacyStore.exists()) {
-        _logger.info('Using legacy settings. Will migrate in the next step.');
-        SharedPreferencesStorePlatform.instance = legacyStore;
-        usingLegacyStore = true;
-      } else {
-        SharedPreferencesStorePlatform.instance = SharedPreferencesFile(filePath: _windowsFile);
-      }
-    }
-
-    final bool isFirstAppStart;
-    final existingVersion = (await SharedPreferencesStorePlatform.instance.getAll())['flutter.$_version'] as int?;
-    _logger.info('Existing version: $existingVersion');
-    if (existingVersion == null && !usingLegacyStore) {
-      isFirstAppStart = true;
-      await SharedPreferencesStorePlatform.instance.setValue('Int', 'flutter.$_version', _latestVersion);
-    } else {
-      isFirstAppStart = false;
-      final fromVersion = existingVersion ?? 1;
-      if (fromVersion < _latestVersion) {
-        await _runMigrations(fromVersion);
-      }
-    }
-
-    try {
-      prefs = await SharedPreferences.getInstance();
-    } catch (e) {
-      if (checkPlatform([TargetPlatform.windows])) {
-        _logger.info('Could not initialize SharedPreferences, trying to delete corrupted settings file', e);
-        File(_windowsFile).deleteSync();
-        prefs = await SharedPreferences.getInstance();
-      } else {
-        throw Exception('Could not initialize SharedPreferences');
-      }
-    }
-
-    // Locale configuration upon persistence initialisation to prevent unlocalised Alias generation
-    final persistedLocale = prefs.getString(_localeKey);
-    if (persistedLocale == null) {
-      await LocaleSettings.useDeviceLocale();
-    } else {
-      await LocaleSettings.setLocaleRaw(persistedLocale);
-    }
-
-    if (prefs.getString(_showToken) == null) {
-      await prefs.setString(_showToken, const Uuid().v4());
-    }
-
-    if (prefs.getString(_aliasKey) == null) {
-      await prefs.setString(_aliasKey, generateRandomAlias());
-    }
-
-    if (prefs.getString(_securityContext) == null) {
-      await prefs.setString(_securityContext, jsonEncode(generateSecurityContext()));
-    }
-
-    if (isFirstAppStart) {
-      final systemAnimations = await getSystemAnimationsStatus();
-      if (!systemAnimations) {
-        _logger.info('System animations are disabled, disabling animations in the app.');
-        await prefs.setBool(_enableAnimations, false);
-      }
-    }
-
-    if (prefs.getString(_colorKey) == null) {
-      await _initColorSetting(prefs, supportsDynamicColors);
-    } else {
-      // fix when device does not support dynamic colors
-      final supported = supportsDynamicColors ? ColorMode.values : ColorMode.values.where((e) => e != ColorMode.system);
-      final colorMode = supported.firstWhereOrNull((color) => color.name == prefs.getString(_colorKey));
-      if (colorMode == null) {
-        await _initColorSetting(prefs, supportsDynamicColors);
-      }
-    }
-
-    // migrate legacy auto start settings (current implementation is stateless and relies on the Windows registry / file system)
-    const launchAtStartupLegacyKey = 'ls_launch_at_startup';
-    const launchMinimizedLegacyKey = 'ls_auto_start_launch_minimized';
-    if (prefs.getBool(launchAtStartupLegacyKey) == true) {
-      _logger.info('Enable auto start on legacy settings');
-      await prefs.remove(launchAtStartupLegacyKey);
-      await enableAutoStart(startHidden: prefs.getBool(launchMinimizedLegacyKey) == true);
-      await prefs.remove(launchMinimizedLegacyKey);
-    }
-
-    return PersistenceService._(prefs, isFirstAppStart);
-  }
-
-  static Future<void> _initColorSetting(SharedPreferences prefs, bool supportsDynamicColors) async {
-    await prefs.setString(
-      _colorKey,
-      checkPlatform([TargetPlatform.android]) && supportsDynamicColors ? ColorMode.system.name : ColorMode.localsend.name,
-    );
-  }
-
-  bool isPortableMode() {
-    return SharedPreferencesStorePlatform.instance is SharedPreferencesPortable;
-  }
-
-  StoredSecurityContext getSecurityContext() {
-    final contextRaw = _prefs.getString(_securityContext)!;
-    return StoredSecurityContext.fromJson(jsonDecode(contextRaw));
-  }
-
-  Future<void> setSecurityContext(StoredSecurityContext context) async {
-    await _prefs.setString(_securityContext, jsonEncode(context));
-  }
-
-  List<String>? getSignalingServers() {
-    final serversRaw = _prefs.getString(_signalingServers);
-    if (serversRaw == null) {
-      return null;
-    }
-
-    return (jsonDecode(serversRaw) as List).cast<String>();
-  }
-
-  Future<void> setSignalingServers(List<String> servers) async {
-    await _prefs.setString(_signalingServers, jsonEncode(servers));
-  }
-
-  List<String>? getStunServers() {
-    final serversRaw = _prefs.getString(_stunServers);
-    if (serversRaw == null) {
-      return null;
-    }
-
-    return (jsonDecode(serversRaw) as List).cast<String>();
-  }
-
-  Future<void> setStunServers(List<String> servers) async {
-    await _prefs.setString(_stunServers, jsonEncode(servers));
-  }
-
-  List<ReceiveHistoryEntry> getReceiveHistory() {
-    final historyRaw = _prefs.getStringList(_receiveHistory) ?? [];
-    return historyRaw.map((entry) => ReceiveHistoryEntry.fromJson(jsonDecode(entry))).toList();
-  }
-
-  Future<void> setReceiveHistory(List<ReceiveHistoryEntry> entries) async {
-    final historyRaw = entries.map((entry) => jsonEncode(entry.toJson())).toList();
-    await _prefs.setStringList(_receiveHistory, historyRaw);
-  }
-
-  List<FavoriteDevice> getFavorites() {
-    final favoritesRaw = _prefs.getStringList(_favorites) ?? [];
-    return favoritesRaw.map((entry) => FavoriteDevice.fromJson(jsonDecode(entry))).toList();
-  }
-
-  Future<void> setFavorites(List<FavoriteDevice> entries) async {
-    final favoritesRaw = entries.map((entry) => jsonEncode(entry.toJson())).toList();
-    await _prefs.setStringList(_favorites, favoritesRaw);
-  }
-
-  String getShowToken() {
-    return _prefs.getString(_showToken)!;
-  }
-
-  String getAlias() {
-    return _prefs.getString(_aliasKey) ?? generateRandomAlias();
-  }
-
-  Future<void> setAlias(String alias) async {
-    await _prefs.setString(_aliasKey, alias);
-  }
-
-  ThemeMode getTheme() {
-    final value = _prefs.getString(_themeKey);
-    if (value == null) {
-      return ThemeMode.system;
-    }
-    return ThemeMode.values.firstWhereOrNull((theme) => theme.name == value) ?? ThemeMode.system;
-  }
-
-  Future<void> setTheme(ThemeMode theme) async {
-    await _prefs.setString(_themeKey, theme.name);
-  }
-
-  ColorMode getColorMode() {
-    final value = _prefs.getString(_colorKey);
-    if (value == null) {
-      return ColorMode.system;
-    }
-    return ColorMode.values.firstWhereOrNull((color) => color.name == value) ?? ColorMode.system;
-  }
-
-  Future<void> setColorMode(ColorMode color) async {
-    await _prefs.setString(_colorKey, color.name);
-  }
-
-  AppLocale? getLocale() {
-    final value = _prefs.getString(_localeKey);
-    if (value == null) {
-      return null;
-    }
-    return AppLocale.values.firstWhereOrNull((locale) => locale.languageTag == value);
-  }
-
-  Future<void> setLocale(AppLocale? locale) async {
-    if (locale == null) {
-      await _prefs.remove(_localeKey);
-    } else {
-      await _prefs.setString(_localeKey, locale.languageTag);
-    }
-  }
-
-  int getPort() {
-    return _prefs.getInt(_portKey) ?? defaultPort;
-  }
-
-  Future<void> setPort(int port) async {
-    await _prefs.setInt(_portKey, port);
-  }
-
-  List<String>? getNetworkWhitelist() {
-    return _prefs.getStringList(_networkWhitelistKey);
-  }
-
-  Future<void> setNetworkWhitelist(List<String>? whitelist) async {
-    if (whitelist == null) {
-      await _prefs.remove(_networkWhitelistKey);
-    } else {
-      await _prefs.setStringList(_networkWhitelistKey, whitelist);
-    }
-  }
-
-  List<String>? getNetworkBlacklist() {
-    return _prefs.getStringList(_networkBlacklistKey);
-  }
-
-  Future<void> setNetworkBlacklist(List<String>? blacklist) async {
-    if (blacklist == null) {
-      await _prefs.remove(_networkBlacklistKey);
-    } else {
-      await _prefs.setStringList(_networkBlacklistKey, blacklist);
-    }
-  }
-
-  int getDiscoveryTimeout() {
-    return _prefs.getInt(_timeoutKey) ?? defaultDiscoveryTimeout;
-  }
-
-  Future<void> setDiscoveryTimeout(int timeout) async {
-    await _prefs.setInt(_timeoutKey, timeout);
-  }
-
-  bool getShareViaLinkAutoAccept() {
-    return _prefs.getBool(_shareViaLinkAutoAccept) ?? false;
-  }
-
-  Future<void> setShareViaLinkAutoAccept(bool shareViaLinkAutoAccept) async {
-    await _prefs.setBool(_shareViaLinkAutoAccept, shareViaLinkAutoAccept);
-  }
-
-  String getMulticastGroup() {
-    return _prefs.getString(_multicastGroupKey) ?? defaultMulticastGroup;
-  }
-
-  Future<void> setMulticastGroup(String group) async {
-    await _prefs.setString(_multicastGroupKey, group);
-  }
-
-  String? getDestination() {
-    return _prefs.getString(_destinationKey);
-  }
-
-  Future<void> setDestination(String? destination) async {
-    if (destination == null) {
-      await _prefs.remove(_destinationKey);
-    } else {
-      await _prefs.setString(_destinationKey, destination);
-    }
-  }
-
-  bool isSaveToGallery() {
-    return _prefs.getBool(_saveToGallery) ?? true;
-  }
-
-  Future<void> setSaveToGallery(bool saveToGallery) async {
-    await _prefs.setBool(_saveToGallery, saveToGallery);
-  }
-
-  bool isSaveToHistory() {
-    return _prefs.getBool(_saveToHistory) ?? true;
-  }
-
-  Future<void> setSaveToHistory(bool saveToHistory) async {
-    await _prefs.setBool(_saveToHistory, saveToHistory);
-  }
-
-  bool getAdvancedSettingsEnabled() {
-    return _prefs.getBool(_advancedSettingsKey) ?? false;
-  }
-
-  Future<void> setAdvancedSettingsEnabled(bool isEnabled) async {
-    await _prefs.setBool(_advancedSettingsKey, isEnabled);
-  }
-
-  bool isQuickSave() {
-    return _prefs.getBool(_quickSave) ?? false;
-  }
-
-  Future<void> setQuickSave(bool quickSave) async {
-    await _prefs.setBool(_quickSave, quickSave);
-  }
-
-  bool isQuickSaveFromFavorites() {
-    return _prefs.getBool(_quickSaveFromFavorites) ?? false;
-  }
-
-  Future<void> setQuickSaveFromFavorites(bool quickSaveFromFavorites) async {
-    await _prefs.setBool(_quickSaveFromFavorites, quickSaveFromFavorites);
-  }
-
-  String? getReceivePin() {
-    return _prefs.getString(_receivePin);
-  }
-
-  Future<void> setReceivePin(String? pin) async {
-    if (pin == null) {
-      await _prefs.remove(_receivePin);
-    } else {
-      await _prefs.setString(_receivePin, pin);
-    }
-  }
-
-  bool isAutoFinish() {
-    return _prefs.getBool(_autoFinish) ?? false;
-  }
-
-  Future<void> setAutoFinish(bool autoFinish) async {
-    await _prefs.setBool(_autoFinish, autoFinish);
-  }
-
-  bool isMinimizeToTray() {
-    return _prefs.getBool(_minimizeToTray) ?? false;
-  }
-
-  Future<void> setMinimizeToTray(bool minimizeToTray) async {
-    await _prefs.setBool(_minimizeToTray, minimizeToTray);
-  }
-
-  bool isHttps() {
-    return _prefs.getBool(_https) ?? true;
-  }
-
-  Future<void> setHttps(bool https) async {
-    await _prefs.setBool(_https, https);
-  }
-
-  SendMode getSendMode() {
-    return SendMode.values.firstWhereOrNull((m) => m.name == _prefs.getString(_sendMode)) ?? SendMode.single;
-  }
-
-  Future<void> setSendMode(SendMode mode) async {
-    await _prefs.setString(_sendMode, mode.name);
-  }
-
-  Future<void> setWindowOffsetX(double x) async {
-    await _prefs.setDouble(_windowOffsetX, x);
-  }
-
-  Future<void> setWindowOffsetY(double y) async {
-    await _prefs.setDouble(_windowOffsetY, y);
-  }
-
-  Future<void> setWindowHeight(double height) async {
-    await _prefs.setDouble(_windowHeight, height);
-  }
-
-  Future<void> setWindowWidth(double width) async {
-    await _prefs.setDouble(_windowWidth, width);
-  }
-
-  WindowDimensions? getWindowLastDimensions() {
-    Size? size;
-    Offset? position;
-    final offsetX = _prefs.getDouble(_windowOffsetX);
-    final offsetY = _prefs.getDouble(_windowOffsetY);
-    final width = _prefs.getDouble(_windowWidth);
-    final height = _prefs.getDouble(_windowHeight);
-
-    if (width != null && height != null) {
-      size = Size(width, height);
-    }
-
-    if (offsetX != null && offsetY != null) {
-      position = Offset(offsetX, offsetY);
-    }
-
-    if (size == null || position == null) {
-      return null;
-    }
-
-    return WindowDimensions(
-      position: position,
-      size: size,
-    );
-  }
-
-  Future<void> setSaveWindowPlacement(bool savePlacement) async {
-    await _prefs.setBool(_saveWindowPlacement, savePlacement);
-  }
-
-  bool getSaveWindowPlacement() {
-    if (!checkPlatformIsNotWaylandDesktop()) return false;
-    return _prefs.getBool(_saveWindowPlacement) ?? true;
-  }
-
-  Future<void> setEnableAnimations(bool enableAnimations) async {
-    await _prefs.setBool(_enableAnimations, enableAnimations);
-  }
-
-  bool getEnableAnimations() {
-    return _prefs.getBool(_enableAnimations) ?? true;
-  }
-
-  DeviceType? getDeviceType() {
-    return DeviceType.values.firstWhereOrNull((m) => m.name == _prefs.getString(_deviceType));
-  }
-
-  Future<void> setDeviceType(DeviceType deviceType) async {
-    await _prefs.setString(_deviceType, deviceType.name);
-  }
-
-  String? getDeviceModel() {
-    return _prefs.getString(_deviceModel);
-  }
-
-  Future<void> setDeviceModel(String deviceModel) async {
-    await _prefs.setString(_deviceModel, deviceModel);
-  }
-
-  Future<void> clear() async {
-    await _prefs.clear();
-  }
+ final SharedPreferences _prefs;
+ final bool isFirstAppStart;
+
+ PersistenceService._(this._prefs, this.isFirstAppStart);
+
+ static Future<PersistenceService> initialize({
+ required bool supportsDynamicColors,
+ }) async {
+ SharedPreferences prefs;
+
+ final portableStore = SharedPreferencesPortable();
+ bool usingLegacyStore = false;
+ if (checkPlatform(const [TargetPlatform.windows, TargetPlatform.linux, TargetPlatform.macOS]) && portableStore.exists()) {
+ _logger.info('Using portable settings.');
+ SharedPreferencesStorePlatform.instance = portableStore;
+ } else if (defaultTargetPlatform == TargetPlatform.windows) {
+ final legacyStore = SharedPreferencesFile(filePath: _windowsLegacyFile);
+ if (legacyStore.exists()) {
+ _logger.info('Using legacy settings. Will migrate in the next step.');
+ SharedPreferencesStorePlatform.instance = legacyStore;
+ usingLegacyStore = true;
+ } else {
+ SharedPreferencesStorePlatform.instance = SharedPreferencesFile(filePath: _windowsFile);
+ }
+ }
+
+ final bool isFirstAppStart;
+ final existingVersion = (await SharedPreferencesStorePlatform.instance.getAll())['flutter.$_version'] as int?;
+ _logger.info('Existing version: $existingVersion');
+ if (existingVersion == null && !usingLegacyStore) {
+ isFirstAppStart = true;
+ await SharedPreferencesStorePlatform.instance.setValue('Int', 'flutter.$_version', _latestVersion);
+ } else {
+ isFirstAppStart = false;
+ final fromVersion = existingVersion ?? 1;
+ if (fromVersion < _latestVersion) {
+ await _runMigrations(fromVersion);
+ }
+ }
+
+ try {
+ prefs = await SharedPreferences.getInstance();
+ } catch (e) {
+ if (checkPlatform([TargetPlatform.windows])) {
+ _logger.info('Could not initialize SharedPreferences, trying to delete corrupted settings file', e);
+ File(_windowsFile).deleteSync();
+ prefs = await SharedPreferences.getInstance();
+ } else {
+ throw Exception('Could not initialize SharedPreferences');
+ }
+ }
+
+ // Locale configuration upon persistence initialisation to prevent unlocalised Alias generation
+ final persistedLocale = prefs.getString(_localeKey);
+ if (persistedLocale == null) {
+ await LocaleSettings.useDeviceLocale();
+ } else {
+ await LocaleSettings.setLocaleRaw(persistedLocale);
+ }
+
+ if (prefs.getString(_showToken) == null) {
+ await prefs.setString(_showToken, const Uuid().v4());
+ }
+
+ if (prefs.getString(_aliasKey) == null) {
+ await prefs.setString(_aliasKey, generateRandomAlias());
+ }
+
+ if (prefs.getString(_securityContext) == null) {
+ await prefs.setString(_securityContext, jsonEncode(generateSecurityContext()));
+ }
+
+ if (isFirstAppStart) {
+ final systemAnimations = await getSystemAnimationsStatus();
+ if (!systemAnimations) {
+ _logger.info('System animations are disabled, disabling animations in the app.');
+ await prefs.setBool(_enableAnimations, false);
+ }
+ }
+
+ if (prefs.getString(_colorKey) == null) {
+ await _initColorSetting(prefs, supportsDynamicColors);
+ } else {
+ // fix when device does not support dynamic colors
+ final supported = supportsDynamicColors ? ColorMode.values : ColorMode.values.where((e) => e != ColorMode.system);
+ final colorMode = supported.firstWhereOrNull((color) => color.name == prefs.getString(_colorKey));
+ if (colorMode == null) {
+ await _initColorSetting(prefs, supportsDynamicColors);
+ }
+ }
+
+ // migrate legacy auto start settings (current implementation is stateless and relies on the Windows registry / file system)
+ const launchAtStartupLegacyKey = 'ls_launch_at_startup';
+ const launchMinimizedLegacyKey = 'ls_auto_start_launch_minimized';
+ if (prefs.getBool(launchAtStartupLegacyKey) == true) {
+ _logger.info('Enable auto start on legacy settings');
+ await prefs.remove(launchAtStartupLegacyKey);
+ await enableAutoStart(startHidden: prefs.getBool(launchMinimizedLegacyKey) == true);
+ await prefs.remove(launchMinimizedLegacyKey);
+ }
+
+ return PersistenceService._(prefs, isFirstAppStart);
+ }
+
+ static Future<void> _initColorSetting(SharedPreferences prefs, bool supportsDynamicColors) async {
+ await prefs.setString(
+ _colorKey,
+ checkPlatform([TargetPlatform.android]) && supportsDynamicColors ? ColorMode.system.name : ColorMode.localsend.name,
+ );
+ }
+
+ bool isPortableMode() {
+ return SharedPreferencesStorePlatform.instance is SharedPreferencesPortable;
+ }
+
+ StoredSecurityContext getSecurityContext() {
+ final contextRaw = _prefs.getString(_securityContext)!;
+ return StoredSecurityContext.fromJson(jsonDecode(contextRaw));
+ }
+
+ Future<void> setSecurityContext(StoredSecurityContext context) async {
+ await _prefs.setString(_securityContext, jsonEncode(context));
+ }
+
+ List<String>? getSignalingServers() {
+ final serversRaw = _prefs.getString(_signalingServers);
+ if (serversRaw == null) {
+ return null;
+ }
+
+ return (jsonDecode(serversRaw) as List).cast<String>();
+ }
+
+ Future<void> setSignalingServers(List<String> servers) async {
+ await _prefs.setString(_signalingServers, jsonEncode(servers));
+ }
+
+ List<String>? getStunServers() {
+ final serversRaw = _prefs.getString(_stunServers);
+ if (serversRaw == null) {
+ return null;
+ }
+
+ return (jsonDecode(serversRaw) as List).cast<String>();
+ }
+
+ Future<void> setStunServers(List<String> servers) async {
+ await _prefs.setString(_stunServers, jsonEncode(servers));
+ }
+
+ List<ReceiveHistoryEntry> getReceiveHistory() {
+ final historyRaw = _prefs.getStringList(_receiveHistory) ?? [];
+ return historyRaw.map((entry) => ReceiveHistoryEntry.fromJson(jsonDecode(entry))).toList();
+ }
+
+ Future<void> setReceiveHistory(List<ReceiveHistoryEntry> entries) async {
+ final historyRaw = entries.map((entry) => jsonEncode(entry.toJson())).toList();
+ await _prefs.setStringList(_receiveHistory, historyRaw);
+ }
+
+ List<FavoriteDevice> getFavorites() {
+ final favoritesRaw = _prefs.getStringList(_favorites) ?? [];
+ return favoritesRaw.map((entry) => FavoriteDevice.fromJson(jsonDecode(entry))).toList();
+ }
+
+ Future<void> setFavorites(List<FavoriteDevice> entries) async {
+ final favoritesRaw = entries.map((entry) => jsonEncode(entry.toJson())).toList();
+ await _prefs.setStringList(_favorites, favoritesRaw);
+ }
+
+ String getShowToken() {
+ return _prefs.getString(_showToken)!;
+ }
+
+ String getAlias() {
+ return _prefs.getString(_aliasKey) ?? generateRandomAlias();
+ }
+
+ Future<void> setAlias(String alias) async {
+ await _prefs.setString(_aliasKey, alias);
+ }
+
+ ThemeMode getTheme() {
+ final value = _prefs.getString(_themeKey);
+ if (value == null) {
+ return ThemeMode.system;
+ }
+ return ThemeMode.values.firstWhereOrNull((theme) => theme.name == value) ?? ThemeMode.system;
+ }
+
+ Future<void> setTheme(ThemeMode theme) async {
+ await _prefs.setString(_themeKey, theme.name);
+ }
+
+ ColorMode getColorMode() {
+ final value = _prefs.getString(_colorKey);
+ if (value == null) {
+ return ColorMode.system;
+ }
+ return ColorMode.values.firstWhereOrNull((color) => color.name == value) ?? ColorMode.system;
+ }
+
+ Future<void> setColorMode(ColorMode color) async {
+ await _prefs.setString(_colorKey, color.name);
+ }
+
+ AppLocale? getLocale() {
+ final value = _prefs.getString(_localeKey);
+ if (value == null) {
+ return null;
+ }
+ return AppLocale.values.firstWhereOrNull((locale) => locale.languageTag == value);
+ }
+
+ Future<void> setLocale(AppLocale? locale) async {
+ if (locale == null) {
+ await _prefs.remove(_localeKey);
+ } else {
+ await _prefs.setString(_localeKey, locale.languageTag);
+ }
+ }
+
+ int getPort() {
+ return _prefs.getInt(_portKey) ?? defaultPort;
+ }
+
+ Future<void> setPort(int port) async {
+ await _prefs.setInt(_portKey, port);
+ }
+
+ List<String>? getNetworkWhitelist() {
+ return _prefs.getStringList(_networkWhitelistKey);
+ }
+
+ Future<void> setNetworkWhitelist(List<String>? whitelist) async {
+ if (whitelist == null) {
+ await _prefs.remove(_networkWhitelistKey);
+ } else {
+ await _prefs.setStringList(_networkWhitelistKey, whitelist);
+ }
+ }
+
+ List<String>? getNetworkBlacklist() {
+ return _prefs.getStringList(_networkBlacklistKey);
+ }
+
+ Future<void> setNetworkBlacklist(List<String>? blacklist) async {
+ if (blacklist == null) {
+ await _prefs.remove(_networkBlacklistKey);
+ } else {
+ await _prefs.setStringList(_networkBlacklistKey, blacklist);
+ }
+ }
+
+ int getDiscoveryTimeout() {
+ return _prefs.getInt(_timeoutKey) ?? defaultDiscoveryTimeout;
+ }
+
+ Future<void> setDiscoveryTimeout(int timeout) async {
+ await _prefs.setInt(_timeoutKey, timeout);
+ }
+
+ bool getShareViaLinkAutoAccept() {
+ return _prefs.getBool(_shareViaLinkAutoAccept) ?? false;
+ }
+
+ Future<void> setShareViaLinkAutoAccept(bool shareViaLinkAutoAccept) async {
+ await _prefs.setBool(_shareViaLinkAutoAccept, shareViaLinkAutoAccept);
+ }
+
+ String getMulticastGroup() {
+ return _prefs.getString(_multicastGroupKey) ?? defaultMulticastGroup;
+ }
+
+ Future<void> setMulticastGroup(String group) async {
+ await _prefs.setString(_multicastGroupKey, group);
+ }
+
+ String? getDestination() {
+ return _prefs.getString(_destinationKey);
+ }
+
+ Future<void> setDestination(String? destination) async {
+ if (destination == null) {
+ await _prefs.remove(_destinationKey);
+ } else {
+ await _prefs.setString(_destinationKey, destination);
+ }
+ }
+
+ bool isSaveToGallery() {
+ return _prefs.getBool(_saveToGallery) ?? true;
+ }
+
+ Future<void> setSaveToGallery(bool saveToGallery) async {
+ await _prefs.setBool(_saveToGallery, saveToGallery);
+ }
+
+ bool isSaveToHistory() {
+ return _prefs.getBool(_saveToHistory) ?? true;
+ }
+
+ Future<void> setSaveToHistory(bool saveToHistory) async {
+ await _prefs.setBool(_saveToHistory, saveToHistory);
+ }
+
+ bool getAdvancedSettingsEnabled() {
+ return _prefs.getBool(_advancedSettingsKey) ?? false;
+ }
+
+ Future<void> setAdvancedSettingsEnabled(bool isEnabled) async {
+ await _prefs.setBool(_advancedSettingsKey, isEnabled);
+ }
+
+ bool isQuickSave() {
+ return _prefs.getBool(_quickSave) ?? false;
+ }
+
+ Future<void> setQuickSave(bool quickSave) async {
+ await _prefs.setBool(_quickSave, quickSave);
+ }
+
+ bool isQuickSaveFromFavorites() {
+ return _prefs.getBool(_quickSaveFromFavorites) ?? false;
+ }
+
+ Future<void> setQuickSaveFromFavorites(bool quickSaveFromFavorites) async {
+ await _prefs.setBool(_quickSaveFromFavorites, quickSaveFromFavorites);
+ }
+
+ String? getReceivePin() {
+ return _prefs.getString(_receivePin);
+ }
+
+ Future<void> setReceivePin(String? pin) async {
+ if (pin == null) {
+ await _prefs.remove(_receivePin);
+ } else {
+ await _prefs.setString(_receivePin, pin);
+ }
+ }
+
+ bool isAutoFinish() {
+ return _prefs.getBool(_autoFinish) ?? false;
+ }
+
+ Future<void> setAutoFinish(bool autoFinish) async {
+ await _prefs.setBool(_autoFinish, autoFinish);
+ }
+
+ bool isMinimizeToTray() {
+ return _prefs.getBool(_minimizeToTray) ?? false;
+ }
+
+ Future<void> setMinimizeToTray(bool minimizeToTray) async {
+ await _prefs.setBool(_minimizeToTray, minimizeToTray);
+ }
+
+ bool isHttps() {
+ return _prefs.getBool(_https) ?? true;
+ }
+
+ Future<void> setHttps(bool https) async {
+ await _prefs.setBool(_https, https);
+ }
+
+ SendMode getSendMode() {
+ return SendMode.values.firstWhereOrNull((m) => m.name == _prefs.getString(_sendMode)) ?? SendMode.single;
+ }
+
+ Future<void> setSendMode(SendMode mode) async {
+ await _prefs.setString(_sendMode, mode.name);
+ }
+
+ Future<void> setWindowOffsetX(double x) async {
+ await _prefs.setDouble(_windowOffsetX, x);
+ }
+
+ Future<void> setWindowOffsetY(double y) async {
+ await _prefs.setDouble(_windowOffsetY, y);
+ }
+
+ Future<void> setWindowHeight(double height) async {
+ await _prefs.setDouble(_windowHeight, height);
+ }
+
+ Future<void> setWindowWidth(double width) async {
+ await _prefs.setDouble(_windowWidth, width);
+ }
+
+ WindowDimensions? getWindowLastDimensions() {
+ Size? size;
+ Offset? position;
+ final offsetX = _prefs.getDouble(_windowOffsetX);
+ final offsetY = _prefs.getDouble(_windowOffsetY);
+ final width = _prefs.getDouble(_windowWidth);
+ final height = _prefs.getDouble(_windowHeight);
+
+ if (width != null && height != null) {
+ size = Size(width, height);
+ }
+
+ if (offsetX != null && offsetY != null) {
+ position = Offset(offsetX, offsetY);
+ }
+
+ if (size == null || position == null) {
+ return null;
+ }
+
+ return WindowDimensions(
+ position: position,
+ size: size,
+ );
+ }
+
+ Future<void> setSaveWindowPlacement(bool savePlacement) async {
+ await _prefs.setBool(_saveWindowPlacement, savePlacement);
+ }
+
+ bool getSaveWindowPlacement() {
+ if (!checkPlatformIsNotWaylandDesktop()) return false;
+ return _prefs.getBool(_saveWindowPlacement) ?? true;
+ }
+
+ Future<void> setEnableAnimations(bool enableAnimations) async {
+ await _prefs.setBool(_enableAnimations, enableAnimations);
+ }
+
+ bool getEnableAnimations() {
+ return _prefs.getBool(_enableAnimations) ?? true;
+ }
+
+ DeviceType? getDeviceType() {
+ return DeviceType.values.firstWhereOrNull((m) => m.name == _prefs.getString(_deviceType));
+ }
+
+ Future<void> setDeviceType(DeviceType deviceType) async {
+ await _prefs.setString(_deviceType, deviceType.name);
+ }
+
+ String? getDeviceModel() {
+ return _prefs.getString(_deviceModel);
+ }
+
+ Future<void> setDeviceModel(String deviceModel) async {
+ await _prefs.setString(_deviceModel, deviceModel);
+ }
+
+ String? getPostReceiveHook() {
+ return _prefs.getString(_postReceiveHook);
+ }
+
+ Future<void> setPostReceiveHook(String? hook) async {
+ if (hook == null || hook.trim().isEmpty) {
+ await _prefs.remove(_postReceiveHook);
+ } else {
+ await _prefs.setString(_postReceiveHook, hook.trim());
+ }
+ }
+
+ Future<void> clear() async {
+ await _prefs.clear();
+ }
 }

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -12,239 +12,247 @@ import 'package:refena_flutter/refena_flutter.dart';
 final _listEq = const ListEquality().equals;
 
 final settingsProvider = NotifierProvider<SettingsService, SettingsState>(
-  (ref) {
-    return SettingsService(ref.read(persistenceProvider));
-  },
-  onChanged: (_, next, ref) {
-    final syncState = ref.read(parentIsolateProvider).syncState;
-    if (_listEq(syncState.networkWhitelist, next.networkWhitelist) &&
-        _listEq(syncState.networkBlacklist, next.networkBlacklist) &&
-        syncState.multicastGroup == next.multicastGroup &&
-        syncState.discoveryTimeout == next.discoveryTimeout) {
-      return;
-    }
+ (ref) {
+ return SettingsService(ref.read(persistenceProvider));
+ },
+ onChanged: (_, next, ref) {
+ final syncState = ref.read(parentIsolateProvider).syncState;
+ if (_listEq(syncState.networkWhitelist, next.networkWhitelist) &&
+ _listEq(syncState.networkBlacklist, next.networkBlacklist) &&
+ syncState.multicastGroup == next.multicastGroup &&
+ syncState.discoveryTimeout == next.discoveryTimeout) {
+ return;
+ }
 
-    ref
-        .redux(parentIsolateProvider)
-        .dispatch(
-          IsolateSyncSettingsAction(
-            networkWhitelist: next.networkWhitelist,
-            networkBlacklist: next.networkBlacklist,
-            multicastGroup: next.multicastGroup,
-            discoveryTimeout: next.discoveryTimeout,
-          ),
-        );
-  },
+ ref
+ .redux(parentIsolateProvider)
+ .dispatch(
+ IsolateSyncSettingsAction(
+ networkWhitelist: next.networkWhitelist,
+ networkBlacklist: next.networkBlacklist,
+ multicastGroup: next.multicastGroup,
+ discoveryTimeout: next.discoveryTimeout,
+ ),
+ );
+ },
 );
 
 class SettingsService extends PureNotifier<SettingsState> {
-  final PersistenceService _persistence;
+ final PersistenceService _persistence;
 
-  SettingsService(this._persistence);
+ SettingsService(this._persistence);
 
-  @override
-  SettingsState init() => SettingsState(
-    showToken: _persistence.getShowToken(),
-    alias: _persistence.getAlias(),
-    theme: _persistence.getTheme(),
-    colorMode: _persistence.getColorMode(),
-    locale: _persistence.getLocale(),
-    port: _persistence.getPort(),
-    networkWhitelist: _persistence.getNetworkWhitelist(),
-    networkBlacklist: _persistence.getNetworkBlacklist(),
-    multicastGroup: _persistence.getMulticastGroup(),
-    destination: _persistence.getDestination(),
-    saveToGallery: _persistence.isSaveToGallery(),
-    saveToHistory: _persistence.isSaveToHistory(),
-    quickSave: _persistence.isQuickSave(),
-    quickSaveFromFavorites: _persistence.isQuickSaveFromFavorites(),
-    receivePin: _persistence.getReceivePin(),
-    autoFinish: _persistence.isAutoFinish(),
-    minimizeToTray: _persistence.isMinimizeToTray(),
-    https: _persistence.isHttps(),
-    sendMode: _persistence.getSendMode(),
-    saveWindowPlacement: _persistence.getSaveWindowPlacement(),
-    enableAnimations: _persistence.getEnableAnimations(),
-    deviceType: _persistence.getDeviceType(),
-    deviceModel: _persistence.getDeviceModel(),
-    shareViaLinkAutoAccept: _persistence.getShareViaLinkAutoAccept(),
-    discoveryTimeout: _persistence.getDiscoveryTimeout(),
-    advancedSettings: _persistence.getAdvancedSettingsEnabled(),
-  );
+ @override
+ SettingsState init() => SettingsState(
+ showToken: _persistence.getShowToken(),
+ alias: _persistence.getAlias(),
+ theme: _persistence.getTheme(),
+ colorMode: _persistence.getColorMode(),
+ locale: _persistence.getLocale(),
+ port: _persistence.getPort(),
+ networkWhitelist: _persistence.getNetworkWhitelist(),
+ networkBlacklist: _persistence.getNetworkBlacklist(),
+ multicastGroup: _persistence.getMulticastGroup(),
+ destination: _persistence.getDestination(),
+ saveToGallery: _persistence.isSaveToGallery(),
+ saveToHistory: _persistence.isSaveToHistory(),
+ quickSave: _persistence.isQuickSave(),
+ quickSaveFromFavorites: _persistence.isQuickSaveFromFavorites(),
+ receivePin: _persistence.getReceivePin(),
+ autoFinish: _persistence.isAutoFinish(),
+ minimizeToTray: _persistence.isMinimizeToTray(),
+ https: _persistence.isHttps(),
+ sendMode: _persistence.getSendMode(),
+ saveWindowPlacement: _persistence.getSaveWindowPlacement(),
+ enableAnimations: _persistence.getEnableAnimations(),
+ deviceType: _persistence.getDeviceType(),
+ deviceModel: _persistence.getDeviceModel(),
+ shareViaLinkAutoAccept: _persistence.getShareViaLinkAutoAccept(),
+ discoveryTimeout: _persistence.getDiscoveryTimeout(),
+ advancedSettings: _persistence.getAdvancedSettingsEnabled(),
+ postReceiveHook: _persistence.getPostReceiveHook(),
+ );
 
-  Future<void> setAlias(String alias) async {
-    await _persistence.setAlias(alias);
-    state = state.copyWith(
-      alias: alias,
-    );
-  }
+ Future<void> setAlias(String alias) async {
+ await _persistence.setAlias(alias);
+ state = state.copyWith(
+ alias: alias,
+ );
+ }
 
-  Future<void> setTheme(ThemeMode theme) async {
-    await _persistence.setTheme(theme);
-    state = state.copyWith(
-      theme: theme,
-    );
-  }
+ Future<void> setTheme(ThemeMode theme) async {
+ await _persistence.setTheme(theme);
+ state = state.copyWith(
+ theme: theme,
+ );
+ }
 
-  Future<void> setColorMode(ColorMode mode) async {
-    await _persistence.setColorMode(mode);
-    state = state.copyWith(
-      colorMode: mode,
-    );
-  }
+ Future<void> setColorMode(ColorMode mode) async {
+ await _persistence.setColorMode(mode);
+ state = state.copyWith(
+ colorMode: mode,
+ );
+ }
 
-  Future<void> setAdvancedSettingsEnabled(bool isEnabled) async {
-    await _persistence.setAdvancedSettingsEnabled(isEnabled);
-    state = state.copyWith(
-      advancedSettings: isEnabled,
-    );
-  }
+ Future<void> setAdvancedSettingsEnabled(bool isEnabled) async {
+ await _persistence.setAdvancedSettingsEnabled(isEnabled);
+ state = state.copyWith(
+ advancedSettings: isEnabled,
+ );
+ }
 
-  Future<void> setLocale(AppLocale? locale) async {
-    await _persistence.setLocale(locale);
-    state = state.copyWith(
-      locale: locale,
-    );
-  }
+ Future<void> setLocale(AppLocale? locale) async {
+ await _persistence.setLocale(locale);
+ state = state.copyWith(
+ locale: locale,
+ );
+ }
 
-  Future<void> setPort(int port) async {
-    await _persistence.setPort(port);
-    state = state.copyWith(
-      port: port,
-    );
-  }
+ Future<void> setPort(int port) async {
+ await _persistence.setPort(port);
+ state = state.copyWith(
+ port: port,
+ );
+ }
 
-  Future<void> setNetworkWhitelist(List<String>? whitelist) async {
-    await _persistence.setNetworkWhitelist(whitelist);
-    state = state.copyWith(
-      networkWhitelist: whitelist,
-    );
-  }
+ Future<void> setNetworkWhitelist(List<String>? whitelist) async {
+ await _persistence.setNetworkWhitelist(whitelist);
+ state = state.copyWith(
+ networkWhitelist: whitelist,
+ );
+ }
 
-  Future<void> setNetworkBlacklist(List<String>? blacklist) async {
-    await _persistence.setNetworkBlacklist(blacklist);
-    state = state.copyWith(
-      networkBlacklist: blacklist,
-    );
-  }
+ Future<void> setNetworkBlacklist(List<String>? blacklist) async {
+ await _persistence.setNetworkBlacklist(blacklist);
+ state = state.copyWith(
+ networkBlacklist: blacklist,
+ );
+ }
 
-  Future<void> setDiscoveryTimeout(int timeout) async {
-    await _persistence.setDiscoveryTimeout(timeout);
-    state = state.copyWith(
-      discoveryTimeout: timeout,
-    );
-  }
+ Future<void> setDiscoveryTimeout(int timeout) async {
+ await _persistence.setDiscoveryTimeout(timeout);
+ state = state.copyWith(
+ discoveryTimeout: timeout,
+ );
+ }
 
-  Future<void> setMulticastGroup(String group) async {
-    await _persistence.setMulticastGroup(group);
-    state = state.copyWith(
-      multicastGroup: group,
-    );
-  }
+ Future<void> setMulticastGroup(String group) async {
+ await _persistence.setMulticastGroup(group);
+ state = state.copyWith(
+ multicastGroup: group,
+ );
+ }
 
-  Future<void> setDestination(String? destination) async {
-    await _persistence.setDestination(destination);
-    state = state.copyWith(
-      destination: destination,
-    );
-  }
+ Future<void> setDestination(String? destination) async {
+ await _persistence.setDestination(destination);
+ state = state.copyWith(
+ destination: destination,
+ );
+ }
 
-  Future<void> setSaveToGallery(bool saveToGallery) async {
-    await _persistence.setSaveToGallery(saveToGallery);
-    state = state.copyWith(
-      saveToGallery: saveToGallery,
-    );
-  }
+ Future<void> setSaveToGallery(bool saveToGallery) async {
+ await _persistence.setSaveToGallery(saveToGallery);
+ state = state.copyWith(
+ saveToGallery: saveToGallery,
+ );
+ }
 
-  Future<void> setSaveToHistory(bool saveToHistory) async {
-    await _persistence.setSaveToHistory(saveToHistory);
-    state = state.copyWith(
-      saveToHistory: saveToHistory,
-    );
-  }
+ Future<void> setSaveToHistory(bool saveToHistory) async {
+ await _persistence.setSaveToHistory(saveToHistory);
+ state = state.copyWith(
+ saveToHistory: saveToHistory,
+ );
+ }
 
-  Future<void> setQuickSave(bool quickSave) async {
-    await _persistence.setQuickSave(quickSave);
-    state = state.copyWith(
-      quickSave: quickSave,
-    );
-  }
+ Future<void> setQuickSave(bool quickSave) async {
+ await _persistence.setQuickSave(quickSave);
+ state = state.copyWith(
+ quickSave: quickSave,
+ );
+ }
 
-  Future<void> setQuickSaveFromFavorites(bool quickSaveFromFavorites) async {
-    await _persistence.setQuickSaveFromFavorites(quickSaveFromFavorites);
-    state = state.copyWith(
-      quickSaveFromFavorites: quickSaveFromFavorites,
-    );
-  }
+ Future<void> setQuickSaveFromFavorites(bool quickSaveFromFavorites) async {
+ await _persistence.setQuickSaveFromFavorites(quickSaveFromFavorites);
+ state = state.copyWith(
+ quickSaveFromFavorites: quickSaveFromFavorites,
+ );
+ }
 
-  Future<void> setReceivePin(String? receivePin) async {
-    await _persistence.setReceivePin(receivePin);
-    state = state.copyWith(
-      receivePin: receivePin,
-    );
-  }
+ Future<void> setReceivePin(String? receivePin) async {
+ await _persistence.setReceivePin(receivePin);
+ state = state.copyWith(
+ receivePin: receivePin,
+ );
+ }
 
-  Future<void> setAutoFinish(bool autoFinish) async {
-    await _persistence.setAutoFinish(autoFinish);
-    state = state.copyWith(
-      autoFinish: autoFinish,
-    );
-  }
+ Future<void> setAutoFinish(bool autoFinish) async {
+ await _persistence.setAutoFinish(autoFinish);
+ state = state.copyWith(
+ autoFinish: autoFinish,
+ );
+ }
 
-  Future<void> setMinimizeToTray(bool minimizeToTray) async {
-    await _persistence.setMinimizeToTray(minimizeToTray);
-    state = state.copyWith(
-      minimizeToTray: minimizeToTray,
-    );
-  }
+ Future<void> setMinimizeToTray(bool minimizeToTray) async {
+ await _persistence.setMinimizeToTray(minimizeToTray);
+ state = state.copyWith(
+ minimizeToTray: minimizeToTray,
+ );
+ }
 
-  Future<void> setHttps(bool https) async {
-    await _persistence.setHttps(https);
-    state = state.copyWith(
-      https: https,
-    );
-  }
+ Future<void> setHttps(bool https) async {
+ await _persistence.setHttps(https);
+ state = state.copyWith(
+ https: https,
+ );
+ }
 
-  Future<void> setSendMode(SendMode mode) async {
-    await _persistence.setSendMode(mode);
-    state = state.copyWith(
-      sendMode: mode,
-    );
-  }
+ Future<void> setSendMode(SendMode mode) async {
+ await _persistence.setSendMode(mode);
+ state = state.copyWith(
+ sendMode: mode,
+ );
+ }
 
-  Future<void> setSaveWindowPlacement(bool savePlacement) async {
-    await _persistence.setSaveWindowPlacement(savePlacement);
-    state = state.copyWith(
-      saveWindowPlacement: savePlacement,
-    );
-  }
+ Future<void> setSaveWindowPlacement(bool savePlacement) async {
+ await _persistence.setSaveWindowPlacement(savePlacement);
+ state = state.copyWith(
+ saveWindowPlacement: savePlacement,
+ );
+ }
 
-  Future<void> setEnableAnimations(bool enableAnimations) async {
-    await _persistence.setEnableAnimations(enableAnimations);
-    state = state.copyWith(
-      enableAnimations: enableAnimations,
-    );
-  }
+ Future<void> setEnableAnimations(bool enableAnimations) async {
+ await _persistence.setEnableAnimations(enableAnimations);
+ state = state.copyWith(
+ enableAnimations: enableAnimations,
+ );
+ }
 
-  Future<void> setDeviceType(DeviceType deviceType) async {
-    await _persistence.setDeviceType(deviceType);
-    state = state.copyWith(
-      deviceType: deviceType,
-    );
-  }
+ Future<void> setDeviceType(DeviceType deviceType) async {
+ await _persistence.setDeviceType(deviceType);
+ state = state.copyWith(
+ deviceType: deviceType,
+ );
+ }
 
-  Future<void> setDeviceModel(String deviceModel) async {
-    await _persistence.setDeviceModel(deviceModel);
-    state = state.copyWith(
-      deviceModel: deviceModel,
-    );
-  }
+ Future<void> setDeviceModel(String deviceModel) async {
+ await _persistence.setDeviceModel(deviceModel);
+ state = state.copyWith(
+ deviceModel: deviceModel,
+ );
+ }
 
-  Future<void> setShareViaLinkAutoAccept(bool shareViaLinkAutoAccept) async {
-    await _persistence.setShareViaLinkAutoAccept(shareViaLinkAutoAccept);
+ Future<void> setShareViaLinkAutoAccept(bool shareViaLinkAutoAccept) async {
+ await _persistence.setShareViaLinkAutoAccept(shareViaLinkAutoAccept);
 
-    state = state.copyWith(
-      shareViaLinkAutoAccept: shareViaLinkAutoAccept,
-    );
-  }
+ state = state.copyWith(
+ shareViaLinkAutoAccept: shareViaLinkAutoAccept,
+ );
+ }
+
+ Future<void> setPostReceiveHook(String? hook) async {
+ await _persistence.setPostReceiveHook(hook);
+ state = state.copyWith(
+ postReceiveHook: hook,
+ );
+ }
 }

--- a/app/lib/util/native/post_receive_hook.dart
+++ b/app/lib/util/native/post_receive_hook.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:common/model/file_type.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('PostReceiveHook');
+
+class PostReceiveHook {
+ final String command;
+
+ PostReceiveHook(this.command);
+
+ Future<void> execute({
+ required String filePath,
+ required String originalFileName,
+ required String senderAlias,
+ required int fileSize,
+ required FileType fileType,
+ required bool savedToGallery,
+ }) async {
+ if (command.trim().isEmpty) {
+ return;
+ }
+
+ final env = {
+ 'LOCALSEND_FILE_PATH': filePath,
+ 'LOCALSEND_ORIGINAL_NAME': originalFileName,
+ 'LOCALSEND_SENDER_ALIAS': senderAlias,
+ 'LOCALSEND_FILE_SIZE': fileSize.toString(),
+   'LOCALSEND_FILE_TYPE': fileType.name,
+   'LOCALSEND_SAVED_TO_GALLERY': savedToGallery.toString(),
+ };
+
+   try {
+     _logger.info('Executing post-receive hook: $command');
+     _logger.fine('Hook environment: $env');
+
+     final process = await Process.run(
+       command,
+       [],
+       environment: env,
+       runInShell: true,
+     );
+
+     if (process.stdout.toString().trim().isNotEmpty) {
+       _logger.info('Hook stdout: ${process.stdout}');
+     }
+     if (process.stderr.toString().trim().isNotEmpty) {
+       _logger.warning('Hook stderr: ${process.stderr}');
+     }
+
+     if (process.exitCode != 0) {
+       _logger.warning('Post-receive hook exited with code ${process.exitCode}');
+     } else {
+       _logger.info('Post-receive hook completed successfully');
+     }
+   } catch (e, st) {
+     _logger.warning('Post-receive hook failed', e, st);
+   }
+ }
+}

--- a/app/lib/widget/dialogs/post_receive_hook_dialog.dart
+++ b/app/lib/widget/dialogs/post_receive_hook_dialog.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:localsend_app/gen/strings.g.dart';
+import 'package:localsend_app/widget/dialogs/alert_dialog.dart';
+import 'package:routerino/routerino.dart';
+
+class PostReceiveHookDialog extends StatefulWidget {
+  final String? initialCommand;
+
+  const PostReceiveHookDialog({super.key, this.initialCommand});
+
+  static Future<String?> open(BuildContext context, {String? initialCommand}) {
+    return showDialog<String>(
+      context: context,
+      builder: (_) => PostReceiveHookDialog(initialCommand: initialCommand),
+    );
+  }
+
+  @override
+  State<PostReceiveHookDialog> createState() => _PostReceiveHookDialogState();
+}
+
+class _PostReceiveHookDialogState extends State<PostReceiveHookDialog> {
+  late TextEditingController _controller;
+  bool _enabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _enabled = widget.initialCommand != null && widget.initialCommand!.trim().isNotEmpty;
+    _controller = TextEditingController(text: widget.initialCommand ?? '');
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    
+    return AlertDialog(
+      title: Text(t.settingsTab.receive.postReceiveHook),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SwitchListTile(
+              title: Text(t.settingsTab.receive.postReceiveHookEnable),
+              value: _enabled,
+              onChanged: (value) {
+                setState(() {
+                  _enabled = value;
+                  if (!value) {
+                    _controller.clear();
+                  }
+                });
+              },
+            ),
+            if (_enabled) ...[
+              const SizedBox(height: 16),
+              TextField(
+                controller: _controller,
+                decoration: InputDecoration(
+                  labelText: t.settingsTab.receive.postReceiveHookCommand,
+                  hintText: 'pwsh -File C:\\Scripts\\Process-File.ps1',
+                  border: const OutlineInputBorder(),
+                ),
+                maxLines: 2,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                t.settingsTab.receive.postReceiveHookVariables,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Card(
+                margin: EdgeInsets.zero,
+                child: Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildEnvVar('LOCALSEND_FILE_PATH', t.settingsTab.receive.postReceiveHookVarPath),
+                      _buildEnvVar('LOCALSEND_ORIGINAL_NAME', t.settingsTab.receive.postReceiveHookVarName),
+                      _buildEnvVar('LOCALSEND_SENDER_ALIAS', t.settingsTab.receive.postReceiveHookVarAlias),
+                      _buildEnvVar('LOCALSEND_FILE_SIZE', t.settingsTab.receive.postReceiveHookVarSize),
+                      _buildEnvVar('LOCALSEND_FILE_TYPE', t.settingsTab.receive.postReceiveHookVarType),
+                      _buildEnvVar('LOCALSEND_SAVED_TO_GALLERY', t.settingsTab.receive.postReceiveHookVarGallery),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                t.settingsTab.receive.postReceiveHookWarning,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: colorScheme.error,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Routerino.context.pop(),
+          child: Text(t.general.cancel),
+        ),
+        TextButton(
+          onPressed: () {
+            final command = _enabled ? _controller.text.trim() : '';
+            Routerino.context.pop(command);
+          },
+          child: Text(t.general.save),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEnvVar(String name, String description) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2.0),
+      child: RichText(
+        text: TextSpan(
+          style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+          children: [
+            TextSpan(text: name, style: const TextStyle(fontWeight: FontWeight.bold)),
+            TextSpan(text: ' - $description'),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Implements post-receive hook feature requested in #3041. This allows users to configure an external command/script that runs automatically after a file is successfully received and saved.

## Changes

### Core Implementation
- **Settings**: Added `postReceiveHook` field to `SettingsState` with persistence support
- **Hook Executor**: Created `PostReceiveHook` utility class that executes commands with environment variables
- **Integration**: Modified `receive_controller.dart` to trigger hook after successful file save (async, non-blocking)
- **Error Handling**: Hook failures are logged but do not affect transfer success

### UI Components
- **Configuration Dialog**: Added `PostReceiveHookDialog` for setting the hook command
- **Receive Tab**: Added hook status indicator and configuration button in advanced info section
- **Translations**: Added English strings for all UI elements

### Environment Variables
The hook receives these environment variables:
- `LOCALSEND_FILE_PATH`: Full path to saved file
- `LOCALSEND_ORIGINAL_NAME`: Original file name from sender
- `LOCALSEND_SENDER_ALIAS`: Sender device alias
- `LOCALSEND_FILE_SIZE`: File size in bytes
- `LOCALSEND_FILE_TYPE`: File type (image, video, etc.)
- `LOCALSEND_SAVED_TO_GALLERY`: Whether saved to gallery (true/false)

## Usage Example
```powershell
pwsh -File C:\Scripts\Process-LocalSendFile.ps1
```

Inside the script, access variables via `$env:LOCALSEND_FILE_PATH`, etc.

## Design Decisions
- **Disabled by default**: Security-first approach, users must explicitly enable
- **Async execution**: Hook runs in background, doesn't block UI or transfer
- **Non-failing**: Hook failures don't mark transfers as failed
- **Cross-platform**: Uses Dart `Process.run` with `runInShell: true`
- **Opt-in per device**: Setting is stored in app preferences

## Testing
1. Configure hook in Receive tab → Advanced info → Post-receive Hook
2. Send file from another device
3. Verify hook executes with correct environment variables
4. Confirm hook failure doesn't affect transfer success
5. Verify empty/disabled hook does nothing

## Security Considerations
- Commands run with same privileges as LocalSend app
- Warning displayed in UI about trusted scripts only
- No input validation on command (user responsibility)
- Environment variables sanitized by Dart/Shell

## Backward Compatibility
- Fully backward compatible: existing behavior unchanged when hook not configured
- New settings field is nullable (disabled by default)
- No migration needed

Closes #3041