### PR TITLE
fix: URL-encode query parameters in TargetUrl

### DIFF
--- a/core/src/http/client/url.rs
+++ b/core/src/http/client/url.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt::Write;
 
 pub struct TargetUrl<'a> {
     pub version: ApiVersion,
@@ -8,7 +9,6 @@ pub struct TargetUrl<'a> {
     pub path: &'static str,
 
     /// Query parameters as key-value pairs.
-    /// Note: It is expected that the caller will URL-encode the values if necessary.
     pub params: &'a [(&'static str, &'a str)],
 }
 
@@ -39,7 +39,7 @@ impl<'a> TargetUrl<'a> {
             let query = self
                 .params
                 .iter()
-                .map(|(k, v)| format!("{}={}", k, v))
+                .map(|(k, v)| format!("{}={}", k, percent_encode(v)))
                 .collect::<Vec<_>>()
                 .join("&");
             format!("{}?{}", base, query)
@@ -47,8 +47,24 @@ impl<'a> TargetUrl<'a> {
     }
 }
 
+/// Percent-encodes characters that are not unreserved in a URL query value
+/// (RFC 3986: unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~").
+fn percent_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char);
+            }
+            _ => write!(out, "%{b:02X}").unwrap(),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
+    use super::percent_encode;
     use super::{ApiVersion, TargetUrl};
 
     #[test]
@@ -91,5 +107,31 @@ mod tests {
         }
         .to_string();
         assert_eq!(url, "http://192.168.1.1:53317/api/localsend/v2/info");
+    }
+
+    #[test]
+    fn test_percent_encode() {
+        assert_eq!(percent_encode("hello"), "hello");
+        assert_eq!(percent_encode("a b"), "a%20b");
+        assert_eq!(percent_encode("key=value"), "key%3Dvalue");
+        assert_eq!(percent_encode("a&b"), "a%26b");
+        assert_eq!(percent_encode("foo-bar_baz.qux~"), "foo-bar_baz.qux~");
+    }
+
+    #[test]
+    fn test_build_url_with_params() {
+        let url = TargetUrl {
+            version: ApiVersion::V2,
+            protocol: "https",
+            host: "192.168.1.1".to_string(),
+            port: 53317,
+            path: "/register",
+            params: &[("sessionId", "abc-123"), ("token", "t&v=1")],
+        }
+        .to_string();
+        assert_eq!(
+            url,
+            "https://192.168.1.1:53317/api/localsend/v2/register?sessionId=abc-123&token=t%26v%3D1"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Query parameters in `core/src/http/client/url.rs` were interpolated with `format!("{}={}", k, v)` without percent-encoding, producing malformed URLs if values contain `&`, `=`, `#`, or other reserved characters.
- Adds a `percent_encode` function and applies it to query values.

## Before
```rust
.map(|(k, v)| format!("{}={}", k, v))  // no encoding
```

## After
```rust
.map(|(k, v)| format!("{}={}", k, percent_encode(v)))  // RFC 3986 encoding
```

## Test plan
- [x] Added 2 new tests: `test_percent_encode` and `test_build_url_with_params`
- [x] All 5 existing + new tests pass (`cargo test url --features full`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)