### PR TITLE
feat: enable arm memory tagging extension

### DIFF
--- a/app/android/app/src/debug/AndroidManifest.xml
+++ b/app/android/app/src/debug/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="LocalSend Debug"
+        android:memtagMode="sync"
         tools:ignore="MissingApplicationIcon"
         tools:replace="android:label" />
 </manifest>

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         android:banner="@drawable/banner"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true"
+        android:memtagMode="async"
     >
 
         <!-- localsend: prevent multiple instances by android:launchMode="singleTask" -->


### PR DESCRIPTION
makes app exploitation much harder on devices and OS's with MTE support https://source.android.com/docs/security/test/memory-safety/arm-mte#enable-mte-apps

sync mode for debugging, async mode for production builds following recommendation https://source.android.com/docs/security/test/memory-safety/arm-mte#async-mode

LocalSend v1.16.1 & v1.17.0 runs fine for me for few months on GrapheneOS with Memory tagging enabled for an app. Propose to enable it by default for Android builds.

This change will affect:
- Google Pixel's users with stock OS with Advanced Protection enabled
- Google Pixel's users with GrapheneOS
- Samsung Galaxy users [in some near future](https://www.androidauthority.com/one-ui-9-memory-tagging-extension-spotted-3654992/)
- other devices with other OS's in some not that near future