### PR TITLE
Feat/smartwatch feaure implementation

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
+    <!-- Wear OS -->
+    <uses-feature android:name="android.hardware.type.watch" android:required="false" />
+
     <application
         android:label="LocalSend"
         android:name="${applicationName}"
@@ -51,6 +54,9 @@
 
                 <!-- enable Android TV -->
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
+
+                <!-- enable Wear OS -->
+                <category android:name="com.google.android.wearable.app.category.WEARABLE_APP" />
             </intent-filter>
 
             <!-- localsend: Receive share intent (share_handler) -->

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -32,6 +32,7 @@ import 'package:localsend_app/provider/purchase_provider.dart';
 import 'package:localsend_app/provider/selection/selected_sending_files_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/provider/tv_provider.dart';
+import 'package:localsend_app/provider/watch_provider.dart';
 import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/rust/api/logging.dart' as rust_logging;
 import 'package:localsend_app/rust/frb_generated.dart';
@@ -151,6 +152,7 @@ Future<RefenaContainer> preInit(List<String> args) async {
       deviceRawInfoProvider.overrideWithValue(await getDeviceInfo()),
       appArgumentsProvider.overrideWithValue(args),
       tvProvider.overrideWithValue(await checkIfTv()),
+      watchProvider.overrideWithValue(await checkIfWatch()),
       dynamicColorsProvider.overrideWithValue(dynamicColors),
       sleepProvider.overrideWithInitialState((ref) => startHidden),
     ],

--- a/app/lib/provider/network/webrtc/signaling_provider.dart
+++ b/app/lib/provider/network/webrtc/signaling_provider.dart
@@ -232,6 +232,7 @@ extension on rust.DeviceType {
       rust.DeviceType.web => DeviceType.web,
       rust.DeviceType.headless => DeviceType.headless,
       rust.DeviceType.server => DeviceType.server,
+      rust.DeviceType.smartwatch => DeviceType.smartwatch,
     };
   }
 }
@@ -244,6 +245,7 @@ extension on DeviceType {
       DeviceType.web => rust.DeviceType.web,
       DeviceType.headless => rust.DeviceType.headless,
       DeviceType.server => rust.DeviceType.server,
+      DeviceType.smartwatch => rust.DeviceType.smartwatch,
     };
   }
 }

--- a/app/lib/provider/watch_provider.dart
+++ b/app/lib/provider/watch_provider.dart
@@ -1,0 +1,18 @@
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/services.dart';
+import 'package:localsend_app/util/native/platform_check.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+final watchProvider = Provider<bool>((_) => throw Exception('watchProvider not initialized'), debugLabel: 'watchProvider');
+
+/// Returns true if this device is a smartwatch.
+/// Currently, only supports Wear OS.
+Future<bool> checkIfWatch() async {
+  if (checkPlatform([TargetPlatform.android])) {
+    final deviceInfo = DeviceInfoPlugin();
+    final androidInfo = await deviceInfo.androidInfo;
+    return androidInfo.systemFeatures.contains('android.hardware.type.watch');
+  } else {
+    return false;
+  }
+}

--- a/app/lib/rust/api/model.dart
+++ b/app/lib/rust/api/model.dart
@@ -12,6 +12,7 @@ enum DeviceType {
   web,
   headless,
   server,
+  smartwatch,
 }
 
 class FileDto {

--- a/app/lib/util/device_type_ext.dart
+++ b/app/lib/util/device_type_ext.dart
@@ -9,6 +9,7 @@ extension DeviceTypeExt on DeviceType {
       DeviceType.web => Icons.language,
       DeviceType.headless => Icons.terminal,
       DeviceType.server => Icons.dns,
+      DeviceType.smartwatch => Icons.watch,
     };
   }
 }

--- a/app/lib/util/native/device_info_helper.dart
+++ b/app/lib/util/native/device_info_helper.dart
@@ -21,37 +21,32 @@ Future<DeviceInfoResult> getDeviceInfo() async {
   } else {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-      case TargetPlatform.iOS:
-        deviceType = DeviceType.mobile;
-        break;
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-      case TargetPlatform.fuchsia:
-        deviceType = DeviceType.desktop;
-        break;
-    }
-
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
         final deviceInfo = await plugin.androidInfo;
+        deviceType = deviceInfo.systemFeatures.contains('android.hardware.type.watch')
+            ? DeviceType.smartwatch
+            : DeviceType.mobile;
         deviceModel = deviceInfo.brand.toCase(CaseStyle.pascal);
         androidSdkInt = deviceInfo.version.sdkInt;
         break;
       case TargetPlatform.iOS:
+        deviceType = DeviceType.mobile;
         final deviceInfo = await plugin.iosInfo;
         deviceModel = deviceInfo.localizedModel;
         break;
       case TargetPlatform.linux:
+        deviceType = DeviceType.desktop;
         deviceModel = 'Linux';
         break;
       case TargetPlatform.macOS:
+        deviceType = DeviceType.desktop;
         deviceModel = 'macOS';
         break;
       case TargetPlatform.windows:
+        deviceType = DeviceType.desktop;
         deviceModel = 'Windows';
         break;
       case TargetPlatform.fuchsia:
+        deviceType = DeviceType.desktop;
         deviceModel = 'Fuchsia';
         break;
     }

--- a/app/lib/util/rust.dart
+++ b/app/lib/util/rust.dart
@@ -43,6 +43,7 @@ extension DeviceTypeExt on DeviceType {
       DeviceType.web => rust_model.DeviceType.web,
       DeviceType.headless => rust_model.DeviceType.headless,
       DeviceType.server => rust_model.DeviceType.server,
+      DeviceType.smartwatch => rust_model.DeviceType.smartwatch,
     };
   }
 }
@@ -74,6 +75,7 @@ extension RustDeviceTypeExt on rust_model.DeviceType {
       rust_model.DeviceType.web => DeviceType.web,
       rust_model.DeviceType.headless => DeviceType.headless,
       rust_model.DeviceType.server => DeviceType.server,
+      rust_model.DeviceType.smartwatch => DeviceType.smartwatch,
     };
   }
 }

--- a/app/lib/widget/dialogs/text_field_tv.dart
+++ b/app/lib/widget/dialogs/text_field_tv.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:localsend_app/config/theme.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/provider/tv_provider.dart';
+import 'package:localsend_app/provider/watch_provider.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
 
@@ -28,8 +29,9 @@ class _TextFieldTvState extends State<TextFieldTv> with Refena {
   @override
   Widget build(BuildContext context) {
     final isTv = ref.watch(tvProvider);
+    final isWatch = ref.watch(watchProvider);
 
-    if (isTv) {
+    if (isTv || isWatch) {
       return TextButton(
         style: TextButton.styleFrom(
           backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,

--- a/app/rust/src/api/model.rs
+++ b/app/rust/src/api/model.rs
@@ -35,6 +35,7 @@ pub enum _DeviceType {
     Web,
     Headless,
     Server,
+    Smartwatch,
 }
 
 #[frb(mirror(ProtocolType))]

--- a/app/rust/src/frb_generated.rs
+++ b/app/rust/src/frb_generated.rs
@@ -2264,7 +2264,7 @@ impl SseDecode for crate::api::model::DeviceType {
             2 => crate::api::model::DeviceType::Web,
             3 => crate::api::model::DeviceType::Headless,
             4 => crate::api::model::DeviceType::Server,
-            _ => unreachable!("Invalid variant for DeviceType: {}", inner),
+            5 => crate::api::model::DeviceType::Smartwatch,
         };
     }
 }
@@ -3207,7 +3207,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::api::model::DeviceType>
             crate::api::model::DeviceType::Web => 2.into_dart(),
             crate::api::model::DeviceType::Headless => 3.into_dart(),
             crate::api::model::DeviceType::Server => 4.into_dart(),
-            _ => unreachable!(),
+            crate::api::model::DeviceType::Smartwatch => 5.into_dart(),
         }
     }
 }
@@ -4010,9 +4010,7 @@ impl SseEncode for crate::api::model::DeviceType {
                 crate::api::model::DeviceType::Web => 2,
                 crate::api::model::DeviceType::Headless => 3,
                 crate::api::model::DeviceType::Server => 4,
-                _ => {
-                    unimplemented!("");
-                }
+                crate::api::model::DeviceType::Smartwatch => 5,
             },
             serializer,
         );

--- a/common/lib/model/device.dart
+++ b/common/lib/model/device.dart
@@ -9,6 +9,7 @@ enum DeviceType {
   web,
   headless,
   server,
+  smartwatch,
 }
 
 @MappableClass()

--- a/common/lib/model/device.mapper.dart
+++ b/common/lib/model/device.mapper.dart
@@ -35,6 +35,8 @@ class DeviceTypeMapper extends EnumMapper<DeviceType> {
         return DeviceType.headless;
       case 'server':
         return DeviceType.server;
+      case 'smartwatch':
+        return DeviceType.smartwatch;
       default:
         return DeviceType.values[1];
     }
@@ -53,6 +55,8 @@ class DeviceTypeMapper extends EnumMapper<DeviceType> {
         return 'headless';
       case DeviceType.server:
         return 'server';
+      case DeviceType.smartwatch:
+        return 'smartwatch';
     }
   }
 }

--- a/common/test/unit/model/device_test.dart
+++ b/common/test/unit/model/device_test.dart
@@ -57,4 +57,9 @@ void main() {
     expect(set, contains(SignalingDiscovery(signalingServer: 'sa')));
     expect(set, contains(SignalingDiscovery(signalingServer: 'sb')));
   });
+
+  test('Should serialize and deserialize smartwatch device type', () {
+    expect(DeviceType.smartwatch.toValue(), 'smartwatch');
+    expect(DeviceTypeMapper.fromValue('smartwatch'), DeviceType.smartwatch);
+  });
 }

--- a/common/test/unit/model/smartwatch_device_type_test.dart
+++ b/common/test/unit/model/smartwatch_device_type_test.dart
@@ -1,0 +1,131 @@
+import 'package:common/model/device.dart';
+import 'package:common/model/dto/info_register_dto.dart';
+import 'package:common/model/dto/multicast_dto.dart';
+import 'package:common/model/dto/register_dto.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('smartwatch DeviceType protocol', () {
+    test('serializes to wire value smartwatch', () {
+      expect(DeviceType.smartwatch.toValue(), 'smartwatch');
+    });
+
+    test('deserializes from wire value smartwatch', () {
+      expect(DeviceTypeMapper.fromValue('smartwatch'), DeviceType.smartwatch);
+    });
+
+    test('is included in DeviceType.values for settings and persistence', () {
+      expect(DeviceType.values, contains(DeviceType.smartwatch));
+      expect(DeviceType.smartwatch.name, 'smartwatch');
+      expect(DeviceType.smartwatch.index, 5);
+    });
+  });
+
+  group('MulticastDto smartwatch', () {
+    test('parses smartwatch from JSON', () {
+      final parsed = MulticastDto.fromJson({
+        'alias': 'Galaxy Watch',
+        'version': '2.0',
+        'deviceModel': 'Samsung',
+        'deviceType': 'smartwatch',
+        'fingerprint': 'fp-1',
+        'port': 53317,
+        'protocol': 'https',
+        'download': false,
+        'announce': true,
+      });
+
+      expect(parsed.deviceType, DeviceType.smartwatch);
+    });
+
+    test('serializes smartwatch to JSON', () {
+      const dto = MulticastDto(
+        alias: 'Galaxy Watch',
+        version: '2.0',
+        deviceModel: 'Samsung',
+        deviceType: DeviceType.smartwatch,
+        fingerprint: 'fp-1',
+        port: 53317,
+        protocol: ProtocolType.https,
+        download: false,
+        announcement: null,
+        announce: true,
+      );
+
+      expect(dto.toJson()['deviceType'], 'smartwatch');
+    });
+
+    test('converts to Device with smartwatch type', () {
+      const dto = MulticastDto(
+        alias: 'Galaxy Watch',
+        version: '2.0',
+        deviceModel: 'Samsung',
+        deviceType: DeviceType.smartwatch,
+        fingerprint: 'fp-1',
+        port: 53317,
+        protocol: ProtocolType.https,
+        download: false,
+        announcement: null,
+        announce: true,
+      );
+
+      final device = dto.toDevice('192.168.1.10', 53317, true);
+      expect(device.deviceType, DeviceType.smartwatch);
+      expect(device.alias, 'Galaxy Watch');
+    });
+  });
+
+  group('RegisterDto smartwatch', () {
+    test('round-trips smartwatch through JSON', () {
+      const dto = RegisterDto(
+        alias: 'Pixel Watch',
+        version: '2.0',
+        deviceModel: 'Google',
+        deviceType: DeviceType.smartwatch,
+        fingerprint: 'fp-2',
+        port: 53317,
+        protocol: ProtocolType.https,
+        download: false,
+      );
+
+      final json = dto.toJson();
+      expect(json['deviceType'], 'smartwatch');
+
+      final parsed = RegisterDto.fromJson(json);
+      expect(parsed.deviceType, DeviceType.smartwatch);
+    });
+
+    test('converts to Device with smartwatch type', () {
+      const dto = RegisterDto(
+        alias: 'Pixel Watch',
+        version: '2.0',
+        deviceModel: 'Google',
+        deviceType: DeviceType.smartwatch,
+        fingerprint: 'fp-2',
+        port: 53317,
+        protocol: ProtocolType.https,
+        download: false,
+      );
+
+      final device = dto.toDevice('10.0.0.5', 53317, true, const HttpDiscovery(ip: '10.0.0.5'));
+      expect(device.deviceType, DeviceType.smartwatch);
+    });
+  });
+
+  group('InfoRegisterDto smartwatch', () {
+    test('parses smartwatch from JSON', () {
+      final parsed = InfoRegisterDto.fromJson({
+        'alias': 'Apple Watch',
+        'version': '2.0',
+        'deviceModel': 'Apple',
+        'deviceType': 'smartwatch',
+        'fingerprint': 'fp-3',
+        'port': 53317,
+        'protocol': 'https',
+        'download': false,
+      });
+
+      expect(parsed.deviceType, DeviceType.smartwatch);
+    });
+  });
+}

--- a/core/src/http/dto_v2.rs
+++ b/core/src/http/dto_v2.rs
@@ -233,6 +233,42 @@ mod tests {
     }
 
     #[test]
+    fn test_register_dto_v2_smartwatch_deserialization() {
+        let json = r#"{
+            "alias": "Galaxy Watch",
+            "version": "2.0",
+            "deviceModel": "Samsung",
+            "deviceType": "SMARTWATCH",
+            "fingerprint": "random string",
+            "port": 53317,
+            "protocol": "https",
+            "download": false
+        }"#;
+
+        let dto: RegisterDtoV2 = serde_json::from_str(json).unwrap();
+        assert_eq!(dto.alias, "Galaxy Watch");
+        assert_eq!(dto.device_type, Some(DeviceType::Smartwatch));
+    }
+
+    #[test]
+    fn test_multicast_message_smartwatch_serialization() {
+        let msg = MulticastMessageV2 {
+            alias: "Pixel Watch".to_string(),
+            version: "2.1".to_string(),
+            device_model: Some("Google".to_string()),
+            device_type: Some(DeviceType::Smartwatch),
+            fingerprint: "random string".to_string(),
+            port: 53317,
+            protocol: ProtocolTypeV2::Https,
+            download: false,
+            announce: true,
+        };
+
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"deviceType\":\"SMARTWATCH\""));
+    }
+
+    #[test]
     fn test_register_dto_v2_deserialization() {
         let json = r#"{
             "alias": "Secret Banana",

--- a/core/src/model/discovery.rs
+++ b/core/src/model/discovery.rs
@@ -8,4 +8,5 @@ pub enum DeviceType {
     Web,
     Headless,
     Server,
+    Smartwatch,
 }


### PR DESCRIPTION
## Summary

Adds first-class smartwatch support to LocalSend by introducing a new `DeviceType.smartwatch` across the Dart/Rust protocol stack, with Wear OS auto-detection and basic platform integration.

- Add `smartwatch` to `DeviceType` in Dart (`common`), Rust core (`core`), and Flutter–Rust bridge (`app/rust`)
- Auto-detect Wear OS devices via `android.hardware.type.watch` and report as `smartwatch` instead of `mobile`
- Add `watchProvider` (mirrors existing `tvProvider` pattern) and wire it into app startup
- Use dialog-based text input on watches via `TextFieldTv` (same UX as Android TV)
- Add Wear OS manifest entries (optional watch feature + wearable launcher category)
- Add unit tests for protocol serialization and DTO round-trips

## Wire format

| Layer | Value |
|-------|-------|
| Dart JSON | `"deviceType": "smartwatch"` |
| Rust JSON | `"deviceType": "SMARTWATCH"` |
| FRB ordinal | `5` |

## Backward compatibility

Older LocalSend clients that don't know `smartwatch` will fall back to `desktop` when receiving this device type (existing dart_mappable default behavior).

## Test plan

- [x] `cd common && dart test` — 18/18 passed (includes 9 smartwatch-specific tests)
- [ ] `cd app && flutter test` — requires Dart SDK ^3.9.0
- [ ] `cd core && cargo test` — verify `SMARTWATCH` serde tests
- [ ] Wear OS emulator: app launches, settings text fields use dialog input
- [ ] Discovery: watch appears on another device's send tab with watch icon
- [ ] Settings: manually select smartwatch in advanced settings, confirm persistence after restart
- [ ] Cross-version: new watch ↔ older desktop/mobile clients can discover each other

## Out of scope

- Dedicated watchOS app / Apple Watch target (no watchOS target in this repo)
- Watch-optimized UI layout (only text-input adaptation via `TextFieldTv`)
- Separate `tv` device type (Android TV still reports as `mobile`, unchanged)