### PR TITLE
fix: automatically handle duplicate filenames to prevent overwrite on receive

### DIFF
--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -42,6 +42,7 @@ import 'package:localsend_app/util/native/directories.dart';
 import 'package:localsend_app/util/native/file_saver.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
+import 'package:localsend_app/util/file_path_helper.dart';
 import 'package:localsend_app/util/rust.dart';
 import 'package:localsend_app/util/simple_server.dart';
 import 'package:localsend_app/widget/dialogs/open_file_dialog.dart';
@@ -270,9 +271,18 @@ class ReceiveController {
     final Map<String, String>? selection;
     if (quickSave) {
       // accept all files
-      selection = {
-        for (final f in dto.files.values) f.id: f.fileName,
-      };
+      selection = {};
+      final savedNames = <String>{};
+      for (final f in dto.files.values) {
+        String name = f.fileName;
+        int counter = 1;
+        while (savedNames.contains(name)) {
+          counter++;
+          name = f.fileName.withCount(counter);
+        }
+        savedNames.add(name);
+        selection[f.id] = name;
+      }
     } else {
       if (checkPlatformHasTray() && (await windowManager.isMinimized() || !(await windowManager.isVisible()) || !(await windowManager.isFocused()))) {
         await showFromTray();

--- a/app/lib/provider/selection/selected_receiving_files_provider.dart
+++ b/app/lib/provider/selection/selected_receiving_files_provider.dart
@@ -22,9 +22,18 @@ class SelectedReceivingFilesNotifier extends Notifier<Map<String, String>> {
   }
 
   void setFiles(List<FileDto> files) {
-    state = {
-      for (final f in files) f.id: f.fileName, // by default, accept all files and take their original name
-    };
+    final savedNames = <String>{};
+    state = {};
+    for (final f in files) {
+      String name = f.fileName;
+      int counter = 1;
+      while (savedNames.contains(name)) {
+        counter++;
+        name = f.fileName.withCount(counter);
+      }
+      savedNames.add(name);
+      state[f.id] = name;
+    }
   }
 
   void unselect(String fileId) {


### PR DESCRIPTION
## Description

When receiving multiple files with the exact same name (e.g., exporting frames from a video app on iOS), the receiver attempts to save them concurrently. This results in a race condition during the file existence check, causing the files to overwrite each other rather than being properly renamed with a suffix.

This PR fixes the issue by deduplicating filenames at the session initialization phase. Incoming files are now automatically appended with  (1),  (2), etc., before the server attempts to save them, preventing concurrent overwrite conflicts and ensuring all files are saved safely.

## Related Issues
Fixes duplicate filename overwrite during bulk transfers.