### PR TITLE
fix: use configured signaling server URI instead of hardcoded value

### DIFF
--- a/app/lib/provider/network/webrtc/signaling_provider.dart
+++ b/app/lib/provider/network/webrtc/signaling_provider.dart
@@ -84,7 +84,7 @@ class _SetupSignalingConnection extends AsyncGlobalAction {
 
     LsSignalingConnection? connection;
     final stream = connect(
-      uri: 'wss://public.localsend.org/v1/ws',
+      uri: signalingServer,
       info: ProposingClientInfo(
         alias: settings.alias,
         version: protocolVersion,


### PR DESCRIPTION
## Summary
- The WebRTC signaling connection in `signaling_provider.dart` always connects to `wss://public.localsend.org/v1/ws` regardless of user configuration.
- The `_SetupSignalingConnection` action correctly receives `signalingServer` as a parameter (iterated from the configured server list) but the `connect()` call ignores it.

## Root cause
Line 87 was:
```dart
final stream = connect(
  uri: 'wss://public.localsend.org/v1/ws',  // hardcoded, ignores signalingServer
```

## Fix
Use the `signalingServer` parameter that was already being passed into the action:
```dart
final stream = connect(
  uri: signalingServer,
```

## Impact
Users who configure alternative/custom signaling servers will now actually connect to their configured servers instead of always connecting to `public.localsend.org`.

## Test plan
- [x] Verified `signalingServer` is already the correct variable — it comes from `state.signalingServers` which defaults to `['wss://public.localsend.org/v1/ws']` but can be customized
- [x] Verified the rest of the action already uses `signalingServer` for connection tracking (`_SetConnectionAction`, `_RemoveConnectionAction`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)