### PR TITLE
fix: restore remoteSessionId assignment in send flow

### DIFF
--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -242,11 +242,11 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     } else {
       try {
         fileMap = response.response!.files;
-        final sessionId = response.response!.sessionId;
+        final remoteSessionId = response.response!.sessionId;
         state = state.updateSession(
           sessionId: sessionId,
           state: (s) => s?.copyWith(
-            remoteSessionId: sessionId,
+            remoteSessionId: remoteSessionId,
           ),
         );
       } catch (e) {


### PR DESCRIPTION
## Problem
After 90de693a ("feat: integrate rust http client"), every file send fails with HTTP 400 "Missing parameters" from the receiver on `POST /api/localsend/v2/upload`.

## Root cause
In `app/lib/provider/network/send_provider.dart`, the rewrite introduced a variable shadow:

    final sessionId = response.response!.sessionId; // shadows outer sessionId
    state = state.updateSession(
      sessionId: sessionId,          // remote id used as lookup key
      state: (s) => s?.copyWith(
        remoteSessionId: sessionId,  // never written to the real entry
      ),
    );

`updateSession` looks up by the (remote) id, finds nothing in the map, and returns it unchanged. `remoteSessionId` stays `null`. Downstream, `_uploadFile` reads that null and passes it to the Rust upload, which builds `?sessionId=&fileId=…&token=…`. The receiver checks `sessionId == null` and returns 400.

## Fix
Rename the inner variable so the outer `sessionId` is no longer shadowed. This restores the pre-90de693a behavior.

## Reproduction
1. Build `main` and run on two devices.
2. Send any file from device A to device B.
3. Observe `[RhttpStatusCodeException] Status code: 400. URL: https://.../api/localsend/v2/upload` on the sender, and `Missing parameters: fileId=…, token=…, sessionId=null` on the receiver.