### PR TITLE
fix: runtime crash on Windows Server due to missing wlanapi.dll

### DIFF
--- a/app/lib/provider/local_ip_provider.dart
+++ b/app/lib/provider/local_ip_provider.dart
@@ -83,12 +83,16 @@ Future<List<String>> _getIp({
   required List<String>? whitelist,
   required List<String>? blacklist,
 }) async {
-  final info = plugin.NetworkInfo();
   String? ip;
-  try {
-    ip = await info.getWifiIP();
-  } catch (e) {
-    _logger.warning('Failed to get wifi IP', e);
+  if (!checkPlatform([TargetPlatform.windows])) {
+    // network_info_plus depends on wlanapi.dll on Windows, which may not be
+    // available on Windows Server. Use native interfaces only on Windows.
+    final info = plugin.NetworkInfo();
+    try {
+      ip = await info.getWifiIP();
+    } catch (e) {
+      _logger.warning('Failed to get wifi IP', e);
+    }
   }
 
   final nativeResult =


### PR DESCRIPTION
## Description

Fixes #436

`network_info_plus` depends on `wlanapi.dll` on Windows, which is not available on Windows Server by default. This caused the app to fail at startup in Windows Server environments.

## Changes

- Skip the `network_info_plus` plugin call entirely on Windows
- Rely on the native `getNetworkInterfaces()` from the common package, which provides equivalent IP address information without the `wlanapi.dll` dependency
- The connectivity listener was already skipped on Windows (existing code), this extends the same treatment to the IP fetch