### PR TITLE
fix: shortcuts not working on linux when numlock is on

### DIFF
--- a/app/lib/widget/watcher/shortcut_watcher.dart
+++ b/app/lib/widget/watcher/shortcut_watcher.dart
@@ -20,21 +20,21 @@ class ShortcutWatcher extends StatelessWidget {
     return Shortcuts(
       shortcuts: {
         // The select button on AndroidTV needs this to work
-        LogicalKeySet(LogicalKeyboardKey.select): const ActivateIntent(),
+        const SingleActivator(LogicalKeyboardKey.select): const ActivateIntent(),
 
         // Add Control+Q binding for Linux
         // https://github.com/localsend/localsend/issues/194
-        if (checkPlatform([TargetPlatform.linux])) LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyQ): _ExitAppIntent(),
+        if (checkPlatform([TargetPlatform.linux])) const SingleActivator(LogicalKeyboardKey.keyQ, control: true): _ExitAppIntent(),
         // Add Command+W to close the window for macOS
-        if (checkPlatform([TargetPlatform.macOS])) LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyW): _CloseWindowIntent(),
+        if (checkPlatform([TargetPlatform.macOS])) const SingleActivator(LogicalKeyboardKey.keyW, meta: true): _CloseWindowIntent(),
         // Add Control+, to open settings for macOS
-        if (checkPlatform([TargetPlatform.macOS])) LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.comma): _OpenSettingsIntent(),
+        if (checkPlatform([TargetPlatform.macOS])) const SingleActivator(LogicalKeyboardKey.comma, meta: true): _OpenSettingsIntent(),
 
-        LogicalKeySet(LogicalKeyboardKey.escape): _PopPageIntent(),
+        const SingleActivator(LogicalKeyboardKey.escape): _PopPageIntent(),
 
         // Control+V and Command+V
-        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV): _PasteIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV): _PasteIntent(),
+        const SingleActivator(LogicalKeyboardKey.keyV, control: true): _PasteIntent(),
+        const SingleActivator(LogicalKeyboardKey.keyV, meta: true): _PasteIntent(),
       },
       child: Actions(
         actions: {


### PR DESCRIPTION
On Linux the keyboard shortcuts (`Ctrl+Q`, `Escape`, `Ctrl+V`) do nothing when `NumLock` is on. The cause is that `LogicalKeySet` only matches when "all keys are pressed, and no others", but on Linux/GTK a locked `NumLock` (or `CapsLock`) stays in `logicalKeysPressed`, so the pressed set `{NumLock, Control, KeyQ}` never equals the required `{Control, KeyQ}` and the shortcut never fires. This PR switches `ShortcutWatcher` from `LogicalKeySet` to `SingleActivator`, which the Flutter docs recommend and which allows extra non-modifier keys and ignores lock states by default. There is no behavior change on other platforms: the `Ctrl+Q` binding is Linux-only, and `SingleActivator` matches a superset of `LogicalKeySet`.

Proofs: the `LogicalKeySet` docs say "It is not recommended to use LogicalKeySet for a common shortcut such as Delete or Ctrl+C, prefer SingleActivator when possible" and that it activates "when all keys are pressed, and no others" (https://api.flutter.dev/flutter/widgets/LogicalKeySet-class.html), while the `SingleActivator` docs say it allows "additional non-modifier keys being pressed in order to activate the shortcut" and "resembles the typical behavior of most operating systems" (https://api.flutter.dev/flutter/widgets/SingleActivator-class.html). This is a known Flutter-on-Linux issue (flutter/flutter#156806), and Flutter migrated its own code the same way (flutter/flutter#80756).
