### PR TITLE
fix(windows): prevent tray icon degradation by using native app_icon

### DIFF
--- a/app/lib/util/native/tray_helper.dart
+++ b/app/lib/util/native/tray_helper.dart
@@ -24,7 +24,7 @@ Future<void> initTray() async {
   }
   try {
     if (checkPlatform([TargetPlatform.windows])) {
-      await tm.trayManager.setIcon(Assets.img.logo);
+      await tm.trayManager.setIcon('app_icon.ico');
     } else if (checkPlatform([TargetPlatform.macOS])) {
       // The menu bar icon will created in AppDelegate.swift
       return;


### PR DESCRIPTION
## Description

Fixes the gradual graphical degradation of the Windows tray icon when the application remains running continuously for several days.

Currently, the 	ray_manager plugin on Windows extracts the provided Assets.img.logo asset into a temporary file (typically in %TEMP%) and uses that to render the tray icon. Over long sessions, if Windows Storage Sense or a temp cleaner deletes this temporary file, Windows falls back to a blurry, degraded cached icon or fails to properly redraw the icon during DPI/Explorer refreshes.

This PR changes the tray icon initialization to use the 'app_icon.ico' string on Windows. This instructs 	ray_manager to hook directly into the IDI_APP_ICON resource built into the native .exe. By doing this, it completely bypasses the temporary file mechanism, ensuring the system tray icon remains perfectly crisp indefinitely.

## Related Issues
Fixes #2317