### PR TITLE
fix: replace unwrap() on peer certificate with safe access

### DIFF
--- a/core/src/http/server/mod.rs
+++ b/core/src/http/server/mod.rs
@@ -144,7 +144,7 @@ async fn start_server_with_addr(
                                 .deref()
                                 .deref()
                                 .peer_certificates()
-                                .map(|cert| cert.get(0).unwrap().to_vec()),
+                                .and_then(|certs| certs.first().map(|c| c.as_ref().to_vec())),
                         }
                     };
 


### PR DESCRIPTION
## Summary
- In `core/src/http/server/mod.rs`, the TLS connection handler extracts the peer certificate with `.get(0).unwrap().to_vec()`, which panics if `peer_certificates()` returns `Some` but the vector is empty.
- While the custom `ClientCertVerifier` makes this unlikely, it is not guaranteed — a panic here crashes the server task.

## Fix
Replace the `unwrap()` with safe `first()` + `map()` access:
```rust
.and_then(|certs| certs.first().map(|c| c.as_ref().to_vec()))
```
Returns `None` instead of panicking when the certificate vector is empty.

## Test plan
- [x] Verified the fix compiles (`cargo check --features http`)
- [x] Type is unchanged: `Option<Vec<u8>>` (the `cert` field type in `RequestClientInfo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)