### PR TITLE
Update LocalSend description

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [github]: https://github.com/localsend/localsend
 [codeberg]: https://codeberg.org/localsend/localsend
 
-LocalSend is a free, open-source app that allows you to securely share files and messages with nearby devices over your local network without needing an internet connection.
+LocalSend is a free, open-source app that allows you to securely share files and messages with nearby devices over your local network without needing an internet connection or passing through external devices, it's peer-to-peer.
 
 - [About](#about)
 - [Sponsors](#sponsors)


### PR DESCRIPTION
Clarify that LocalSend operates peer-to-peer without external devices.