### PR TITLE
fix: add missing /tree/ guard in ContentUriHelper.convertTreeUriToDocumentUri

### DIFF
--- a/app/lib/util/native/content_uri_helper.dart
+++ b/app/lib/util/native/content_uri_helper.dart
@@ -65,6 +65,9 @@ class ContentUriHelper {
     String? suffix,
   }) {
     final index = treeUri.indexOf('/tree/');
+    if (index == -1) {
+      return treeUri;
+    }
     final treePath = treeUri.substring(index + 6);
 
     if (suffix == null) {


### PR DESCRIPTION
## Summary
- `convertTreeUriToDocumentUri` calls `indexOf('/tree/')` but never checks for `-1`, producing garbage output on invalid input.
- The sibling methods `getPathFromTreeUri` and `encodeTreeUri` both have this guard — `convertTreeUriToDocumentUri` is the only one missing it.

## Root cause
```dart
final index = treeUri.indexOf('/tree/');
final treePath = treeUri.substring(index + 6); // index=-1 → substring(5) → garbage
```

## Fix
Add the same guard used by `encodeTreeUri`:
```dart
if (index == -1) {
  return treeUri;
}
```

## Test plan
- [x] Verified the fix matches the pattern in `encodeTreeUri` (line 83-84) and `getPathFromTreeUri` (line 11-13)
- [x] Valid URIs with `/tree/` are unaffected — the guard passes and behavior is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)