### PR TITLE
fix: add timeouts to HTTP send operations (#3044)

### DIFF
--- a/app/lib/provider/http_provider.dart
+++ b/app/lib/provider/http_provider.dart
@@ -2,6 +2,22 @@ import 'package:localsend_app/provider/security_provider.dart';
 import 'package:localsend_app/rust/api/http.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 
+/// Default timeout for peer-to-peer HTTP requests.
+///
+/// Without this, packet loss, a Wi-Fi drop, or a peer crash mid-handshake
+/// can leave the request awaited indefinitely. 30s is generous enough for
+/// slow networks while still letting the user recover and retry.
+const httpRequestTimeout = Duration(seconds: 30);
+
+/// Shorter timeout for fire-and-forget signaling calls like `cancel`,
+/// where waiting longer just delays local UI cleanup.
+const httpFireAndForgetTimeout = Duration(seconds: 5);
+
+/// Maximum gap between successive progress events during an active upload.
+/// This is an *inactivity* timeout, not a wall-clock one: large transfers
+/// can legitimately take many minutes, but a stalled socket should not.
+const uploadProgressInactivityTimeout = Duration(seconds: 60);
+
 class HttpClientCollection {
   final RsHttpClient v2;
 

--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -147,15 +147,17 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     do {
       invalidPin = false;
       try {
-        response = await client.prepareUpload(
-          protocol: target.getProtocolType(),
-          ip: target.ip!,
-          port: target.port,
-          payload: requestDto,
-          // TODO
-          publicKey: null,
-          pin: pin,
-        );
+        response = await client
+            .prepareUpload(
+              protocol: target.getProtocolType(),
+              ip: target.ip!,
+              port: target.port,
+              payload: requestDto,
+              // TODO
+              publicKey: null,
+              pin: pin,
+            )
+            .timeout(httpRequestTimeout);
       } on rust_http.RsHttpClientError_StatusCode catch (e) {
         switch (e.status) {
           case 401:
@@ -458,7 +460,16 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
         ),
       );
 
-      await for (final progress in taskResult.progress) {
+      // Use an inactivity timeout (resets on every event) rather than an
+      // overall one, since large transfers can legitimately take many minutes
+      // but a stalled socket should not.
+      final progressStream = taskResult.progress.timeout(
+        uploadProgressInactivityTimeout,
+        onTimeout: (sink) => sink.addError(
+          TimeoutException('Upload stalled', uploadProgressInactivityTimeout),
+        ),
+      );
+      await for (final progress in progressStream) {
         ref
             .notifier(progressProvider)
             .setProgress(
@@ -522,16 +533,20 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     // notify the receiver
     final target = sessionState.target;
     try {
+      // ignore: discarded_futures
       ref
           .read(httpProvider)
           .v2
-          // ignore: discarded_futures
           .cancel(
             protocol: target.getProtocolType(),
             ip: target.ip!,
             port: target.port,
             sessionId: remoteSessionId,
-          );
+          )
+          .timeout(httpFireAndForgetTimeout)
+          .catchError((Object e) {
+            _logger.warning('Error while canceling session', e);
+          });
     } catch (e) {
       _logger.warning('Error while canceling session', e);
     }


### PR DESCRIPTION
## Summary

Closes #3044. Adds timeouts to the HTTP operations in the file-send flow so a network anomaly (Wi-Fi drop, firewall, peer crash) no longer leaves the UI in an unrecoverable hung state.

Three timeout constants live in `app/lib/provider/http_provider.dart`:

| Constant | Duration | Where it applies |
|---|---|---|
| `httpRequestTimeout` | 30s | wall-clock timeout for one-shot RPCs |
| `httpFireAndForgetTimeout` | 5s | non-awaited signaling like `cancel` |
| `uploadProgressInactivityTimeout` | 60s | **inactivity** timeout on the upload progress stream — resets every event |

The inactivity timeout (rather than wall-clock) is deliberate: a 2 GB transfer can legitimately take many minutes, but a fully stalled socket should still surface an error to the user.

## Locations changed

The issue called out three problematic spots; all three are addressed:

- `send_provider.dart` — `client.prepareUpload(...)` now ends in `.timeout(httpRequestTimeout)`.
- `send_provider.dart` — the `await for (final progress in taskResult.progress)` stream is wrapped via `Stream.timeout(uploadProgressInactivityTimeout, onTimeout: ...)`. A timeout is delivered as a `TimeoutException` on the stream, so it flows through the existing `catch (e)` block and the file is correctly marked `failed`.
- `send_provider.dart` — the discarded `cancel(...)` future in `cancelSession` gets `.timeout(httpFireAndForgetTimeout)` plus a `.catchError` so a timeout no longer becomes an unhandled async exception.

## Scope notes

- **Rust client (`createClient`):** the issue also suggested adding a `timeout:` parameter to the Rust HTTP client. That requires regenerating `flutter_rust_bridge` bindings and is intentionally left for a follow-up so this PR stays a focused Dart-side fix.
- **Other call sites:** `RsHttpClient.register` is also called from a few favorite/address dialogs and from the discovery isolate (#3028 looks related). Intentionally out of scope here — happy to extend in a follow-up if reviewers prefer one combined change.
- **Orphaned upload task on stream timeout:** when the progress stream times out, the file is marked failed but the underlying isolate upload task is not explicitly canceled. Adding an `IsolateHttpUploadCancelAction` dispatch on timeout would be a natural follow-up.

## Tests

No unit test is added in this PR. `SendNotifier` is not currently covered by tests and there is no `RsHttpClient` mock in `app/test/mocks.dart` — adding the harness for a one-line `.timeout()` change felt out of proportion. Happy to add coverage if a reviewer points at the preferred shape (mockito spec on `RsHttpClient`, fake `Stream<double>` for the progress path).

## Reproduction (from the issue)

> 1. Initiate file transfer to a device
> 2. Simulate network failure: `iptables -A INPUT -p tcp --dport 53317 -j DROP`
> 3. Before: application hangs permanently with no cancel option.
> 4. After: `prepareUpload` rejects after 30s, or the progress stream raises a `TimeoutException` after 60s of no progress, the session moves to `finishedWithErrors`, and the UI is responsive again.

All three timeout values are conservative defaults — happy to retune if maintainers have data on real-world transfers.