### PR TITLE
feat: skip or overwrite duplicate files

### DIFF
--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -120,7 +120,9 @@
       "destination": "Save to folder",
       "downloads": "(Downloads)",
       "saveToGallery": "Save media to gallery",
-      "saveToHistory": "Save to history"
+      "saveToHistory": "Save to history",
+      "overwriteDuplicateFiles": "Overwrite duplicate files",
+      "skipDuplicateFiles": "Skip duplicate filesaaa"
     },
     "send": {
       "title": "Send",

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 53
-/// Strings: 17825 (336 per locale)
+/// Strings: 17827 (336 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -1049,6 +1049,12 @@ class TranslationsSettingsTabReceiveEn {
 
   /// en: 'Save to history'
   String get saveToHistory => 'Save to history';
+
+  /// en: 'Overwrite duplicate files'
+  String get overwriteDuplicateFiles => 'Overwrite duplicate files';
+
+  /// en: 'Skip duplicate files'
+  String get skipDuplicateFiles => 'Skip duplicate files';
 }
 
 // Path: settingsTab.send

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -32,6 +32,8 @@ class SettingsState with SettingsStateMappable {
   final bool enableAnimations;
   final DeviceType? deviceType;
   final String? deviceModel;
+  final bool overwriteDuplicateFiles;
+  final bool skipDuplicateFiles;
   final bool shareViaLinkAutoAccept;
   final int discoveryTimeout;
   final bool advancedSettings;
@@ -60,6 +62,8 @@ class SettingsState with SettingsStateMappable {
     required this.enableAnimations,
     required this.deviceType,
     required this.deviceModel,
+    required this.overwriteDuplicateFiles,
+    required this.skipDuplicateFiles,
     required this.shareViaLinkAutoAccept,
     required this.discoveryTimeout,
     required this.advancedSettings,

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -131,6 +131,17 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     'deviceModel',
     _$deviceModel,
   );
+  static bool _$overwriteDuplicateFiles(SettingsState v) =>
+      v.overwriteDuplicateFiles;
+  static const Field<SettingsState, bool> _f$overwriteDuplicateFiles = Field(
+    'overwriteDuplicateFiles',
+    _$overwriteDuplicateFiles,
+  );
+  static bool _$skipDuplicateFiles(SettingsState v) => v.skipDuplicateFiles;
+  static const Field<SettingsState, bool> _f$skipDuplicateFiles = Field(
+    'skipDuplicateFiles',
+    _$skipDuplicateFiles,
+  );
   static bool _$shareViaLinkAutoAccept(SettingsState v) =>
       v.shareViaLinkAutoAccept;
   static const Field<SettingsState, bool> _f$shareViaLinkAutoAccept = Field(
@@ -173,6 +184,8 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #enableAnimations: _f$enableAnimations,
     #deviceType: _f$deviceType,
     #deviceModel: _f$deviceModel,
+    #overwriteDuplicateFiles: _f$overwriteDuplicateFiles,
+    #skipDuplicateFiles: _f$skipDuplicateFiles,
     #shareViaLinkAutoAccept: _f$shareViaLinkAutoAccept,
     #discoveryTimeout: _f$discoveryTimeout,
     #advancedSettings: _f$advancedSettings,
@@ -203,6 +216,8 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
       enableAnimations: data.dec(_f$enableAnimations),
       deviceType: data.dec(_f$deviceType),
       deviceModel: data.dec(_f$deviceModel),
+      overwriteDuplicateFiles: data.dec(_f$overwriteDuplicateFiles),
+      skipDuplicateFiles: data.dec(_f$skipDuplicateFiles),
       shareViaLinkAutoAccept: data.dec(_f$shareViaLinkAutoAccept),
       discoveryTimeout: data.dec(_f$discoveryTimeout),
       advancedSettings: data.dec(_f$advancedSettings),
@@ -299,6 +314,8 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out>
     bool? enableAnimations,
     DeviceType? deviceType,
     String? deviceModel,
+    bool? overwriteDuplicateFiles,
+    bool? skipDuplicateFiles,
     bool? shareViaLinkAutoAccept,
     int? discoveryTimeout,
     bool? advancedSettings,
@@ -357,6 +374,8 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     bool? enableAnimations,
     Object? deviceType = $none,
     Object? deviceModel = $none,
+    bool? overwriteDuplicateFiles,
+    bool? skipDuplicateFiles,
     bool? shareViaLinkAutoAccept,
     int? discoveryTimeout,
     bool? advancedSettings,
@@ -387,6 +406,9 @@ class _SettingsStateCopyWithImpl<$R, $Out>
       if (enableAnimations != null) #enableAnimations: enableAnimations,
       if (deviceType != $none) #deviceType: deviceType,
       if (deviceModel != $none) #deviceModel: deviceModel,
+      if (overwriteDuplicateFiles != null)
+        #overwriteDuplicateFiles: overwriteDuplicateFiles,
+      if (skipDuplicateFiles != null) #skipDuplicateFiles: skipDuplicateFiles,
       if (shareViaLinkAutoAccept != null)
         #shareViaLinkAutoAccept: shareViaLinkAutoAccept,
       if (discoveryTimeout != null) #discoveryTimeout: discoveryTimeout,
@@ -424,6 +446,14 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     enableAnimations: data.get(#enableAnimations, or: $value.enableAnimations),
     deviceType: data.get(#deviceType, or: $value.deviceType),
     deviceModel: data.get(#deviceModel, or: $value.deviceModel),
+    overwriteDuplicateFiles: data.get(
+      #overwriteDuplicateFiles,
+      or: $value.overwriteDuplicateFiles,
+    ),
+    skipDuplicateFiles: data.get(
+      #skipDuplicateFiles,
+      or: $value.skipDuplicateFiles,
+    ),
     shareViaLinkAutoAccept: data.get(
       #shareViaLinkAutoAccept,
       or: $value.shareViaLinkAutoAccept,

--- a/app/lib/pages/receive_page.dart
+++ b/app/lib/pages/receive_page.dart
@@ -10,6 +10,7 @@ import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/pages/receive_options_page.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
+import 'package:localsend_app/provider/network/server/server_provider.dart';
 import 'package:localsend_app/provider/selection/selected_receiving_files_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/device_type_ext.dart';
@@ -84,7 +85,17 @@ class _ReceivePageState extends State<ReceivePage> with Refena {
     return ViewModelBuilder(
       provider: (ref) => widget.vm,
       onFirstFrame: (context, vm) {
-        ref.notifier(selectedReceivingFilesProvider).setFiles(vm.files);
+        final settings = ref.read(settingsProvider);
+        final destinationDir = ref.read(serverProvider)?.session?.destinationDirectory;
+        if (destinationDir != null) {
+          ref.notifier(selectedReceivingFilesProvider).initFiles(
+            files: vm.files,
+            destinationDir: destinationDir,
+            skipDuplicateFiles: settings.skipDuplicateFiles,
+          );
+        } else {
+          ref.notifier(selectedReceivingFilesProvider).setFiles(vm.files);
+        }
       },
       dispose: (ref) {
         ref.dispose(widget.vm);

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -250,6 +250,20 @@ class SettingsTab extends StatelessWidget {
                           await ref.notifier(settingsProvider).setSaveToHistory(b);
                         },
                       ),
+                      _BooleanEntry(
+                        label: 'Overwrite duplicate files',
+                        value: vm.settings.overwriteDuplicateFiles,
+                        onChanged: (b) async {
+                          await ref.notifier(settingsProvider).setOverwriteDuplicateFiles(b);
+                        },
+                      ),
+                      _BooleanEntry(
+                        label: 'Skip duplicate files',
+                        value: vm.settings.skipDuplicateFiles,
+                        onChanged: (b) async {
+                          await ref.notifier(settingsProvider).setSkipDuplicateFiles(b);
+                        },
+                      ),
                     ],
                   ),
                   if (vm.advanced)

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -251,14 +251,14 @@ class SettingsTab extends StatelessWidget {
                         },
                       ),
                       _BooleanEntry(
-                        label: 'Overwrite duplicate files',
+                        label: t.settingsTab.receive.overwriteDuplicateFiles,
                         value: vm.settings.overwriteDuplicateFiles,
                         onChanged: (b) async {
                           await ref.notifier(settingsProvider).setOverwriteDuplicateFiles(b);
                         },
                       ),
                       _BooleanEntry(
-                        label: 'Skip duplicate files',
+                        label: t.settingsTab.receive.skipDuplicateFiles,
                         value: vm.settings.skipDuplicateFiles,
                         onChanged: (b) async {
                           await ref.notifier(settingsProvider).setSkipDuplicateFiles(b);

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -46,6 +46,7 @@ import 'package:localsend_app/util/rust.dart';
 import 'package:localsend_app/util/simple_server.dart';
 import 'package:localsend_app/widget/dialogs/open_file_dialog.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
@@ -270,9 +271,21 @@ class ReceiveController {
     final Map<String, String>? selection;
     if (quickSave) {
       // accept all files
-      selection = {
-        for (final f in dto.files.values) f.id: f.fileName,
-      };
+      final map = <String, String>{};
+      for (final f in dto.files.values) {
+        if (settings.skipDuplicateFiles) {
+          bool exists = false;
+          try {
+            exists = File(path.join(destinationDir, f.fileName)).existsSync();
+          } catch (_) {}
+          if (!exists) {
+            map[f.id] = f.fileName;
+          }
+        } else {
+          map[f.id] = f.fileName;
+        }
+      }
+      selection = map;
     } else {
       if (checkPlatformHasTray() && (await windowManager.isMinimized() || !(await windowManager.isVisible()) || !(await windowManager.isFocused()))) {
         await showFromTray();
@@ -509,6 +522,7 @@ class ReceiveController {
         saveToGallery: shouldSaveToGallery,
         isImage: fileType == FileType.image,
         stream: request,
+        overwriteDuplicateFiles: server.ref.read(settingsProvider).overwriteDuplicateFiles,
         onProgress: (savedBytes) {
           if (receivingFile.file.size != 0) {
             server.ref

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -362,7 +362,21 @@ class PersistenceService {
   bool getShareViaLinkAutoAccept() {
     return _prefs.getBool(_shareViaLinkAutoAccept) ?? false;
   }
+  bool getOverwriteDuplicateFiles() {
+    return _prefs.getBool('overwriteDuplicateFiles') ?? false;
+  }
 
+  Future<void> setOverwriteDuplicateFiles(bool overwriteDuplicateFiles) async {
+    await _prefs.setBool('overwriteDuplicateFiles', overwriteDuplicateFiles);
+  }
+
+  bool getSkipDuplicateFiles() {
+    return _prefs.getBool('skipDuplicateFiles') ?? false;
+  }
+
+  Future<void> setSkipDuplicateFiles(bool skipDuplicateFiles) async {
+    await _prefs.setBool('skipDuplicateFiles', skipDuplicateFiles);
+  }
   Future<void> setShareViaLinkAutoAccept(bool shareViaLinkAutoAccept) async {
     await _prefs.setBool(_shareViaLinkAutoAccept, shareViaLinkAutoAccept);
   }

--- a/app/lib/provider/selection/selected_receiving_files_provider.dart
+++ b/app/lib/provider/selection/selected_receiving_files_provider.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:common/model/dto/file_dto.dart';
 import 'package:localsend_app/util/file_path_helper.dart';
+import 'package:path/path.dart' as p;
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:uuid/uuid.dart';
 
@@ -19,6 +22,28 @@ class SelectedReceivingFilesNotifier extends Notifier<Map<String, String>> {
   @override
   Map<String, String> init() {
     return {};
+  }
+
+  void initFiles({
+    required List<FileDto> files,
+    required String destinationDir,
+    required bool skipDuplicateFiles,
+  }) {
+    final Map<String, String> map = {};
+    for (final f in files) {
+      if (skipDuplicateFiles) {
+        bool exists = false;
+        try {
+          exists = File(p.join(destinationDir, f.fileName)).existsSync();
+        } catch (_) {}
+        if (!exists) {
+          map[f.id] = f.fileName;
+        }
+      } else {
+        map[f.id] = f.fileName;
+      }
+    }
+    state = map;
   }
 
   void setFiles(List<FileDto> files) {

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -244,15 +244,31 @@ class SettingsService extends PureNotifier<SettingsState> {
 
   Future<void> setSkipDuplicateFiles(bool skipDuplicateFiles) async {
     await _persistence.setSkipDuplicateFiles(skipDuplicateFiles);
+    
+    bool overwriteDuplicateFiles = state.overwriteDuplicateFiles;
+    if (skipDuplicateFiles && overwriteDuplicateFiles) {
+      overwriteDuplicateFiles = false;
+      await _persistence.setOverwriteDuplicateFiles(false);
+    }
+    
     state = state.copyWith(
       skipDuplicateFiles: skipDuplicateFiles,
+      overwriteDuplicateFiles: overwriteDuplicateFiles,
     );
   }
 
   Future<void> setOverwriteDuplicateFiles(bool overwriteDuplicateFiles) async {
     await _persistence.setOverwriteDuplicateFiles(overwriteDuplicateFiles);
+    
+    bool skipDuplicateFiles = state.skipDuplicateFiles;
+    if (overwriteDuplicateFiles && skipDuplicateFiles) {
+      skipDuplicateFiles = false;
+      await _persistence.setSkipDuplicateFiles(false);
+    }
+    
     state = state.copyWith(
       overwriteDuplicateFiles: overwriteDuplicateFiles,
+      skipDuplicateFiles: skipDuplicateFiles,
     );
   }
 

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -67,6 +67,8 @@ class SettingsService extends PureNotifier<SettingsState> {
     enableAnimations: _persistence.getEnableAnimations(),
     deviceType: _persistence.getDeviceType(),
     deviceModel: _persistence.getDeviceModel(),
+    overwriteDuplicateFiles: _persistence.getOverwriteDuplicateFiles(),
+    skipDuplicateFiles: _persistence.getSkipDuplicateFiles(),
     shareViaLinkAutoAccept: _persistence.getShareViaLinkAutoAccept(),
     discoveryTimeout: _persistence.getDiscoveryTimeout(),
     advancedSettings: _persistence.getAdvancedSettingsEnabled(),
@@ -237,6 +239,20 @@ class SettingsService extends PureNotifier<SettingsState> {
     await _persistence.setDeviceModel(deviceModel);
     state = state.copyWith(
       deviceModel: deviceModel,
+    );
+  }
+
+  Future<void> setSkipDuplicateFiles(bool skipDuplicateFiles) async {
+    await _persistence.setSkipDuplicateFiles(skipDuplicateFiles);
+    state = state.copyWith(
+      skipDuplicateFiles: skipDuplicateFiles,
+    );
+  }
+
+  Future<void> setOverwriteDuplicateFiles(bool overwriteDuplicateFiles) async {
+    await _persistence.setOverwriteDuplicateFiles(overwriteDuplicateFiles);
+    state = state.copyWith(
+      overwriteDuplicateFiles: overwriteDuplicateFiles,
     );
   }
 

--- a/app/lib/util/native/file_saver.dart
+++ b/app/lib/util/native/file_saver.dart
@@ -39,6 +39,7 @@ Future<(bool, String?)> saveFile({
   required Stream<Uint8List> stream,
   required void Function(int) onProgress,
   required Set<String> createdDirectories,
+  bool overwriteDuplicateFiles = false,
   int? androidSdkInt,
   DateTime? lastModified,
   DateTime? lastAccessed,
@@ -49,6 +50,7 @@ Future<(bool, String?)> saveFile({
     parentDirectory: parentDirectory,
     fileName: fileName,
     createdDirectories: createdDirectories,
+    overwriteDuplicateFiles: overwriteDuplicateFiles,
   );
 
   // When saveToGallery is enabled, cache directory is used so SAF is not needed
@@ -212,6 +214,7 @@ Future<(String, String?, String)> digestFilePathAndPrepareDirectory({
   required String parentDirectory,
   required String fileName,
   required Set<String> createdDirectories,
+  bool overwriteDuplicateFiles = false,
 }) async {
   if (parentDirectory.startsWith('content://')) {
     final String documentUri;
@@ -251,11 +254,15 @@ Future<(String, String?, String)> digestFilePathAndPrepareDirectory({
   }
 
   String destinationPath;
-  int counter = 1;
-  do {
-    destinationPath = counter == 1 ? p.join(dir, actualFileName) : p.join(dir, actualFileName.withCount(counter));
-    counter++;
-  } while (await File(destinationPath).exists());
+  if (overwriteDuplicateFiles) {
+    destinationPath = p.join(dir, actualFileName);
+  } else {
+    int counter = 1;
+    do {
+      destinationPath = counter == 1 ? p.join(dir, actualFileName) : p.join(dir, actualFileName.withCount(counter));
+      counter++;
+    } while (await File(destinationPath).exists());
+  }
   return (destinationPath, null, p.basename(destinationPath));
 }
 

--- a/app/test/mocks.mocks.dart
+++ b/app/test/mocks.mocks.dart
@@ -11,7 +11,8 @@ import 'package:flutter/material.dart' as _i8;
 import 'package:localsend_app/gen/strings.g.dart' as _i10;
 import 'package:localsend_app/model/persistence/color_mode.dart' as _i9;
 import 'package:localsend_app/model/persistence/favorite_device.dart' as _i6;
-import 'package:localsend_app/model/persistence/receive_history_entry.dart' as _i5;
+import 'package:localsend_app/model/persistence/receive_history_entry.dart'
+    as _i5;
 import 'package:localsend_app/model/send_mode.dart' as _i11;
 import 'package:localsend_app/provider/persistence_provider.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
@@ -32,14 +33,17 @@ import 'package:shared_preferences/shared_preferences.dart' as _i13;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeStoredSecurityContext_0 extends _i1.SmartFake implements _i2.StoredSecurityContext {
-  _FakeStoredSecurityContext_0(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeStoredSecurityContext_0 extends _i1.SmartFake
+    implements _i2.StoredSecurityContext {
+  _FakeStoredSecurityContext_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [PersistenceService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService {
+class MockPersistenceService extends _i1.Mock
+    implements _i3.PersistenceService {
   @override
   bool get isFirstAppStart =>
       (super.noSuchMethod(
@@ -282,6 +286,44 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
             returnValueForMissingStub: false,
           )
           as bool);
+
+  @override
+  bool getOverwriteDuplicateFiles() =>
+      (super.noSuchMethod(
+            Invocation.method(#getOverwriteDuplicateFiles, []),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
+
+  @override
+  _i4.Future<void> setOverwriteDuplicateFiles(bool? overwriteDuplicateFiles) =>
+      (super.noSuchMethod(
+            Invocation.method(#setOverwriteDuplicateFiles, [
+              overwriteDuplicateFiles,
+            ]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
+  bool getSkipDuplicateFiles() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSkipDuplicateFiles, []),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
+
+  @override
+  _i4.Future<void> setSkipDuplicateFiles(bool? skipDuplicateFiles) =>
+      (super.noSuchMethod(
+            Invocation.method(#setSkipDuplicateFiles, [skipDuplicateFiles]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
 
   @override
   _i4.Future<void> setShareViaLinkAutoAccept(bool? shareViaLinkAutoAccept) =>

--- a/app/test/unit/provider/selection/selected_receiving_files_provider_test.dart
+++ b/app/test/unit/provider/selection/selected_receiving_files_provider_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+import 'package:common/model/dto/file_dto.dart';
+import 'package:common/model/file_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localsend_app/provider/selection/selected_receiving_files_provider.dart';
+import 'package:path/path.dart' as p;
+import 'package:refena_flutter/refena_flutter.dart';
+
+void main() {
+  group('SelectedReceivingFilesNotifier', () {
+    late Ref ref;
+    late Directory tempDir;
+
+    setUp(() {
+      ref = RefenaContainer();
+      tempDir = Directory.systemTemp.createTempSync('localsend_test_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('Should accept all files if skipDuplicateFiles is false', () {
+      final notifier = ref.notifier(selectedReceivingFilesProvider);
+
+      notifier.initFiles(
+        files: [
+          const FileDto(id: '1', fileName: 'test1.txt', size: 100, fileType: FileType.text, hash: null, preview: null, metadata: null),
+          const FileDto(id: '2', fileName: 'test2.txt', size: 100, fileType: FileType.text, hash: null, preview: null, metadata: null),
+        ],
+        destinationDir: tempDir.path,
+        skipDuplicateFiles: false,
+      );
+
+      final state = ref.read(selectedReceivingFilesProvider);
+      expect(state, {
+        '1': 'test1.txt',
+        '2': 'test2.txt',
+      });
+    });
+
+    test('Should skip existing files if skipDuplicateFiles is true', () {
+      // Create a dummy existing file
+      File(p.join(tempDir.path, 'test1.txt')).writeAsStringSync('existing file');
+
+      final notifier = ref.notifier(selectedReceivingFilesProvider);
+
+      notifier.initFiles(
+        files: [
+          const FileDto(id: '1', fileName: 'test1.txt', size: 100, fileType: FileType.text, hash: null, preview: null, metadata: null),
+          const FileDto(id: '2', fileName: 'test2.txt', size: 100, fileType: FileType.text, hash: null, preview: null, metadata: null),
+        ],
+        destinationDir: tempDir.path,
+        skipDuplicateFiles: true,
+      );
+
+      final state = ref.read(selectedReceivingFilesProvider);
+      
+      // test1.txt should be skipped
+      // test2.txt should be kept
+      expect(state, {
+        '2': 'test2.txt',
+      });
+    });
+  });
+}

--- a/app/test/unit/util/native/file_saver_test.dart
+++ b/app/test/unit/util/native/file_saver_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localsend_app/util/native/file_saver.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('digestFilePathAndPrepareDirectory', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('localsend_saver_test_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('Should increment counter if file already exists', () async {
+      File(p.join(tempDir.path, 'test.txt')).writeAsStringSync('existing file');
+
+      final (destinationPath, _, finalName) = await digestFilePathAndPrepareDirectory(
+        parentDirectory: tempDir.path,
+        fileName: 'test.txt',
+        createdDirectories: {},
+        overwriteDuplicateFiles: false,
+      );
+
+      final expectedPath = p.join(tempDir.path, 'test (2).txt');
+      expect(destinationPath, expectedPath);
+      expect(finalName, 'test (2).txt');
+    });
+
+    test('Should overwrite if file already exists and overwriteDuplicateFiles is true', () async {
+      File(p.join(tempDir.path, 'test.txt')).writeAsStringSync('existing file');
+
+      final (destinationPath, _, finalName) = await digestFilePathAndPrepareDirectory(
+        parentDirectory: tempDir.path,
+        fileName: 'test.txt',
+        createdDirectories: {},
+        overwriteDuplicateFiles: true,
+      );
+
+      final expectedPath = p.join(tempDir.path, 'test.txt');
+      expect(destinationPath, expectedPath);
+      expect(finalName, 'test.txt');
+    });
+
+    test('Should not change file name if file does not exist and overwriteDuplicateFiles is true', () async {
+      final (destinationPath, _, finalName) = await digestFilePathAndPrepareDirectory(
+        parentDirectory: tempDir.path,
+        fileName: 'test.txt',
+        createdDirectories: {},
+        overwriteDuplicateFiles: true,
+      );
+
+      final expectedPath = p.join(tempDir.path, 'test.txt');
+      expect(destinationPath, expectedPath);
+      expect(finalName, 'test.txt');
+    });
+    
+    test('Should not change file name if file does not exist and overwriteDuplicateFiles is false', () async {
+      final (destinationPath, _, finalName) = await digestFilePathAndPrepareDirectory(
+        parentDirectory: tempDir.path,
+        fileName: 'test.txt',
+        createdDirectories: {},
+        overwriteDuplicateFiles: false,
+      );
+
+      final expectedPath = p.join(tempDir.path, 'test.txt');
+      expect(destinationPath, expectedPath);
+      expect(finalName, 'test.txt');
+    });
+  });
+}


### PR DESCRIPTION
Hi, this is my first time contributing to an open source project, so any feedback is appreciated. I started using the app recently and i think it's great, now I wanted to contribute with this little improvement. I have a large folder that I modify partially from time to time and have to transfer between my devices. However, as the app is, it takes some time figuring out the exact files to send in order to avoid duplicates. So I wanted to implement this so i can only select the root folder and don't worry about the rest, I hope it can be helpful to other people too

When running the project for the first time I had an issue when installing the dependencies I wasn't sure how to solve, it worked when editing `app/pubspec.yml` from this:

```
dev_dependencies:
  build_runner: 2.7.1
  dart_mappable_builder: 4.6.0
  flutter_gen_runner: 5.12.0
  flutter_lints: 5.0.0
  freezed: 3.2.3
  mockito: 5.5.0
  refena_inspector: 2.1.0
  slang_build_runner: 4.9.0
  test: ^1.26.2
```

to this:
```
dev_dependencies:
  build_runner: 2.7.1
  dart_mappable_builder: 4.6.0
  flutter_gen_runner: 5.12.0
  flutter_lints: 5.0.0
  freezed: 3.2.3
  mockito: ^5.4.4
  refena_inspector: 2.1.0
  slang_build_runner: 4.9.0
```
Also, do I have to include all the translations to be able to merge? 

| Before | After |
|:------:|:-----:|
| <img width="524" height="852" alt="Captura de tela de 2026-05-07 12-54-39" src="https://github.com/user-attachments/assets/843eb88e-2afa-4821-b394-84466ddbfe3d" /> | <img width="525" height="843" alt="Captura de tela de 2026-05-07 12-57-28" src="https://github.com/user-attachments/assets/95a242c1-700c-4408-81e7-82e055586b8f" /> |