### PR TITLE
fix(macos): restore menubar icon after Control Center removal

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -9,6 +9,8 @@ import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/pages/home_page.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/util/native/macos_channel.dart';
+import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/ui/dynamic_colors.dart';
 import 'package:localsend_app/widget/watcher/life_cycle_watcher.dart';
 import 'package:localsend_app/widget/watcher/shortcut_watcher.dart';
@@ -54,6 +56,10 @@ class LocalSendApp extends StatelessWidget {
             switch (state) {
               case AppLifecycleState.resumed:
                 ref.redux(localIpProvider).dispatch(InitLocalIpAction());
+                if (checkPlatform([TargetPlatform.macOS])) {
+                  // ignore: discarded_futures
+                  ensureStatusBarVisible();
+                }
                 break;
               case AppLifecycleState.detached:
                 // The main isolate is only exited when all child isolates are exited.

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -1,12 +1,15 @@
 import 'package:collection/collection.dart';
 import 'package:common/isolate.dart';
 import 'package:common/model/device.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/model/send_mode.dart';
 import 'package:localsend_app/model/state/settings_state.dart';
 import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:localsend_app/util/native/macos_channel.dart';
+import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 
 final _listEq = const ListEquality().equals;
@@ -196,6 +199,9 @@ class SettingsService extends PureNotifier<SettingsState> {
     state = state.copyWith(
       minimizeToTray: minimizeToTray,
     );
+    if (checkPlatform([TargetPlatform.macOS])) {
+      await setupStatusBar();
+    }
   }
 
   Future<void> setHttps(bool https) async {

--- a/app/lib/util/native/macos_channel.dart
+++ b/app/lib/util/native/macos_channel.dart
@@ -14,6 +14,11 @@ Future<void> setupStatusBar() async {
   });
 }
 
+/// Re-creates the menu bar icon if macOS Control Center hid it.
+Future<bool> ensureStatusBarVisible() async {
+  return await _methodChannel.invokeMethod('ensureStatusBarVisible') ?? false;
+}
+
 Future<void> removeExistingDestinationAccess() async {
   await _methodChannel.invokeMethod('removeExistingDestinationAccess');
 }

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -18,6 +18,9 @@ class AppDelegate: FlutterAppDelegate {
     private var pendingFilesObservation: Defaults.Observation?
     private var pendingStringsObservation: Defaults.Observation?
     private var isLaunchedAsLoginItem: Bool?
+    private var statusBarI18n: [String: String]?
+    private var statusBarRecreateAttempted = false
+    private static let statusItemAutosaveName = "org.localsend.localsend_app.status-item"
     
     override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
         return true
@@ -47,6 +50,10 @@ class AppDelegate: FlutterAppDelegate {
         showLocalSendFromMenuBar()
         return false
     }
+
+    override func applicationDidBecomeActive(_ notification: Notification) {
+        ensureStatusBarVisible()
+    }
     
     private func setupPendingItemsObservation() {
         self.pendingFilesObservation = Defaults.observe(.pendingFiles) { change in
@@ -71,36 +78,105 @@ class AppDelegate: FlutterAppDelegate {
         }
     }
     
-    private func setupStatusBarItem(i18n: [String: String]) {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        if let button = statusItem?.button {
-            let image = NSImage(named: "StatusBarItemIcon")
-            image!.size = NSSize(width: 18, height: 18)
-            image!.isTemplate = true
-            button.image = image
-            
-            let menu = NSMenu()
-            
-            let openString = i18n["open"]!
-            let openItem = NSMenuItem(title: openString, action: #selector(showLocalSendFromMenuBar), keyEquivalent: "o")
-            menu.addItem(openItem)
-            
-            let quitString = i18n["quit"]!
-            let quitItem = NSMenuItem(title: quitString, action: #selector(quitApp), keyEquivalent: "q")
-            menu.addItem(quitItem)
-            
-            statusItem?.menu = menu
-            
-            let dragView = ContentDropView(frame: button.bounds)
-            button.addSubview(dragView)
-            
-            dragView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                dragView.topAnchor.constraint(equalTo: button.topAnchor),
-                dragView.leadingAnchor.constraint(equalTo: button.leadingAnchor),
-                dragView.trailingAnchor.constraint(equalTo: button.trailingAnchor),
-                dragView.bottomAnchor.constraint(equalTo: button.bottomAnchor)
-            ])
+    private func removeStatusBarItem() {
+        if let item = statusItem {
+            NSStatusBar.system.removeStatusItem(item)
+            statusItem = nil
+        }
+    }
+
+    private func configureStatusBarButton(_ button: NSStatusBarButton, i18n: [String: String]) {
+        let image = NSImage(named: "StatusBarItemIcon")
+        image!.size = NSSize(width: 18, height: 18)
+        image!.isTemplate = true
+        button.image = image
+
+        let menu = NSMenu()
+
+        let openString = i18n["open"]!
+        let openItem = NSMenuItem(title: openString, action: #selector(showLocalSendFromMenuBar), keyEquivalent: "o")
+        menu.addItem(openItem)
+
+        let quitString = i18n["quit"]!
+        let quitItem = NSMenuItem(title: quitString, action: #selector(quitApp), keyEquivalent: "q")
+        menu.addItem(quitItem)
+
+        statusItem?.menu = menu
+
+        button.subviews.forEach { $0.removeFromSuperview() }
+
+        let dragView = ContentDropView(frame: button.bounds)
+        button.addSubview(dragView)
+
+        dragView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dragView.topAnchor.constraint(equalTo: button.topAnchor),
+            dragView.leadingAnchor.constraint(equalTo: button.leadingAnchor),
+            dragView.trailingAnchor.constraint(equalTo: button.trailingAnchor),
+            dragView.bottomAnchor.constraint(equalTo: button.bottomAnchor)
+        ])
+    }
+
+    private func setupStatusBarItem(i18n: [String: String], forceNewIdentity: Bool = false) {
+        statusBarI18n = i18n
+        removeStatusBarItem()
+
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        if forceNewIdentity {
+            item.autosaveName = NSStatusItem.AutoSaveName("\(Self.statusItemAutosaveName).\(UUID().uuidString)")
+        } else {
+            item.autosaveName = NSStatusItem.AutoSaveName(Self.statusItemAutosaveName)
+        }
+        item.isVisible = true
+        statusItem = item
+
+        if let button = item.button {
+            configureStatusBarButton(button, i18n: i18n)
+        }
+
+        scheduleStatusBarVisibilityCheck()
+    }
+
+    private func scheduleStatusBarVisibilityCheck() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.ensureStatusBarVisible()
+        }
+    }
+
+    private func isStatusBarItemActuallyVisible() -> Bool {
+        guard let item = statusItem, item.isVisible else { return false }
+        guard let button = item.button else { return false }
+
+        // On macOS Tahoe, Control Center may keep isVisible=true while placing the item off-screen.
+        if let window = button.window {
+            if window.screen == nil {
+                return false
+            }
+            if window.frame.origin.y < 0 {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private func ensureStatusBarVisible() {
+        guard let i18n = statusBarI18n else { return }
+
+        if statusItem == nil {
+            setupStatusBarItem(i18n: i18n)
+            return
+        }
+
+        if isStatusBarItemActuallyVisible() {
+            return
+        }
+
+        // macOS Control Center can hide removed menu bar items until they are recreated.
+        // Try once with a fresh autosave identity before giving up.
+        if !statusBarRecreateAttempted {
+            statusBarRecreateAttempted = true
+            setupStatusBarItem(i18n: i18n, forceNewIdentity: true)
         }
     }
     
@@ -145,8 +221,12 @@ class AppDelegate: FlutterAppDelegate {
             result(nil)
         case "setupStatusBar":
             let i18n = call.arguments as! [String: String]
+            statusBarRecreateAttempted = false
             setupStatusBarItem(i18n: i18n)
             result(nil)
+        case "ensureStatusBarVisible":
+            ensureStatusBarVisible()
+            result(isStatusBarItemActuallyVisible())
         case "removeDestinationFolderAccess":
             removeExistingDestinationAccess()
             result(nil)


### PR DESCRIPTION
## Summary
Fixes menubar icon not returning after removing LocalSend from the macOS Tahoe Control Center menu bar.

- Remove and recreate NSStatusItem instead of leaking stale references
- Detect off-screen status items (Control Center can hide while isVisible=true)
- Re-ensure visibility on app resume and when tray setting is toggled
- Add autosaveName for Control Center persistence

## Reproduction (before fix)
1. Control Center → Edit Controls → drag LocalSend out of menubar
2. Quit and restart app (or toggle tray setting)
3. Icon never returns

## Test plan
- [ ] Remove menubar icon via Control Center, restart app → icon returns
- [ ] Remove icon, toggle "Minimize to Tray" off/on → icon returns
- [ ] Bring app to foreground after removal → icon returns
- [ ] Normal menubar open/quit menu still works
- [ ] Drag-and-drop onto menubar icon still works