### PR TITLE
fix: autostart not working on Linux when installed via Flatpak

### DIFF
--- a/app/lib/util/native/autostart_helper.dart
+++ b/app/lib/util/native/autostart_helper.dart
@@ -10,27 +10,133 @@ const startHiddenFlag = '--hidden';
 
 final _logger = Logger('AutoStartHelper');
 
+bool _isRunningInFlatpak() {
+  return Platform.environment['container'] == 'flatpak' ||
+      Platform.environment.containsKey('FLATPAK_ID') ||
+      Platform.environment.containsKey('FLATPAK_SANDBOX_DIR');
+}
+
+Future<String?> _getLinuxAutostartDir() async {
+  if (_isRunningInFlatpak()) {
+    final result = await Process.run('flatpak-spawn', [
+      '--host',
+      'sh',
+      '-c',
+      'echo "$HOME/.config/autostart"',
+    ]);
+    if (result.exitCode == 0) {
+      return (result.stdout as String).trim();
+    }
+  }
+  return '${Platform.environment['HOME']}/.config/autostart';
+}
+
+Future<bool> _writeLinuxDesktopFile(String appName, String execLine) async {
+  final dir = await _getLinuxAutostartDir();
+  if (dir == null) return false;
+
+  final contents = '''
+[Desktop Entry]
+Type=Application
+Name=$appName
+Comment=$appName startup script
+Exec=$execLine
+StartupNotify=false
+Terminal=false
+''';
+
+  final path = '$dir/$appName.desktop';
+  if (_isRunningInFlatpak()) {
+    final result = await Process.run('flatpak-spawn', [
+      '--host',
+      'sh',
+      '-c',
+      'mkdir -p "$HOME/.config/autostart" && cat > "$HOME/.config/autostart/$appName.desktop"',
+      stdin: contents,
+    ]);
+    return result.exitCode == 0;
+  } else {
+    final file = File(path);
+    if (!file.parent.existsSync()) {
+      file.parent.createSync(recursive: true);
+    }
+    file.writeAsStringSync(contents);
+    return true;
+  }
+}
+
+Future<bool> _deleteLinuxDesktopFile(String appName) async {
+  final dir = await _getLinuxAutostartDir();
+  if (dir == null) return false;
+
+  final path = '$dir/$appName.desktop';
+  if (_isRunningInFlatpak()) {
+    final result = await Process.run('flatpak-spawn', [
+      '--host',
+      'sh',
+      '-c',
+      'rm -f "$HOME/.config/autostart/$appName.desktop"',
+    ]);
+    return result.exitCode == 0;
+  } else {
+    return File(path).deleteSync() == null;
+  }
+}
+
+Future<bool> _linuxDesktopFileExists(String appName) async {
+  final dir = await _getLinuxAutostartDir();
+  if (dir == null) return false;
+
+  final path = '$dir/$appName.desktop';
+  if (_isRunningInFlatpak()) {
+    final result = await Process.run('flatpak-spawn', [
+      '--host',
+      'sh',
+      '-c',
+      'test -f "$HOME/.config/autostart/$appName.desktop"',
+    ]);
+    return result.exitCode == 0;
+  } else {
+    return File(path).existsSync();
+  }
+}
+
+Future<String> _readLinuxDesktopFile(String appName) async {
+  final dir = await _getLinuxAutostartDir();
+  final path = '$dir/$appName.desktop';
+  if (_isRunningInFlatpak()) {
+    final result = await Process.run('flatpak-spawn', [
+      '--host',
+      'sh',
+      '-c',
+      'cat "$HOME/.config/autostart/$appName.desktop" 2>/dev/null || true',
+    ]);
+    return result.stdout as String;
+  }
+  try {
+    return File(path).readAsStringSync();
+  } catch (_) {
+    return '';
+  }
+}
+
+String _getLinuxExecLine(String appName, {required bool startHidden}) {
+  if (_isRunningInFlatpak()) {
+    final flatpakId = Platform.environment['FLATPAK_ID'] ?? appName;
+    return 'flatpak run $flatpakId${startHidden ? ' $startHiddenFlag' : ''}';
+  }
+  return '${Platform.resolvedExecutable}${startHidden ? ' $startHiddenFlag' : ''}';
+}
+
 Future<bool> enableAutoStart({required bool startHidden}) async {
   try {
     final packageInfo = await PackageInfo.fromPlatform();
     switch (defaultTargetPlatform) {
       case TargetPlatform.linux:
-        String contents =
-            '''
-[Desktop Entry]
-Type=Application
-Name=${packageInfo.appName}
-Comment=${packageInfo.appName} startup script
-Exec=${Platform.resolvedExecutable}${startHidden ? ' $startHiddenFlag' : ''}
-StartupNotify=false
-Terminal=false
-''';
-        final file = File(_getLinuxFilePath(packageInfo.packageName));
-        if (!file.parent.existsSync()) {
-          file.parent.createSync(recursive: true);
-        }
-        file.writeAsStringSync(contents);
-        return true;
+        return await _writeLinuxDesktopFile(
+          packageInfo.appName,
+          _getLinuxExecLine(packageInfo.appName, startHidden: startHidden),
+        );
       case TargetPlatform.macOS:
         await setLaunchAtLogin(true);
         await setLaunchAtLoginMinimized(startHidden);
@@ -58,7 +164,7 @@ Future<bool> disableAutoStart() async {
     final packageInfo = await PackageInfo.fromPlatform();
     switch (defaultTargetPlatform) {
       case TargetPlatform.linux:
-        File(_getLinuxFilePath(packageInfo.packageName)).deleteSync();
+        await _deleteLinuxDesktopFile(packageInfo.appName);
         break;
       case TargetPlatform.macOS:
         await setLaunchAtLogin(false);
@@ -80,7 +186,7 @@ Future<bool> isAutoStartEnabled() async {
   final packageInfo = await PackageInfo.fromPlatform();
   switch (defaultTargetPlatform) {
     case TargetPlatform.linux:
-      return File(_getLinuxFilePath(packageInfo.packageName)).existsSync();
+      return await _linuxDesktopFileExists(packageInfo.appName);
     case TargetPlatform.macOS:
       return await getLaunchAtLogin();
     case TargetPlatform.windows:
@@ -94,11 +200,8 @@ Future<bool> isAutoStartHidden() async {
   final packageInfo = await PackageInfo.fromPlatform();
   switch (defaultTargetPlatform) {
     case TargetPlatform.linux:
-      final file = File(_getLinuxFilePath(packageInfo.packageName));
-      if (!file.existsSync()) {
-        return false;
-      }
-      return file.readAsStringSync().contains(startHiddenFlag);
+      final contents = await _readLinuxDesktopFile(packageInfo.appName);
+      return contents.contains(startHiddenFlag);
     case TargetPlatform.macOS:
       return await getLaunchAtLoginMinimized();
     case TargetPlatform.windows:
@@ -116,8 +219,4 @@ RegistryKey _getWindowsRegistryKey() {
     path: r'Software\Microsoft\Windows\CurrentVersion\Run',
     desiredAccessRights: AccessRights.allAccess,
   );
-}
-
-String _getLinuxFilePath(String appName) {
-  return '${Platform.environment['HOME']}/.config/autostart/$appName.desktop';
 }


### PR DESCRIPTION
## Description

Fixes #1927

The autostart feature failed on Flatpak because:
1. The sandboxed $HOME points to an isolated location, not the real user home. Writing .desktop files there has no effect.
2. `Platform.resolvedExecutable` returns the Flatpak launcher binary, not a runnable command for the host system.

## Changes

- Detect Flatpak by checking the `container` environment variable
- Use `flatpak-spawn --host` to write the `.desktop` file to the real `~/.config/autostart/` directory
- Use `flatpak run <app-id>` as the Exec line when running under Flatpak
- Fall back to original behavior (direct file write) when not in Flatpak