### PR TITLE
feat: Add cross-subnet discovery

### DIFF
--- a/app/lib/model/persistence/known_peer.dart
+++ b/app/lib/model/persistence/known_peer.dart
@@ -1,0 +1,182 @@
+import 'package:collection/collection.dart';
+import 'package:common/constants.dart';
+import 'package:common/model/device.dart';
+
+class KnownPeerEndpoint {
+  final String ip;
+  final int port;
+  final bool https;
+  final int lastSeen;
+  final int failures;
+
+  const KnownPeerEndpoint({
+    required this.ip,
+    required this.port,
+    required this.https,
+    required this.lastSeen,
+    this.failures = 0,
+  });
+
+  factory KnownPeerEndpoint.fromJson(Map<String, dynamic> json) {
+    return KnownPeerEndpoint(
+      ip: json['ip'] as String,
+      port: json['port'] as int,
+      https: json['https'] as bool? ?? true,
+      lastSeen: json['lastSeen'] as int? ?? 0,
+      failures: json['failures'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'ip': ip,
+      'port': port,
+      'https': https,
+      'lastSeen': lastSeen,
+      'failures': failures,
+    };
+  }
+
+  String get key => '$ip:$port:${https ? 'https' : 'http'}';
+
+  KnownPeerEndpoint copyWith({
+    String? ip,
+    int? port,
+    bool? https,
+    int? lastSeen,
+    int? failures,
+  }) {
+    return KnownPeerEndpoint(
+      ip: ip ?? this.ip,
+      port: port ?? this.port,
+      https: https ?? this.https,
+      lastSeen: lastSeen ?? this.lastSeen,
+      failures: failures ?? this.failures,
+    );
+  }
+}
+
+class KnownPeer {
+  final String fingerprint;
+  final String alias;
+  final String? deviceModel;
+  final DeviceType deviceType;
+  final bool download;
+  final List<KnownPeerEndpoint> endpoints;
+  final int lastSeen;
+
+  const KnownPeer({
+    required this.fingerprint,
+    required this.alias,
+    required this.deviceModel,
+    required this.deviceType,
+    required this.download,
+    required this.endpoints,
+    required this.lastSeen,
+  });
+
+  factory KnownPeer.fromJson(Map<String, dynamic> json) {
+    return KnownPeer(
+      fingerprint: json['fingerprint'] as String,
+      alias: json['alias'] as String,
+      deviceModel: json['deviceModel'] as String?,
+      deviceType:
+          DeviceType.values.firstWhereOrNull(
+            (type) => type.name == json['deviceType'],
+          ) ??
+          DeviceType.desktop,
+      download: json['download'] as bool? ?? false,
+      endpoints: ((json['endpoints'] as List?) ?? [])
+          .whereType<Map>()
+          .map(
+            (entry) =>
+                KnownPeerEndpoint.fromJson(entry.cast<String, dynamic>()),
+          )
+          .toList(),
+      lastSeen: json['lastSeen'] as int? ?? 0,
+    );
+  }
+
+  factory KnownPeer.fromDevice(Device device, int now) {
+    return KnownPeer(
+      fingerprint: device.fingerprint,
+      alias: device.alias,
+      deviceModel: device.deviceModel,
+      deviceType: device.deviceType,
+      download: device.download,
+      endpoints: [
+        if (device.ip != null)
+          KnownPeerEndpoint(
+            ip: device.ip!,
+            port: device.port,
+            https: device.https,
+            lastSeen: now,
+          ),
+      ],
+      lastSeen: now,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'fingerprint': fingerprint,
+      'alias': alias,
+      'deviceModel': deviceModel,
+      'deviceType': deviceType.name,
+      'download': download,
+      'endpoints': endpoints.map((endpoint) => endpoint.toJson()).toList(),
+      'lastSeen': lastSeen,
+    };
+  }
+
+  KnownPeer mergeDevice(Device device, int now) {
+    final updatedEndpoint = device.ip == null
+        ? null
+        : KnownPeerEndpoint(
+            ip: device.ip!,
+            port: device.port,
+            https: device.https,
+            lastSeen: now,
+          );
+    final endpointByKey = {
+      for (final endpoint in endpoints) endpoint.key: endpoint,
+      if (updatedEndpoint != null) updatedEndpoint.key: updatedEndpoint,
+    };
+    final sortedEndpoints = endpointByKey.values
+        .sorted((a, b) => b.lastSeen.compareTo(a.lastSeen))
+        .take(maxKnownPeerEndpoints)
+        .toList();
+
+    return KnownPeer(
+      fingerprint: fingerprint,
+      alias: device.alias,
+      deviceModel: device.deviceModel,
+      deviceType: device.deviceType,
+      download: device.download,
+      endpoints: sortedEndpoints,
+      lastSeen: now,
+    );
+  }
+
+  KnownPeer markFailures(Set<String> endpointKeys) {
+    final updatedEndpoints = endpoints
+        .map((endpoint) {
+          if (!endpointKeys.contains(endpoint.key)) {
+            return endpoint;
+          }
+          return endpoint.copyWith(failures: endpoint.failures + 1);
+        })
+        .where((endpoint) => endpoint.failures < 3)
+        .toList();
+
+    return KnownPeer(
+      fingerprint: fingerprint,
+      alias: alias,
+      deviceModel: deviceModel,
+      deviceType: deviceType,
+      download: download,
+      endpoints: updatedEndpoints,
+      lastSeen: lastSeen,
+    );
+  }
+}

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -34,6 +34,9 @@ class SettingsState with SettingsStateMappable {
   final String? deviceModel;
   final bool shareViaLinkAutoAccept;
   final int discoveryTimeout;
+  final bool crossSubnetScan;
+  final int crossSubnetScanDepth;
+  final List<String> customSubnetScanRanges;
   final bool advancedSettings;
 
   const SettingsState({
@@ -62,6 +65,9 @@ class SettingsState with SettingsStateMappable {
     required this.deviceModel,
     required this.shareViaLinkAutoAccept,
     required this.discoveryTimeout,
+    required this.crossSubnetScan,
+    required this.crossSubnetScanDepth,
+    required this.customSubnetScanRanges,
     required this.advancedSettings,
   });
 }

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -142,6 +142,20 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     'discoveryTimeout',
     _$discoveryTimeout,
   );
+  static bool _$crossSubnetScan(SettingsState v) => v.crossSubnetScan;
+  static const Field<SettingsState, bool> _f$crossSubnetScan = Field(
+    'crossSubnetScan',
+    _$crossSubnetScan,
+  );
+  static int _$crossSubnetScanDepth(SettingsState v) => v.crossSubnetScanDepth;
+  static const Field<SettingsState, int> _f$crossSubnetScanDepth = Field(
+    'crossSubnetScanDepth',
+    _$crossSubnetScanDepth,
+  );
+  static List<String> _$customSubnetScanRanges(SettingsState v) =>
+      v.customSubnetScanRanges;
+  static const Field<SettingsState, List<String>> _f$customSubnetScanRanges =
+      Field('customSubnetScanRanges', _$customSubnetScanRanges);
   static bool _$advancedSettings(SettingsState v) => v.advancedSettings;
   static const Field<SettingsState, bool> _f$advancedSettings = Field(
     'advancedSettings',
@@ -175,6 +189,9 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #deviceModel: _f$deviceModel,
     #shareViaLinkAutoAccept: _f$shareViaLinkAutoAccept,
     #discoveryTimeout: _f$discoveryTimeout,
+    #crossSubnetScan: _f$crossSubnetScan,
+    #crossSubnetScanDepth: _f$crossSubnetScanDepth,
+    #customSubnetScanRanges: _f$customSubnetScanRanges,
     #advancedSettings: _f$advancedSettings,
   };
 
@@ -205,6 +222,9 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
       deviceModel: data.dec(_f$deviceModel),
       shareViaLinkAutoAccept: data.dec(_f$shareViaLinkAutoAccept),
       discoveryTimeout: data.dec(_f$discoveryTimeout),
+      crossSubnetScan: data.dec(_f$crossSubnetScan),
+      crossSubnetScanDepth: data.dec(_f$crossSubnetScanDepth),
+      customSubnetScanRanges: data.dec(_f$customSubnetScanRanges),
       advancedSettings: data.dec(_f$advancedSettings),
     );
   }
@@ -275,6 +295,8 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out>
   get networkWhitelist;
   ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>?
   get networkBlacklist;
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>
+  get customSubnetScanRanges;
   $R call({
     String? showToken,
     String? alias,
@@ -301,6 +323,9 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out>
     String? deviceModel,
     bool? shareViaLinkAutoAccept,
     int? discoveryTimeout,
+    bool? crossSubnetScan,
+    int? crossSubnetScanDepth,
+    List<String>? customSubnetScanRanges,
     bool? advancedSettings,
   });
   SettingsStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
@@ -333,6 +358,13 @@ class _SettingsStateCopyWithImpl<$R, $Out>
         )
       : null;
   @override
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>
+  get customSubnetScanRanges => ListCopyWith(
+    $value.customSubnetScanRanges,
+    (v, t) => ObjectCopyWith(v, $identity, t),
+    (v) => call(customSubnetScanRanges: v),
+  );
+  @override
   $R call({
     String? showToken,
     String? alias,
@@ -359,6 +391,9 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     Object? deviceModel = $none,
     bool? shareViaLinkAutoAccept,
     int? discoveryTimeout,
+    bool? crossSubnetScan,
+    int? crossSubnetScanDepth,
+    List<String>? customSubnetScanRanges,
     bool? advancedSettings,
   }) => $apply(
     FieldCopyWithData({
@@ -390,6 +425,11 @@ class _SettingsStateCopyWithImpl<$R, $Out>
       if (shareViaLinkAutoAccept != null)
         #shareViaLinkAutoAccept: shareViaLinkAutoAccept,
       if (discoveryTimeout != null) #discoveryTimeout: discoveryTimeout,
+      if (crossSubnetScan != null) #crossSubnetScan: crossSubnetScan,
+      if (crossSubnetScanDepth != null)
+        #crossSubnetScanDepth: crossSubnetScanDepth,
+      if (customSubnetScanRanges != null)
+        #customSubnetScanRanges: customSubnetScanRanges,
       if (advancedSettings != null) #advancedSettings: advancedSettings,
     }),
   );
@@ -429,6 +469,15 @@ class _SettingsStateCopyWithImpl<$R, $Out>
       or: $value.shareViaLinkAutoAccept,
     ),
     discoveryTimeout: data.get(#discoveryTimeout, or: $value.discoveryTimeout),
+    crossSubnetScan: data.get(#crossSubnetScan, or: $value.crossSubnetScan),
+    crossSubnetScanDepth: data.get(
+      #crossSubnetScanDepth,
+      or: $value.crossSubnetScanDepth,
+    ),
+    customSubnetScanRanges: data.get(
+      #customSubnetScanRanges,
+      or: $value.customSubnetScanRanges,
+    ),
     advancedSettings: data.get(#advancedSettings, or: $value.advancedSettings),
   );
 
@@ -437,4 +486,3 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     Then<$Out2, $R2> t,
   ) => _SettingsStateCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
-

--- a/app/lib/provider/known_peers_provider.dart
+++ b/app/lib/provider/known_peers_provider.dart
@@ -1,0 +1,98 @@
+import 'package:common/model/device.dart';
+import 'package:localsend_app/model/persistence/known_peer.dart';
+import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:logging/logging.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+final _logger = Logger('KnownPeers');
+
+final knownPeersProvider = ReduxProvider<KnownPeersService, List<KnownPeer>>((ref) {
+  return KnownPeersService(ref.read(persistenceProvider));
+});
+
+class KnownPeersService extends ReduxNotifier<List<KnownPeer>> {
+  final PersistenceService _persistence;
+
+  KnownPeersService(this._persistence);
+
+  @override
+  List<KnownPeer> init() => _persistence.getKnownPeers();
+}
+
+class UpdateKnownPeerAction
+    extends AsyncReduxAction<KnownPeersService, List<KnownPeer>> {
+  final Device device;
+
+  UpdateKnownPeerAction(this.device);
+
+  @override
+  Future<List<KnownPeer>> reduce() async {
+    if (device.ip == null || device.fingerprint.isEmpty) {
+      return state;
+    }
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final index = state.indexWhere(
+      (peer) => peer.fingerprint == device.fingerprint,
+    );
+    final KnownPeer updatedPeer;
+    final List<KnownPeer> updated;
+    if (index == -1) {
+      updatedPeer = KnownPeer.fromDevice(device, now);
+      updated = [updatedPeer, ...state];
+      _logger.info(
+        '[KNOWN_PEERS] Cache create: ${device.alias} (${device.ip}:${device.port})',
+      );
+    } else {
+      updatedPeer = state[index].mergeDevice(device, now);
+      updated = <KnownPeer>[...state]
+        ..replaceRange(index, index + 1, [updatedPeer]);
+      _logger.info(
+        '[KNOWN_PEERS] Cache update: ${device.alias} (${device.ip}:${device.port})',
+      );
+    }
+
+    final sorted = updated.where((peer) => peer.endpoints.isNotEmpty).toList()
+      ..sort((a, b) => b.lastSeen.compareTo(a.lastSeen));
+    await notifier._persistence.setKnownPeers(sorted);
+    return sorted;
+  }
+}
+
+class RecordKnownPeerFailuresAction
+    extends AsyncReduxAction<KnownPeersService, List<KnownPeer>> {
+  final Set<String> endpointKeys;
+
+  RecordKnownPeerFailuresAction(this.endpointKeys);
+
+  @override
+  Future<List<KnownPeer>> reduce() async {
+    if (endpointKeys.isEmpty) {
+      return state;
+    }
+
+    final updated = state
+        .map((peer) => peer.markFailures(endpointKeys))
+        .where((peer) => peer.endpoints.isNotEmpty)
+        .toList();
+    final beforeEndpoints = state.fold<int>(
+      0,
+      (count, peer) => count + peer.endpoints.length,
+    );
+    final afterEndpoints = updated.fold<int>(
+      0,
+      (count, peer) => count + peer.endpoints.length,
+    );
+    if (afterEndpoints < beforeEndpoints) {
+      _logger.info(
+        '[KNOWN_PEERS] Cache invalidated ${beforeEndpoints - afterEndpoints} stale endpoints',
+      );
+    } else {
+      _logger.info(
+        '[KNOWN_PEERS] Cache miss for ${endpointKeys.length} endpoints',
+      );
+    }
+    await notifier._persistence.setKnownPeers(updated);
+    return updated;
+  }
+}

--- a/app/lib/provider/network/nearby_devices_provider.dart
+++ b/app/lib/provider/network/nearby_devices_provider.dart
@@ -6,6 +6,7 @@ import 'package:common/model/device.dart';
 import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/model/state/nearby_devices_state.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
+import 'package:localsend_app/provider/known_peers_provider.dart';
 import 'package:localsend_app/provider/logging/discovery_logs_provider.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 
@@ -18,6 +19,7 @@ final nearbyDevicesProvider = ReduxProvider<NearbyDevicesService, NearbyDevicesS
   return NearbyDevicesService(
     isolateController: ref.notifier(parentIsolateProvider),
     favoriteService: ref.notifier(favoritesProvider),
+    knownPeersService: ref.notifier(knownPeersProvider),
     discoveryLogs: ref.notifier(discoveryLoggerProvider),
   );
 });
@@ -25,14 +27,17 @@ final nearbyDevicesProvider = ReduxProvider<NearbyDevicesService, NearbyDevicesS
 class NearbyDevicesService extends ReduxNotifier<NearbyDevicesState> {
   final IsolateController _isolateController;
   final FavoritesService _favoriteService;
+  final KnownPeersService _knownPeersService;
   final DiscoveryLogger _discoveryLogger;
 
   NearbyDevicesService({
     required IsolateController isolateController,
     required FavoritesService favoriteService,
+    required KnownPeersService knownPeersService,
     required DiscoveryLogger discoveryLogs,
   }) : _discoveryLogger = discoveryLogs,
        _isolateController = isolateController,
+       _knownPeersService = knownPeersService,
        _favoriteService = favoriteService;
 
   @override
@@ -88,6 +93,8 @@ class RegisterDeviceAction extends AsyncReduxAction<NearbyDevicesService, Nearby
     } else {
       await Future.microtask(() {});
     }
+    await external(notifier._knownPeersService).dispatchAsync(UpdateKnownPeerAction(device));
+    notifier._discoveryLogger.addLog('[KNOWN_PEERS] Cache update: ${device.alias} (${device.ip}:${device.port})');
     return state.copyWith(
       devices: {...state.devices}..update(device.ip!, (_) => device, ifAbsent: () => device),
     );
@@ -143,6 +150,81 @@ class StartMulticastScan extends ReduxAction<NearbyDevicesService, NearbyDevices
   }
 }
 
+class StartKnownPeersScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevicesState> {
+  @override
+  Future<NearbyDevicesState> reduce() async {
+    final endpoints = notifier._knownPeersService.state.expand((peer) => peer.endpoints).toList();
+    if (endpoints.isEmpty) {
+      notifier._discoveryLogger.addLog('[KNOWN_PEERS] Cache miss: no remembered endpoints');
+      return state;
+    }
+
+    notifier._discoveryLogger.addLog('[KNOWN_PEERS] Cache hit: probing ${endpoints.length} remembered endpoints');
+    final targets = endpoints
+        .map((endpoint) => HttpDiscoveryTarget(
+              ip: endpoint.ip,
+              port: endpoint.port,
+              https: endpoint.https,
+            ))
+        .toList();
+    final stream = external(notifier._isolateController).dispatchTakeResult(
+      IsolateTargetHttpDiscoveryAction(targets: targets),
+    );
+    final foundKeys = <String>{};
+    await for (final device in stream) {
+      notifier._discoveryLogger.addLog('[DISCOVER/KNOWN] ${device.alias} (${device.ip}, model: ${device.deviceModel})');
+      if (device.ip != null) {
+        foundKeys.add(_targetKey(device.ip!, device.port, device.https));
+      }
+      await dispatchAsync(RegisterDeviceAction(device));
+    }
+
+    final failedKeys = endpoints.map((endpoint) => endpoint.key).where((key) => !foundKeys.contains(key)).toSet();
+    if (failedKeys.isNotEmpty) {
+      notifier._discoveryLogger.addLog('[KNOWN_PEERS] Cache miss: ${failedKeys.length} endpoints failed or timed out');
+      await external(notifier._knownPeersService).dispatchAsync(RecordKnownPeerFailuresAction(failedKeys));
+    }
+
+    return state;
+  }
+}
+
+class StartCrossSubnetScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevicesState> {
+  final List<HttpDiscoveryTarget> targets;
+  final List<String> ranges;
+  final bool truncated;
+
+  StartCrossSubnetScan({
+    required this.targets,
+    required this.ranges,
+    required this.truncated,
+  });
+
+  @override
+  Future<NearbyDevicesState> reduce() async {
+    if (targets.isEmpty) {
+      notifier._discoveryLogger.addLog('[DISCOVER/CROSS_SUBNET] Skipped: no scan targets');
+      return state;
+    }
+
+    notifier._discoveryLogger.addLog(
+      '[DISCOVER/CROSS_SUBNET] Start scan: ${targets.length} targets in ${ranges.join(', ')}${truncated ? ' (truncated)' : ''}',
+    );
+    final stream = external(notifier._isolateController).dispatchTakeResult(
+      IsolateTargetHttpDiscoveryAction(targets: targets),
+    );
+    var found = 0;
+    await for (final device in stream) {
+      found++;
+      notifier._discoveryLogger.addLog('[DISCOVER/CROSS_SUBNET] ${device.alias} (${device.ip}, model: ${device.deviceModel})');
+      await dispatchAsync(RegisterDeviceAction(device));
+    }
+    notifier._discoveryLogger.addLog('[DISCOVER/CROSS_SUBNET] Finished scan: found $found devices');
+
+    return state;
+  }
+}
+
 /// Scans one particular subnet with traditional HTTP/TCP discovery.
 /// This method awaits until the scan is finished.
 class StartLegacyScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevicesState> {
@@ -165,6 +247,7 @@ class StartLegacyScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevic
     }
 
     dispatch(_SetRunningIpsAction({...state.runningIps, localIp}));
+    notifier._discoveryLogger.addLog('[DISCOVER/TCP] Start subnet scan: ${localIp.split('.').take(3).join('.')}.*:$port');
 
     final stream = external(notifier._isolateController).dispatchTakeResult(
       IsolateInterfaceHttpDiscoveryAction(
@@ -179,6 +262,7 @@ class StartLegacyScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevic
       await dispatchAsync(RegisterDeviceAction(device));
     }
 
+    notifier._discoveryLogger.addLog('[DISCOVER/TCP] Finished subnet scan: ${localIp.split('.').take(3).join('.')}.*:$port');
     return state.copyWith(
       runningIps: state.runningIps.where((ip) => ip != localIp).toSet(),
     );
@@ -218,6 +302,8 @@ class StartFavoriteScan extends AsyncReduxAction<NearbyDevicesService, NearbyDev
     );
   }
 }
+
+String _targetKey(String ip, int port, bool https) => '$ip:$port:${https ? 'https' : 'http'}';
 
 class _SetRunningIpsAction extends ReduxAction<NearbyDevicesService, NearbyDevicesState> {
   final Set<String> runningIps;

--- a/app/lib/provider/network/scan_facade.dart
+++ b/app/lib/provider/network/scan_facade.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
+import 'package:common/constants.dart';
+import 'package:common/isolate.dart';
 import 'package:common/util/sleep.dart';
+import 'package:flutter/foundation.dart';
 import 'package:localsend_app/pages/home_page.dart';
 import 'package:localsend_app/pages/home_page_controller.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
@@ -27,10 +30,14 @@ class StartSmartScan extends AsyncGlobalAction {
     // Try performant Multicast/UDP method first
     ref.redux(nearbyDevicesProvider).dispatch(StartMulticastScan());
 
-    // At the same time, try to discover favorites
+    // At the same time, try to discover known peers and favorites
+    final nearbyDevices = ref.redux(nearbyDevicesProvider);
     final favorites = ref.read(favoritesProvider);
     final https = ref.read(settingsProvider).https;
-    await ref.redux(nearbyDevicesProvider).dispatchAsync(StartFavoriteScan(devices: favorites, https: https));
+    await Future.wait<void>([
+      nearbyDevices.dispatchAsync(StartKnownPeersScan()),
+      nearbyDevices.dispatchAsync(StartFavoriteScan(devices: favorites, https: https)),
+    ]);
 
     if (!forceLegacy) {
       // Wait a bit before trying the legacy method.
@@ -46,6 +53,7 @@ class StartSmartScan extends AsyncGlobalAction {
       final networkInterfaces = ref.read(localIpProvider).localIps.take(maxInterfaces).toList();
       if (networkInterfaces.isNotEmpty) {
         await dispatchAsync(StartLegacySubnetScan(subnets: networkInterfaces));
+        await _maybeStartCrossSubnetScan(networkInterfaces, forceLegacy: forceLegacy);
       }
     } else {
       if (!stillEmpty) {
@@ -55,6 +63,42 @@ class StartSmartScan extends AsyncGlobalAction {
         emitMessage('User left the send tab. No need to start legacy scan.');
       }
     }
+  }
+
+  Future<void> _maybeStartCrossSubnetScan(List<String> networkInterfaces, {required bool forceLegacy}) async {
+    final settings = ref.read(settingsProvider);
+    if (!settings.crossSubnetScan) {
+      emitMessage('Cross-subnet scan is disabled.');
+      return;
+    }
+
+    final stillInSendTab = ref.read(homePageControllerProvider).currentTab == HomeTab.send;
+    if (!stillInSendTab) {
+      emitMessage('User left the send tab. No need to start cross-subnet scan.');
+      return;
+    }
+
+    final hasCustomRanges = settings.customSubnetScanRanges.isNotEmpty;
+    final stillEmpty = ref.read(nearbyDevicesProvider).devices.isEmpty;
+    if (!forceLegacy && !stillEmpty && !hasCustomRanges) {
+      emitMessage('Already found devices. Skipping automatic neighbouring subnet scan.');
+      return;
+    }
+
+    final plan = buildCrossSubnetScanPlan(
+      localIps: networkInterfaces,
+      port: settings.port,
+      https: settings.https,
+      depth: settings.crossSubnetScanDepth,
+      customRanges: settings.customSubnetScanRanges,
+    );
+    await ref.redux(nearbyDevicesProvider).dispatchAsync(
+          StartCrossSubnetScan(
+            targets: plan.targets,
+            ranges: plan.ranges,
+            truncated: plan.truncated,
+          ),
+        );
   }
 }
 
@@ -79,4 +123,148 @@ class StartLegacySubnetScan extends AsyncGlobalAction {
       for (final subnet in subnets) ref.redux(nearbyDevicesProvider).dispatchAsync(StartLegacyScan(port: port, localIp: subnet, https: https)),
     ]);
   }
+}
+
+class CrossSubnetScanPlan {
+  final List<HttpDiscoveryTarget> targets;
+  final List<String> ranges;
+  final bool truncated;
+
+  const CrossSubnetScanPlan({
+    required this.targets,
+    required this.ranges,
+    required this.truncated,
+  });
+}
+
+@visibleForTesting
+CrossSubnetScanPlan buildCrossSubnetScanPlan({
+  required List<String> localIps,
+  required int port,
+  required bool https,
+  required int depth,
+  required List<String> customRanges,
+  int maxHosts = maxCrossSubnetScanHosts,
+}) {
+  final localIpSet = localIps.toSet();
+  final ranges = <String>[];
+  final ips = <String>{};
+  var truncated = false;
+
+  void addIp(String ip) {
+    if (ips.length >= maxHosts) {
+      truncated = true;
+      return;
+    }
+    if (!localIpSet.contains(ip)) {
+      ips.add(ip);
+    }
+  }
+
+  final safeDepth = depth.clamp(0, maxCrossSubnetScanDepth).toInt();
+  for (final localIp in localIps) {
+    final octets = _parseIpv4(localIp);
+    if (octets == null) {
+      continue;
+    }
+    for (var offset = 1; offset <= safeDepth; offset++) {
+      for (final thirdOctet in [octets[2] - offset, octets[2] + offset]) {
+        if (thirdOctet < 0 || thirdOctet > 255) {
+          continue;
+        }
+        final prefix = '${octets[0]}.${octets[1]}.$thirdOctet';
+        ranges.add('$prefix.0/24');
+        for (var host = 1; host <= 254; host++) {
+          addIp('$prefix.$host');
+        }
+      }
+    }
+  }
+
+  for (final range in customRanges) {
+    final expanded = _expandCidr(range, maxHosts - ips.length);
+    if (expanded == null) {
+      ranges.add('$range (invalid)');
+      continue;
+    }
+    ranges.add(range);
+    if (expanded.truncated) {
+      truncated = true;
+    }
+    for (final ip in expanded.ips) {
+      addIp(ip);
+    }
+  }
+
+  return CrossSubnetScanPlan(
+    targets: ips.map((ip) => HttpDiscoveryTarget(ip: ip, port: port, https: https)).toList(),
+    ranges: ranges,
+    truncated: truncated,
+  );
+}
+
+({List<String> ips, bool truncated})? _expandCidr(String cidr, int remainingHosts) {
+  if (remainingHosts <= 0) {
+    return (ips: const [], truncated: true);
+  }
+  final parts = cidr.trim().split('/');
+  if (parts.length != 2) {
+    return null;
+  }
+  final ip = _ipv4ToInt(parts[0]);
+  final prefix = int.tryParse(parts[1]);
+  if (ip == null || prefix == null || prefix < 0 || prefix > 32) {
+    return null;
+  }
+
+  final hostBits = 32 - prefix;
+  final mask = prefix == 0 ? 0 : (0xffffffff << hostBits) & 0xffffffff;
+  final network = ip & mask;
+  final broadcast = network | (~mask & 0xffffffff);
+  final first = prefix >= 31 ? network : network + 1;
+  final last = prefix >= 31 ? broadcast : broadcast - 1;
+  final ips = <String>[];
+  var truncated = false;
+  for (var current = first; current <= last; current++) {
+    if (ips.length >= remainingHosts) {
+      truncated = true;
+      break;
+    }
+    ips.add(_intToIpv4(current));
+  }
+
+  return (ips: ips, truncated: truncated);
+}
+
+int? _ipv4ToInt(String ip) {
+  final octets = _parseIpv4(ip);
+  if (octets == null) {
+    return null;
+  }
+  return (octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3];
+}
+
+List<int>? _parseIpv4(String ip) {
+  final parts = ip.trim().split('.');
+  if (parts.length != 4) {
+    return null;
+  }
+  final octets = <int>[];
+  for (final part in parts) {
+    final value = int.tryParse(part);
+    if (value == null || value < 0 || value > 255) {
+      return null;
+    }
+    octets.add(value);
+  }
+  return octets;
+}
+
+String _intToIpv4(int value) {
+  return [
+    (value >> 24) & 0xff,
+    (value >> 16) & 0xff,
+    (value >> 8) & 0xff,
+    value & 0xff,
+  ].join('.');
 }

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/model/persistence/favorite_device.dart';
+import 'package:localsend_app/model/persistence/known_peer.dart';
 import 'package:localsend_app/model/persistence/receive_history_entry.dart';
 import 'package:localsend_app/model/send_mode.dart';
 import 'package:localsend_app/provider/window_dimensions_provider.dart';
@@ -57,6 +58,9 @@ const _receiveHistory = 'ls_receive_history';
 // Favorites
 const _favorites = 'ls_favorites';
 
+// Known peers
+const _knownPeers = 'ls_known_peers';
+
 // App Window Offset and Size info
 const _windowOffsetX = 'ls_window_offset_x';
 const _windowOffsetY = 'ls_window_offset_y';
@@ -75,6 +79,9 @@ const _networkWhitelistKey = 'ls_network_whitelist';
 const _networkBlacklistKey = 'ls_network_blacklist';
 const _timeoutKey = 'ls_timeout';
 const _multicastGroupKey = 'ls_multicast_group';
+const _crossSubnetScanKey = 'ls_cross_subnet_scan';
+const _crossSubnetScanDepthKey = 'ls_cross_subnet_scan_depth';
+const _customSubnetScanRangesKey = 'ls_custom_subnet_scan_ranges';
 const _destinationKey = 'ls_destination';
 const _saveToGallery = 'ls_save_to_gallery';
 const _saveToHistory = 'ls_save_to_history';
@@ -267,6 +274,18 @@ class PersistenceService {
     await _prefs.setStringList(_favorites, favoritesRaw);
   }
 
+  List<KnownPeer> getKnownPeers() {
+    final peersRaw = _prefs.getStringList(_knownPeers) ?? [];
+    return peersRaw
+        .map((entry) => KnownPeer.fromJson((jsonDecode(entry) as Map).cast<String, dynamic>()))
+        .toList();
+  }
+
+  Future<void> setKnownPeers(List<KnownPeer> entries) async {
+    final peersRaw = entries.map((entry) => jsonEncode(entry.toJson())).toList();
+    await _prefs.setStringList(_knownPeers, peersRaw);
+  }
+
   String getShowToken() {
     return _prefs.getString(_showToken)!;
   }
@@ -373,6 +392,30 @@ class PersistenceService {
 
   Future<void> setMulticastGroup(String group) async {
     await _prefs.setString(_multicastGroupKey, group);
+  }
+
+  bool getCrossSubnetScan() {
+    return _prefs.getBool(_crossSubnetScanKey) ?? defaultCrossSubnetScan;
+  }
+
+  Future<void> setCrossSubnetScan(bool enabled) async {
+    await _prefs.setBool(_crossSubnetScanKey, enabled);
+  }
+
+  int getCrossSubnetScanDepth() {
+    return _prefs.getInt(_crossSubnetScanDepthKey) ?? defaultCrossSubnetScanDepth;
+  }
+
+  Future<void> setCrossSubnetScanDepth(int depth) async {
+    await _prefs.setInt(_crossSubnetScanDepthKey, depth);
+  }
+
+  List<String> getCustomSubnetScanRanges() {
+    return _prefs.getStringList(_customSubnetScanRangesKey) ?? const [];
+  }
+
+  Future<void> setCustomSubnetScanRanges(List<String> ranges) async {
+    await _prefs.setStringList(_customSubnetScanRangesKey, ranges);
   }
 
   String? getDestination() {

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -69,6 +69,9 @@ class SettingsService extends PureNotifier<SettingsState> {
     deviceModel: _persistence.getDeviceModel(),
     shareViaLinkAutoAccept: _persistence.getShareViaLinkAutoAccept(),
     discoveryTimeout: _persistence.getDiscoveryTimeout(),
+    crossSubnetScan: _persistence.getCrossSubnetScan(),
+    crossSubnetScanDepth: _persistence.getCrossSubnetScanDepth(),
+    customSubnetScanRanges: _persistence.getCustomSubnetScanRanges(),
     advancedSettings: _persistence.getAdvancedSettingsEnabled(),
   );
 
@@ -139,6 +142,27 @@ class SettingsService extends PureNotifier<SettingsState> {
     await _persistence.setMulticastGroup(group);
     state = state.copyWith(
       multicastGroup: group,
+    );
+  }
+
+  Future<void> setCrossSubnetScan(bool enabled) async {
+    await _persistence.setCrossSubnetScan(enabled);
+    state = state.copyWith(
+      crossSubnetScan: enabled,
+    );
+  }
+
+  Future<void> setCrossSubnetScanDepth(int depth) async {
+    await _persistence.setCrossSubnetScanDepth(depth);
+    state = state.copyWith(
+      crossSubnetScanDepth: depth,
+    );
+  }
+
+  Future<void> setCustomSubnetScanRanges(List<String> ranges) async {
+    await _persistence.setCustomSubnetScanRanges(ranges);
+    state = state.copyWith(
+      customSubnetScanRanges: ranges,
     );
   }
 

--- a/app/test/unit/provider/network/scan_facade_test.dart
+++ b/app/test/unit/provider/network/scan_facade_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localsend_app/provider/network/scan_facade.dart';
+
+void main() {
+  group('buildCrossSubnetScanPlan', () {
+    test('includes neighbouring /24 subnets within depth', () {
+      final plan = buildCrossSubnetScanPlan(
+        localIps: ['192.168.73.15'],
+        port: 53317,
+        https: true,
+        depth: 4,
+        customRanges: const [],
+      );
+
+      final ips = plan.targets.map((target) => target.ip).toSet();
+      expect(ips, contains('192.168.69.200'));
+      expect(ips, contains('192.168.77.200'));
+      expect(ips, isNot(contains('192.168.73.15')));
+      expect(ips, isNot(contains('192.168.73.200')));
+      expect(plan.truncated, isFalse);
+    });
+
+    test('expands custom cidr ranges and keeps protocol settings', () {
+      final plan = buildCrossSubnetScanPlan(
+        localIps: ['10.0.0.5'],
+        port: 53317,
+        https: false,
+        depth: 0,
+        customRanges: const ['192.168.64.0/30'],
+      );
+
+      expect(plan.targets.map((target) => target.ip), [
+        '192.168.64.1',
+        '192.168.64.2',
+      ]);
+      expect(plan.targets.every((target) => target.port == 53317), isTrue);
+      expect(plan.targets.every((target) => !target.https), isTrue);
+      expect(plan.truncated, isFalse);
+    });
+
+    test('marks large generated plans as truncated', () {
+      final plan = buildCrossSubnetScanPlan(
+        localIps: ['192.168.73.15'],
+        port: 53317,
+        https: true,
+        depth: 4,
+        customRanges: const [],
+        maxHosts: 100,
+      );
+
+      expect(plan.targets.length, 100);
+      expect(plan.truncated, isTrue);
+    });
+  });
+}

--- a/common/lib/constants.dart
+++ b/common/lib/constants.dart
@@ -30,3 +30,23 @@ const defaultDiscoveryTimeout = 500;
 /// because on some Android devices this is the only IP range
 /// that can receive UDP multicast messages.
 const defaultMulticastGroup = '224.0.0.167';
+
+/// Whether LocalSend should try bounded cross-subnet HTTP discovery after
+/// the local subnet scan could not find any devices.
+const defaultCrossSubnetScan = true;
+
+/// Number of neighbouring /24 subnets scanned on each side of the current one.
+///
+/// Example: 192.168.73.15 with depth 4 scans 192.168.69.0/24 through
+/// 192.168.77.0/24, excluding the current 192.168.73.0/24 because the legacy
+/// local subnet scan already covers it.
+const defaultCrossSubnetScanDepth = 4;
+
+/// Upper bound for neighbouring /24 subnet expansion.
+const maxCrossSubnetScanDepth = 16;
+
+/// Hard limit for generated cross-subnet scan targets.
+const maxCrossSubnetScanHosts = 4096;
+
+/// Maximum number of endpoint addresses remembered for a known peer.
+const maxKnownPeerEndpoints = 8;

--- a/common/lib/isolate.dart
+++ b/common/lib/isolate.dart
@@ -4,3 +4,4 @@ export 'package:common/src/isolate/child/upload_isolate.dart' show UriContentStr
 export 'package:common/src/isolate/parent/actions.dart';
 export 'package:common/src/isolate/parent/actions_sync.dart';
 export 'package:common/src/isolate/parent/parent_isolate_provider.dart';
+export 'package:common/src/task/discovery/http_scan_discovery.dart' show HttpDiscoveryTarget;

--- a/common/lib/src/isolate/child/http_scan_discovery_isolate.dart
+++ b/common/lib/src/isolate/child/http_scan_discovery_isolate.dart
@@ -30,6 +30,14 @@ class HttpFavoriteScanTask implements HttpScanTask {
   });
 }
 
+class HttpTargetScanTask implements HttpScanTask {
+  final List<HttpDiscoveryTarget> targets;
+
+  HttpTargetScanTask({
+    required this.targets,
+  });
+}
+
 @internal
 Future<void> setupHttpScanDiscoveryIsolate(
   Stream<SendToIsolateData<IsolateTask<HttpScanTask>>> receiveFromMain,
@@ -51,6 +59,9 @@ Future<void> setupHttpScanDiscoveryIsolate(
         HttpFavoriteScanTask data => ref.read(httpScanDiscoveryProvider).getFavoriteStream(
               devices: data.favorites,
               https: data.https,
+            ),
+        HttpTargetScanTask data => ref.read(httpScanDiscoveryProvider).getTargetStream(
+              targets: data.targets,
             ),
       };
       await for (final device in stream) {

--- a/common/lib/src/isolate/parent/actions.dart
+++ b/common/lib/src/isolate/parent/actions.dart
@@ -8,6 +8,7 @@ import 'package:common/src/isolate/dto/isolate_task.dart';
 import 'package:common/src/isolate/dto/isolate_task_result.dart';
 import 'package:common/src/isolate/dto/send_to_isolate_data.dart';
 import 'package:common/src/isolate/parent/parent_isolate_provider.dart';
+import 'package:common/src/task/discovery/http_scan_discovery.dart';
 import 'package:common/src/util/id_provider.dart';
 import 'package:common/src/util/isolate_helper.dart';
 import 'package:refena/refena.dart';
@@ -67,6 +68,34 @@ class IsolateFavoriteHttpDiscoveryAction extends ReduxActionWithResult<IsolateCo
     final task = HttpFavoriteScanTask(
       favorites: favorites,
       https: https,
+    );
+
+    return (
+      state,
+      _sendTaskAndListenStream(
+        task: task,
+        connection: connection,
+      )
+    );
+  }
+}
+
+class IsolateTargetHttpDiscoveryAction extends ReduxActionWithResult<IsolateController, ParentIsolateState, Stream<Device>> {
+  final List<HttpDiscoveryTarget> targets;
+
+  IsolateTargetHttpDiscoveryAction({
+    required this.targets,
+  });
+
+  @override
+  (ParentIsolateState, Stream<Device>) reduce() {
+    final connection = state.httpScanDiscovery;
+    if (connection == null) {
+      throw StateError('httpScanDiscovery is not initialized');
+    }
+
+    final task = HttpTargetScanTask(
+      targets: targets,
     );
 
     return (

--- a/common/lib/src/task/discovery/http_scan_discovery.dart
+++ b/common/lib/src/task/discovery/http_scan_discovery.dart
@@ -14,6 +14,23 @@ final httpScanDiscoveryProvider = ViewProvider((ref) {
 
 Map<String, TaskRunner> _runners = {};
 
+class HttpDiscoveryTarget {
+  final String ip;
+  final int port;
+  final bool https;
+
+  const HttpDiscoveryTarget({
+    required this.ip,
+    required this.port,
+    required this.https,
+  });
+
+  String get key => '$ip:$port:${https ? 'https' : 'http'}';
+
+  @override
+  String toString() => '${https ? 'https' : 'http'}://$ip:$port';
+}
+
 class HttpScanDiscoveryService {
   final StateAccessor<HttpTargetDiscoveryService> _targetedDiscoveryService;
 
@@ -21,21 +38,42 @@ class HttpScanDiscoveryService {
     required StateAccessor<HttpTargetDiscoveryService> targetedDiscoveryService,
   }) : _targetedDiscoveryService = targetedDiscoveryService;
 
-  Stream<Device> getStream({required String networkInterface, required int port, required bool https}) {
-    final ipList = List.generate(256, (i) => '${networkInterface.split('.').take(3).join('.')}.$i').where((ip) => ip != networkInterface).toList();
+  Stream<Device> getStream({
+    required String networkInterface,
+    required int port,
+    required bool https,
+  }) {
+    final ipList = List.generate(
+      256,
+      (i) => '${networkInterface.split('.').take(3).join('.')}.$i',
+    ).where((ip) => ip != networkInterface).toList();
     _runners[networkInterface]?.stop();
+    _logger.info(
+      '[DISCOVER/TCP] Start subnet scan: ${networkInterface.split('.').take(3).join('.')}.*:$port (${https ? 'HTTPS' : 'HTTP'})',
+    );
     _runners[networkInterface] = TaskRunner<Device?>(
       initialTasks: List.generate(
         ipList.length,
-        (index) => () async => _doRequest(ipList[index], port, https),
+        (index) =>
+            () async => _doRequest(ipList[index], port, https),
       ),
       concurrency: 50,
+      onFinish: () {
+        _logger.info(
+          '[DISCOVER/TCP] Finished subnet scan: ${networkInterface.split('.').take(3).join('.')}.*:$port',
+        );
+      },
     );
 
-    return _runners[networkInterface]!.stream.where((device) => device != null).cast<Device>();
+    return _runners[networkInterface]!.stream
+        .where((device) => device != null)
+        .cast<Device>();
   }
 
-  Stream<Device> getFavoriteStream({required List<(String, int)> devices, required bool https}) {
+  Stream<Device> getFavoriteStream({
+    required List<(String, int)> devices,
+    required bool https,
+  }) {
     final runner = TaskRunner<Device?>(
       initialTasks: List.generate(
         devices.length,
@@ -45,6 +83,34 @@ class HttpScanDiscoveryService {
         },
       ),
       concurrency: 50,
+      onFinish: () {
+        _logger.info(
+          '[DISCOVER/TCP] Finished favorite scan (${devices.length} targets)',
+        );
+      },
+    );
+
+    return runner.stream.where((device) => device != null).cast<Device>();
+  }
+
+  Stream<Device> getTargetStream({required List<HttpDiscoveryTarget> targets}) {
+    final dedupedTargets = {
+      for (final target in targets) target.key: target,
+    }.values.toList();
+    _logger.info(
+      '[DISCOVER/TCP] Start target scan (${dedupedTargets.length} targets)',
+    );
+    final runner = TaskRunner<Device?>(
+      initialTasks: List.generate(dedupedTargets.length, (index) {
+        final target = dedupedTargets[index];
+        return () async => _doRequest(target.ip, target.port, target.https);
+      }),
+      concurrency: 50,
+      onFinish: () {
+        _logger.info(
+          '[DISCOVER/TCP] Finished target scan (${dedupedTargets.length} targets)',
+        );
+      },
     );
 
     return runner.stream.where((device) => device != null).cast<Device>();
@@ -56,10 +122,14 @@ class HttpScanDiscoveryService {
       ip: currentIp,
       port: port,
       https: https,
-      onError: null,
+      onError: (url, error) {
+        _logger.fine('[DISCOVER/TCP] Failed to discover $url: $error');
+      },
     );
     if (device != null) {
-      _logger.info('[DISCOVER/TCP] ${device.alias} (${device.ip}, model: ${device.deviceModel})');
+      _logger.info(
+        '[DISCOVER/TCP] ${device.alias} (${device.ip}, model: ${device.deviceModel})',
+      );
     }
 
     return device;

--- a/common/lib/src/task/discovery/multicast_discovery.dart
+++ b/common/lib/src/task/discovery/multicast_discovery.dart
@@ -55,15 +55,25 @@ class MulticastService {
           }
 
           try {
-            final dto = MulticastDto.fromJson(jsonDecode(utf8.decode(datagram.data)));
+            _logger.info(
+              'Received UDP multicast packet from ${datagram.address.address}:${datagram.port} (${datagram.data.length} bytes)',
+            );
+            final dto = MulticastDto.fromJson(
+              jsonDecode(utf8.decode(datagram.data)),
+            );
             if (dto.fingerprint == syncState.securityContext.certificateHash) {
               return;
             }
 
             final ip = datagram.address.address;
-            final peer = dto.toDevice(ip, syncState.port, syncState.protocol == ProtocolType.https);
+            final peer = dto.toDevice(
+              ip,
+              syncState.port,
+              syncState.protocol == ProtocolType.https,
+            );
             streamController.add(peer);
-            if ((dto.announcement == true || dto.announce == true) && syncState.serverRunning) {
+            if ((dto.announcement == true || dto.announce == true) &&
+                syncState.serverRunning) {
               // only respond when server is running
               // ignore: discarded_futures
               _answerAnnouncement(peer);
@@ -115,15 +125,27 @@ class MulticastService {
     for (final wait in [100, 500, 2000]) {
       await sleepAsync(wait);
 
-      _logger.info('Announce via UDP');
       for (final socket in sockets) {
         try {
-          socket.socket.send(dto, InternetAddress(syncState.multicastGroup), syncState.port);
-          socket.socket.close();
+          _logger.info(
+            'Send UDP multicast announcement to ${syncState.multicastGroup}:${syncState.port} '
+            'from ${socket.interface.addresses.map((a) => a.address).join(',')}',
+          );
+          socket.socket.send(
+            dto,
+            InternetAddress(syncState.multicastGroup),
+            syncState.port,
+          );
         } catch (e) {
-          _logger.warning('Could not send multicast message', e);
+          _logger.warning(
+            'Could not send UDP multicast announcement to ${syncState.multicastGroup}:${syncState.port}',
+            e,
+          );
         }
       }
+    }
+    for (final socket in sockets) {
+      socket.socket.close();
     }
   }
 
@@ -131,11 +153,16 @@ class MulticastService {
   Future<void> _answerAnnouncement(Device peer) async {
     try {
       // Answer with TCP
-      await _ref.read(httpProvider).discovery.post(
+      await _ref
+          .read(httpProvider)
+          .discovery
+          .post(
             uri: ApiRoute.register.target(peer),
             json: _getRegisterDto().toJson(),
           );
-      _logger.info('Respond to announcement of ${peer.alias} (${peer.ip}, model: ${peer.deviceModel}) via TCP');
+      _logger.info(
+        'Respond to announcement of ${peer.alias} (${peer.ip}, model: ${peer.deviceModel}) via TCP',
+      );
     } catch (e) {
       // Fallback: Answer with UDP
       final syncState = _ref.read(syncProvider);
@@ -147,13 +174,26 @@ class MulticastService {
       final dto = _getMulticastDto(announcement: false);
       for (final socket in sockets) {
         try {
-          socket.socket.send(dto, InternetAddress(syncState.multicastGroup), syncState.port);
+          _logger.info(
+            'Send UDP multicast response to ${syncState.multicastGroup}:${syncState.port} '
+            'from ${socket.interface.addresses.map((a) => a.address).join(',')}',
+          );
+          socket.socket.send(
+            dto,
+            InternetAddress(syncState.multicastGroup),
+            syncState.port,
+          );
           socket.socket.close();
         } catch (e) {
-          _logger.warning('Could not send multicast message', e);
+          _logger.warning(
+            'Could not send UDP multicast response to ${syncState.multicastGroup}:${syncState.port}',
+            e,
+          );
         }
       }
-      _logger.info('Respond to announcement of ${peer.alias} (${peer.ip}, model: ${peer.deviceModel}) with UDP because TCP failed');
+      _logger.info(
+        'Respond to announcement of ${peer.alias} (${peer.ip}, model: ${peer.deviceModel}) with UDP because TCP failed',
+      );
     }
   }
 
@@ -210,8 +250,15 @@ Future<List<_SocketResult>> _getSockets({
   final sockets = <_SocketResult>[];
   for (final interface in interfaces) {
     try {
-      final socket = await RawDatagramSocket.bind(InternetAddress.anyIPv4, port ?? 0);
+      final socket = await RawDatagramSocket.bind(
+        InternetAddress.anyIPv4,
+        port ?? 0,
+      );
       socket.joinMulticast(InternetAddress(multicastGroup), interface);
+      _logger.info(
+        'Joined UDP multicast group $multicastGroup on ${interface.name} '
+        '(${interface.addresses.map((a) => a.address).join(',')}) using port ${port ?? 'auto'}',
+      );
       sockets.add(_SocketResult(interface, socket));
     } catch (e) {
       _logger.warning(


### PR DESCRIPTION
## What changed

- Keeps the existing UDP multicast discovery path intact.
- Adds a persistent known-peers cache keyed by device fingerprint and remembered HTTP endpoints.
- Probes known peers during Smart Scan so previously seen devices can be rediscovered across routed subnets or VLANs.
- Adds bounded cross-subnet HTTP discovery after the existing local subnet fallback.
- Adds a reusable target-list HTTP discovery task shared by known-peer probing and cross-subnet scans.
- Adds discovery logs for multicast send/receive/join events, known-peer cache hits/updates/invalidations, TCP failures, and cross-subnet scan lifecycle events.
- Adds scan-plan tests for neighbouring subnet expansion and CIDR expansion.

## Why

The current default multicast group (`224.0.0.167`) is link-local multicast, so it does not cross routed subnets. In routed LANs or VLAN setups, devices can often reach each other via TCP/HTTP but still fail automatic discovery because neither multicast nor the current local `/24` fallback reaches the other subnet.

This preserves same-subnet behavior while adding low-cost recovery for known peers and a capped HTTP fallback for nearby or configured subnets.

## Behavior

Smart Scan now tries:

1. UDP multicast announcement.
2. Known peers and favorites in parallel.
3. Existing local `/24` HTTP scan if needed.
4. Bounded cross-subnet HTTP scan if still needed or custom ranges are configured.

The default neighbouring scan depth is 4, so a device on `192.168.73.x` can probe nearby `/24` networks including `192.168.69.x`, subject to routing and firewall reachability.

## Validation

- `git diff --check`
- `cd common && dart analyze`
- `cd common && dart test`

App-level `flutter pub get` / `build_runner` / `flutter analyze` could not be completed in this local environment because the current Flutter SDK pins `flutter_test` dependencies that conflict with the repository's `mockito`, `test`, and `dynamic_color` constraints. The generated `settings_state.mapper.dart` changes were applied manually to match the added settings fields.
