### PR TITLE
fix: auto-fallback to next available port when default port is in use

### DIFF
--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -39,7 +39,8 @@
     "save": "Save",
     "unchanged": "Unchanged",
     "unknown": "Unknown",
-    "noItemInClipboard": "No items in Clipboard."
+    "noItemInClipboard": "No items in Clipboard.",
+    "portInUseFallback": "Port {port} is already in use. LocalSend started on port {port} instead."
   },
   "receiveTab": {
     "title": "Receive",

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -35,6 +35,7 @@ import 'package:localsend_app/provider/tv_provider.dart';
 import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/rust/api/logging.dart' as rust_logging;
 import 'package:localsend_app/rust/frb_generated.dart';
+import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/util/i18n.dart';
 import 'package:localsend_app/util/native/autostart_helper.dart';
 import 'package:localsend_app/util/native/cache_helper.dart';
@@ -212,7 +213,14 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
   }
 
   try {
-    await ref.notifier(serverProvider).startServerFromSettings();
+    final settings = ref.read(settingsProvider);
+    final serverState = await ref.notifier(serverProvider).startServerFromSettings();
+    // If the server bound to a different port than configured (e.g. because the
+    // default port was already occupied by Google Drive or another app), inform
+    // the user so they are not confused about the port shown in the Receive tab.
+    if (serverState != null && serverState.port != settings.port && context.mounted) {
+      context.showSnackBar(t.general.portInUseFallback(port: serverState.port));
+    }
   } catch (e) {
     if (context.mounted) {
       context.showSnackBar(e.toString());

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -195,6 +195,9 @@ class TranslationsGeneralEn {
 
   /// en: 'No items in Clipboard.'
   String get noItemInClipboard => 'No items in Clipboard.';
+
+  /// en: 'Port {port} is already in use. LocalSend started on port {port} instead.'
+  String portInUseFallback({required Object port}) => 'Port ${port} is already in use. LocalSend started on port ${port} instead.';
 }
 
 // Path: receiveTab

--- a/app/lib/provider/network/server/server_provider.dart
+++ b/app/lib/provider/network/server/server_provider.dart
@@ -18,6 +18,9 @@ import 'package:refena_flutter/refena_flutter.dart';
 
 final _logger = Logger('Server');
 
+/// Maximum number of consecutive ports to try when the configured port is in use.
+const _maxPortRetries = 10;
+
 /// This provider runs the server and provides the current server state.
 /// It is a singleton provider, so only one server can be running at a time.
 /// The server state is null if the server is not running.
@@ -85,6 +88,9 @@ class ServerService extends Notifier<ServerState?> {
   }
 
   /// Starts the server.
+  ///
+  /// If [port] is already in use, the server will automatically try up to
+  /// [_maxPortRetries] consecutive ports before giving up.
   Future<ServerState?> startServer({
     required String alias,
     required int port,
@@ -104,12 +110,58 @@ class ServerService extends Notifier<ServerState?> {
       port = defaultPort;
     }
 
+    _logger.info('Starting server...');
+
+    // Try to bind to the requested port, falling back to the next available
+    // port if the current one is already in use (e.g. occupied by Google Drive).
+    HttpServer? httpServer;
+    int actualPort = port;
+    for (int attempt = 0; attempt < _maxPortRetries; attempt++) {
+      try {
+        if (https) {
+          final securityContext = ref.read(securityProvider);
+          httpServer = await HttpServer.bindSecure(
+            '0.0.0.0',
+            actualPort,
+            SecurityContext()
+              ..usePrivateKeyBytes(securityContext.privateKey.codeUnits)
+              ..useCertificateChainBytes(securityContext.certificate.codeUnits),
+          );
+        } else {
+          httpServer = await HttpServer.bind('0.0.0.0', actualPort);
+        }
+        // Bind succeeded — exit the retry loop.
+        break;
+      } on SocketException catch (e) {
+        _logger.warning('Cannot bind to port $actualPort: $e');
+        if (attempt < _maxPortRetries - 1) {
+          actualPort++;
+          _logger.info('Retrying on port $actualPort...');
+        } else {
+          // All retries exhausted — propagate the original error.
+          rethrow;
+        }
+      }
+    }
+
+    if (https) {
+      _logger.info('Server started. (Port: $actualPort, HTTPS only)');
+    } else {
+      _logger.info('Server started. (Port: $actualPort, HTTP only)');
+    }
+
+    if (actualPort != port) {
+      _logger.warning('Configured port $port was in use. Bound to fallback port $actualPort.');
+    }
+
+    // Install routes AFTER we know the actual bound port so that all
+    // request-handler closures capture the correct port value.
     final router = SimpleServerRouteBuilder();
     final fingerprint = ref.read(securityProvider).certificateHash;
     _receiveController.installRoutes(
       router: router,
       alias: alias,
-      port: port,
+      port: actualPort,
       https: https,
       fingerprint: fingerprint,
       showToken: ref.read(settingsProvider).showToken,
@@ -120,33 +172,12 @@ class ServerService extends Notifier<ServerState?> {
       fingerprint: fingerprint,
     );
 
-    _logger.info('Starting server...');
-
-    final HttpServer httpServer;
-    if (https) {
-      final securityContext = ref.read(securityProvider);
-      httpServer = await HttpServer.bindSecure(
-        '0.0.0.0',
-        port,
-        SecurityContext()
-          ..usePrivateKeyBytes(securityContext.privateKey.codeUnits)
-          ..useCertificateChainBytes(securityContext.certificate.codeUnits),
-      );
-      _logger.info('Server started. (Port: $port, HTTPS only)');
-    } else {
-      httpServer = await HttpServer.bind(
-        '0.0.0.0',
-        port,
-      );
-      _logger.info('Server started. (Port: $port, HTTP only)');
-    }
-
-    final server = SimpleServer.start(server: httpServer, routes: router);
+    final server = SimpleServer.start(server: httpServer!, routes: router);
 
     final newServerState = ServerState(
       httpServer: server,
       alias: alias,
-      port: port,
+      port: actualPort,
       https: https,
       session: null,
       webSendState: null,


### PR DESCRIPTION
## Problem

When an application such as **Google Drive** is running on Windows and occupies the default port 53317, LocalSend fails on startup with:

> `failed to create server socket`

The app shows a raw `SocketException` and does not start. Users must manually close the conflicting app, change the LocalSend port in settings, or restart their computer.

**Reproduction:**
1. Turn on Google Drive (or any app that binds port 53317)
2. Launch LocalSend (first launch since boot)
3. LocalSend fails with "failed to create server socket"

## Solution

This PR adds **automatic port fallback**: if the configured port is unavailable, LocalSend silently tries the next consecutive port, up to 10 times (e.g. 53317 ? 53318 ? . ? 53326). The first port that successfully binds is used and the user is informed via a short snackbar.

## Changes

### `app/lib/provider/network/server/server_provider.dart`
- Added `const _maxPortRetries = 10`
- Wrapped `HttpServer.bind` / `HttpServer.bindSecure` in a retry loop that catches `SocketException` and increments the port
- Moved `installRoutes()` to **after** the successful bind so all request-handler closures capture the correct `actualPort` (not the originally-requested port)
- `ServerState.port` now reflects the actual bound port (visible in the Receive tab)

### `app/lib/config/init.dart`
- After `startServerFromSettings()` returns, compare `serverState.port` with `settings.port`
- If they differ, show a user-friendly snackbar: *"Port 53317 is already in use. LocalSend started on port 53318 instead."*
- Added import for `gen/strings.g.dart`

### `app/assets/i18n/en.json`
- Added `portInUseFallback` key under `general` for the snackbar message

### `app/lib/gen/strings_en.g.dart`
- Added `portInUseFallback({required Object port})` to `TranslationsGeneralEn`
- Note: this file is code-generated; running `dart run slang` from `app/` will cleanly regenerate it from `en.json`

## Behaviour After Fix

| Scenario | Before | After |
|---|---|---|
| Google Drive running (port 53317 occupied) | ? Crash with raw error | ? Starts on 53318, shows friendly snackbar |
| All 10 fallback ports also occupied | ? Crash | ? Same error (by design - all options exhausted) |
| Normal startup (port free) | ? Works | ? Works, no snackbar |

Fixes the issue reported by users on Windows where Google Drive occupies port 53317.