### PR TITLE
perf: reduce window dragging lag on GNOME by adding RepaintBoundary layers

### DIFF
--- a/app/lib/pages/home_page.dart
+++ b/app/lib/pages/home_page.dart
@@ -151,33 +151,35 @@ class _HomePageState extends State<HomePage> with Refena {
                     ],
                   ),
                 Expanded(
-                  child: Stack(
-                    children: [
-                      PageView(
-                        controller: vm.controller,
-                        physics: const NeverScrollableScrollPhysics(),
-                        children: const [
-                          SafeArea(child: ReceiveTab()),
-                          SafeArea(child: SendTab()),
-                          SettingsTab(),
-                        ],
-                      ),
-                      if (_dragAndDropIndicator)
-                        Container(
-                          width: double.infinity,
-                          decoration: BoxDecoration(
-                            color: Theme.of(context).scaffoldBackgroundColor,
-                          ),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              const Icon(Icons.file_download, size: 128),
-                              const SizedBox(height: 30),
-                              Text(t.sendTab.placeItems, style: Theme.of(context).textTheme.titleLarge),
-                            ],
-                          ),
+                  child: RepaintBoundary(
+                    child: Stack(
+                      children: [
+                        PageView(
+                          controller: vm.controller,
+                          physics: const NeverScrollableScrollPhysics(),
+                          children: const [
+                            RepaintBoundary(child: SafeArea(child: ReceiveTab())),
+                            RepaintBoundary(child: SafeArea(child: SendTab())),
+                            RepaintBoundary(child: SettingsTab()),
+                          ],
                         ),
-                    ],
+                        if (_dragAndDropIndicator)
+                          Container(
+                            width: double.infinity,
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).scaffoldBackgroundColor,
+                            ),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const Icon(Icons.file_download, size: 128),
+                                const SizedBox(height: 30),
+                                Text(t.sendTab.placeItems, style: Theme.of(context).textTheme.titleLarge),
+                              ],
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
               ],


### PR DESCRIPTION
Fixes #895

Window dragging and UI animations on GNOME caused visible lag because the entire widget tree was repainted on every frame.

Wrap the main content area and each tab with RepaintBoundary widgets to isolate repaint boundaries and prevent unnecessary repaints during window dragging.