### PR TITLE
perf: improve transfer speeds and server error handling

### DIFF
--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -458,14 +458,21 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
         ),
       );
 
+      double lastSentProgress = -1;
+      int lastProgressTime = 0;
       await for (final progress in taskResult.progress) {
-        ref
-            .notifier(progressProvider)
-            .setProgress(
-              sessionId: sessionId,
-              fileId: file.file.id,
-              progress: progress,
-            );
+        final now = DateTime.now().millisecondsSinceEpoch;
+        if (progress - lastSentProgress >= 0.01 || now - lastProgressTime >= 200) {
+          lastSentProgress = progress;
+          lastProgressTime = now;
+          ref
+              .notifier(progressProvider)
+              .setProgress(
+                sessionId: sessionId,
+                fileId: file.file.id,
+                progress: progress,
+              );
+        }
       }
 
       // set progress to 100% when successfully finished

--- a/app/lib/provider/network/server/server_provider.dart
+++ b/app/lib/provider/network/server/server_provider.dart
@@ -123,22 +123,36 @@ class ServerService extends Notifier<ServerState?> {
     _logger.info('Starting server...');
 
     final HttpServer httpServer;
-    if (https) {
-      final securityContext = ref.read(securityProvider);
-      httpServer = await HttpServer.bindSecure(
-        '0.0.0.0',
-        port,
-        SecurityContext()
-          ..usePrivateKeyBytes(securityContext.privateKey.codeUnits)
-          ..useCertificateChainBytes(securityContext.certificate.codeUnits),
-      );
-      _logger.info('Server started. (Port: $port, HTTPS only)');
-    } else {
-      httpServer = await HttpServer.bind(
-        '0.0.0.0',
-        port,
-      );
-      _logger.info('Server started. (Port: $port, HTTP only)');
+    try {
+      if (https) {
+        final securityContext = ref.read(securityProvider);
+        httpServer = await HttpServer.bindSecure(
+          '0.0.0.0',
+          port,
+          SecurityContext()
+            ..usePrivateKeyBytes(securityContext.privateKey.codeUnits)
+            ..useCertificateChainBytes(securityContext.certificate.codeUnits),
+        );
+        _logger.info('Server started. (Port: $port, HTTPS only)');
+      } else {
+        httpServer = await HttpServer.bind(
+          '0.0.0.0',
+          port,
+        );
+        _logger.info('Server started. (Port: $port, HTTP only)');
+      }
+    } on SocketException catch (e) {
+      _logger.severe('Failed to bind to port $port: $e');
+      if (e.osError?.message?.toLowerCase().contains('permission') == true ||
+          e.osError?.errorCode == 10013) {
+        // Common on Windows when Hyper-V or another service reserves the port
+        _logger.severe('Port $port is blocked. Try a different port in Settings > Network.');
+      } else if (e.osError?.errorCode == 10048 || e.osError?.errorCode == 98) {
+        // WSAEADDRINUSE (10048) on Windows, EADDRINUSE (98) on Linux
+        _logger.severe('Port $port is already in use by another application.');
+      }
+      state = null;
+      return null;
     }
 
     final server = SimpleServer.start(server: httpServer, routes: router);

--- a/app/rust/src/api/stream.rs
+++ b/app/rust/src/api/stream.rs
@@ -9,9 +9,7 @@ pub struct Dart2RustStreamReceiver {
 }
 
 pub fn create_stream() -> (Dart2RustStreamSink, Dart2RustStreamReceiver) {
-    // We don't need to have a buffer because we already buffer on Dart side.
-    // However, a buffer of 1 seems to improve performance.
-    let (sender, receiver) = mpsc::channel(1);
+    let (sender, receiver) = mpsc::channel(64);
     (
         Dart2RustStreamSink { sender },
         Dart2RustStreamReceiver { receiver },

--- a/common/lib/src/isolate/child/upload_isolate.dart
+++ b/common/lib/src/isolate/child/upload_isolate.dart
@@ -8,7 +8,6 @@ import 'package:common/src/isolate/dto/isolate_task.dart';
 import 'package:common/src/isolate/dto/isolate_task_result.dart';
 import 'package:common/src/isolate/dto/send_to_isolate_data.dart';
 import 'package:common/src/task/upload/http_upload.dart';
-import 'package:common/util/stream.dart';
 import 'package:meta/meta.dart';
 import 'package:refena/refena.dart';
 
@@ -96,20 +95,18 @@ Future<void> setupHttpUploadIsolate(
           return;
       }
 
-      final Stream<List<int>>? fileStream = uploadTask.filePath != null
+      final fileStream = uploadTask.filePath != null
           ? _uriContentStreamResolver != null && uploadTask.filePath!.startsWith('content://')
               ? _uriContentStreamResolver!.resolve(Uri.parse(uploadTask.filePath!))
               : File(uploadTask.filePath!).openRead()
           : null;
-
-      final (streamController, subscription) = fileStream?.digested() ?? (null, null);
 
       try {
         final cancelToken = CustomCancelToken();
         ref.read(_cancelTokenProvider).putIfAbsent(task.id, () => cancelToken);
 
         await ref.read(httpUploadProvider).upload(
-              stream: streamController?.stream ?? Stream.fromIterable([uploadTask.fileBytes!]),
+              stream: fileStream ?? Stream.fromIterable([uploadTask.fileBytes!]),
               contentLength: uploadTask.fileSize,
               contentType: uploadTask.mime,
               target: uploadTask.device,
@@ -133,14 +130,6 @@ Future<void> setupHttpUploadIsolate(
           id: task.id,
           error: e.toString(),
         ));
-      } finally {
-        // Close the stream if it is still open
-        // ignore: unawaited_futures
-        streamController?.close();
-
-        // Cancel the subscription if it is still open
-        // ignore: unawaited_futures
-        subscription?.cancel();
       }
     },
   );

--- a/common/lib/src/isolate/parent/parent_isolate_provider.dart
+++ b/common/lib/src/isolate/parent/parent_isolate_provider.dart
@@ -14,7 +14,7 @@ import 'package:refena/refena.dart';
 
 part 'parent_isolate_provider.mapper.dart';
 
-const _uploadIsolateCount = 2;
+const _uploadIsolateCount = 4;
 
 /// Holds the state of the parent isolate that is visible in the main Flutter isolate.
 /// The [ParentIsolateState.syncState] is synchronized with all child isolates.


### PR DESCRIPTION
## Performance Improvements

### 1. Remove digested() stream wrapper overhead
Eliminated the unnecessary  relay StreamController/Subscription pair from the upload hot path. The wrapper added memory and CPU overhead without providing any value.

### 2. Increase Rust mpsc channel buffer (1 → 64)
The Dart-to-Rust stream bridge used , causing tight producer-consumer coupling. Each chunk had to be fully processed by reqwest before the next chunk could be sent. Increasing to 64 decouples the pipeline and reduces backpressure stalls.

### 3. Throttle sender-side progress notifications
Previously every ~64KB chunk triggered . For a 1GB file that's ~16,000 UI rebuilds. Now throttled to a minimum 1% progress delta or 200ms interval.

### 4. Increase upload concurrency (2 → 4)
Better parallel throughput on multi-core devices.

## Error Handling

### 5. Catch port binding errors gracefully
Fixes #125, #2746 —  could throw  when port 53317 is in use (common on Windows due to Hyper-V). Now caught with helpful log messages suggesting the user change ports in Settings.

## Files changed
-  — removed digested() wrapper
-  — mpsc channel 1→64
-  — progress throttling
-  — concurrency 2→4
-  — SocketException handling