### PR TITLE
[codex] Fix iOS scene lifecycle and media permission handling

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -2,18 +2,20 @@ import UIKit
 import Flutter
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
 
-    let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
 
-    let engine = controller.engine
     let channel = FlutterMethodChannel(
       name: "ios-delegate-channel",
-      binaryMessenger: engine.binaryMessenger
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
     )
     channel.setMethodCallHandler { (call: FlutterMethodCall, result: @escaping FlutterResult) in
       if call.method == "isReduceMotionEnabled" {
@@ -22,8 +24,5 @@ import Flutter
         result(FlutterMethodNotImplemented)
       }
     }
-
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -24,6 +24,27 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/app/lib/util/native/file_picker.dart
+++ b/app/lib/util/native/file_picker.dart
@@ -242,32 +242,51 @@ Future<void> _pickFolder(BuildContext context, Ref ref) async {
 }
 
 Future<void> _pickMedia(BuildContext context, Ref ref) async {
-  if (checkPlatform([TargetPlatform.android])) {
-    await PhotoManager.requestPermissionExtend(
-      requestOption: const PermissionRequestOption(
-        androidPermission: AndroidPermission(
-          type: RequestType.common,
-          mediaLocation: true,
-        ),
-      ),
-    );
-  }
+  final permissionRequestOption = checkPlatform([TargetPlatform.android])
+      ? const PermissionRequestOption(
+          androidPermission: AndroidPermission(
+            type: RequestType.common,
+            mediaLocation: true,
+          ),
+        )
+      : const PermissionRequestOption();
 
+  final permissionState = await PhotoManager.requestPermissionExtend(
+    requestOption: permissionRequestOption,
+  );
   if (!context.mounted) return;
 
-  final oldBrightness = Theme.of(context).brightness;
-  final List<AssetEntity>? result = await AssetPicker.pickAssets(
-    context,
-    pickerConfig: const AssetPickerConfig(maxAssets: 999, textDelegate: TranslatedAssetPickerTextDelegate()),
-  );
+  if (!permissionState.hasAccess) {
+    await _showMediaPermissionDialog(context);
+    return;
+  }
 
-  WidgetsBinding.instance.addPostFrameCallback((_) async {
-    // restore brightness for Android
-    await sleepAsync(500);
-    if (context.mounted) {
-      await updateSystemOverlayStyleWithBrightness(oldBrightness);
+  final oldBrightness = Theme.of(context).brightness;
+  final List<AssetEntity>? result;
+  try {
+    result = await AssetPicker.pickAssets(
+      context,
+      pickerConfig: const AssetPickerConfig(maxAssets: 999, textDelegate: TranslatedAssetPickerTextDelegate()),
+      permissionRequestOption: permissionRequestOption,
+    );
+  } on StateError catch (e) {
+    if (e.message.startsWith('Permission state error')) {
+      if (context.mounted) {
+        await _showMediaPermissionDialog(context);
+      }
+      _logger.warning('Media permission denied', e);
+      return;
     }
-  });
+    rethrow;
+  } finally {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // restore brightness for Android
+      await sleepAsync(500);
+      if (context.mounted) {
+        await updateSystemOverlayStyleWithBrightness(oldBrightness);
+      }
+    });
+  }
 
   if (result != null) {
     await ref
@@ -279,6 +298,15 @@ Future<void> _pickMedia(BuildContext context, Ref ref) async {
           ),
         );
   }
+}
+
+Future<void> _showMediaPermissionDialog(BuildContext context) {
+  final additionalContent = checkPlatform([TargetPlatform.iOS]) ? 'iOS: Ajustes > Fotos > Todas las fotos.' : null;
+
+  return showDialog(
+    context: context,
+    builder: (_) => NoPermissionDialog(additionalContent: additionalContent),
+  );
 }
 
 Future<void> _pickText(BuildContext context, Ref ref) async {

--- a/app/lib/widget/dialogs/no_permission_dialog.dart
+++ b/app/lib/widget/dialogs/no_permission_dialog.dart
@@ -1,19 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:routerino/routerino.dart';
+import 'package:system_settings_2/system_settings_2.dart';
 
 class NoPermissionDialog extends StatelessWidget {
-  const NoPermissionDialog({super.key});
+  const NoPermissionDialog({
+    super.key,
+    this.additionalContent,
+  });
+
+  final String? additionalContent;
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text(t.dialogs.noPermission.title),
-      content: Text(t.dialogs.noPermission.content),
+      content: Text(
+        additionalContent == null ? t.dialogs.noPermission.content : '${t.dialogs.noPermission.content}\n\n$additionalContent',
+      ),
       actions: [
         TextButton(
           onPressed: () => context.pop(),
           child: Text(t.general.close),
+        ),
+        ElevatedButton.icon(
+          onPressed: () async {
+            context.pop();
+            await SystemSettings.app();
+          },
+          icon: const Icon(Icons.settings),
+          label: Text(t.general.settings),
         ),
       ],
     );


### PR DESCRIPTION
## Summary

This updates the iOS runner to support the UIScene lifecycle and makes media permission denial a handled flow instead of an uncaught picker error.

## Changes

- Adds `UIApplicationSceneManifest` for the Flutter scene lifecycle.
- Moves Flutter plugin/channel setup from `didFinishLaunching` to `didInitializeImplicitFlutterEngine`, avoiding early access to `window?.rootViewController`.
- Requests media-library permission before opening `wechat_assets_picker`.
- Handles denied media permission without throwing through Refena.
- Adds a settings action to the no-permission dialog, with iOS-specific guidance for enabling Photos access.

## Why

Flutter warns that UIScene lifecycle support will be required for upcoming iOS versions. The previous AppDelegate initialization also depended on `window` before the scene lifecycle owns it.

For media picking, `wechat_assets_picker` throws a `StateError` when `PhotoManager` returns `PermissionState.denied`. This caused the action to surface as an unhandled exception instead of prompting the user to fix the permission.

## Validation

- `plutil -lint app/ios/Runner/Info.plist`
- `xcrun swiftc -typecheck -parse-as-library ... app/ios/Runner/AppDelegate.swift`
- `flutter analyze lib/util/native/file_picker.dart lib/widget/dialogs/no_permission_dialog.dart --no-pub`