### PR TITLE
feat: add copy-image-to-clipboard option for received images

### DIFF
--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -191,7 +191,8 @@
       "open": "Open file",
       "showInFolder": "Show in folder",
       "info": "Information",
-      "deleteFromHistory": "Delete from history"
+      "deleteFromHistory": "Delete from history",
+      "copy": "Copy image to clipboard"
     }
   },
   "apkPickerPage": {

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -1218,6 +1218,9 @@ class TranslationsReceiveHistoryPageEntryActionsEn {
 
   /// en: 'Delete from history'
   String get deleteFromHistory => 'Delete from history';
+
+  /// en: 'Copy image to clipboard'
+  String get copy => 'Copy image to clipboard';
 }
 
 // Path: progressPage.total

--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -437,7 +437,7 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                             tooltip: t.general.copy,
                             onPressed: () async {
                               final ok = await copyImageToClipboard(filePath!);
-                              if (ok && mounted) {
+                              if (ok && context.mounted) {
                                 context.showSnackBar(t.general.copiedToClipboard);
                               }
                             },

--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:common/model/dto/file_dto.dart';
 import 'package:common/model/file_status.dart';
+import 'package:common/model/file_type.dart';
 import 'package:common/model/session_status.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -16,11 +17,13 @@ import 'package:localsend_app/provider/progress_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/file_size_helper.dart';
 import 'package:localsend_app/util/file_speed_helper.dart';
+import 'package:localsend_app/util/native/clipboard.dart';
 import 'package:localsend_app/util/native/open_file.dart';
 import 'package:localsend_app/util/native/open_folder.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/taskbar_helper.dart';
 import 'package:localsend_app/util/ui/nav_bar_padding.dart';
+import 'package:localsend_app/util/ui/snackbar.dart';
 import 'package:localsend_app/widget/custom_basic_appbar.dart';
 import 'package:localsend_app/widget/custom_progress_bar.dart';
 import 'package:localsend_app/widget/dialogs/cancel_session_dialog.dart';
@@ -422,6 +425,21 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                                     file: sendSession.files[file.id]!,
                                     isRetry: true,
                                   );
+                            },
+                          ),
+                        if (filePath != null &&
+                            file.fileType == FileType.image &&
+                            fileStatus == FileStatus.finished &&
+                            receiveSession != null &&
+                            checkPlatformIsDesktop())
+                          IconButton(
+                            icon: const Icon(Icons.copy),
+                            tooltip: t.general.copy,
+                            onPressed: () async {
+                              final ok = await copyImageToClipboard(filePath!);
+                              if (ok && mounted) {
+                                context.showSnackBar(t.general.copiedToClipboard);
+                              }
                             },
                           ),
                       ],

--- a/app/lib/pages/receive_history_page.dart
+++ b/app/lib/pages/receive_history_page.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:common/model/device.dart';
+import 'package:common/model/file_type.dart';
 import 'package:common/model/session_status.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/config/theme.dart';
@@ -10,10 +11,12 @@ import 'package:localsend_app/pages/receive_page.dart';
 import 'package:localsend_app/provider/receive_history_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/file_size_helper.dart';
+import 'package:localsend_app/util/native/clipboard.dart';
 import 'package:localsend_app/util/native/directories.dart';
 import 'package:localsend_app/util/native/open_file.dart';
 import 'package:localsend_app/util/native/open_folder.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
+import 'package:localsend_app/util/ui/snackbar.dart';
 import 'package:localsend_app/widget/custom_basic_appbar.dart';
 import 'package:localsend_app/widget/dialogs/file_info_dialog.dart';
 import 'package:localsend_app/widget/dialogs/history_clear_dialog.dart';
@@ -27,7 +30,8 @@ enum _EntryOption {
   open,
   showInFolder,
   info,
-  delete;
+  delete,
+  copy;
 
   String get label {
     return switch (this) {
@@ -35,12 +39,28 @@ enum _EntryOption {
       _EntryOption.showInFolder => t.receiveHistoryPage.entryActions.showInFolder,
       _EntryOption.info => t.receiveHistoryPage.entryActions.info,
       _EntryOption.delete => t.receiveHistoryPage.entryActions.deleteFromHistory,
+      _EntryOption.copy => t.receiveHistoryPage.entryActions.copy,
     };
   }
 }
 
-const _optionsAll = _EntryOption.values;
-final _optionsWithoutOpen = [_EntryOption.info, _EntryOption.delete];
+List<_EntryOption> _optionsFor(ReceiveHistoryEntry entry, bool isDesktop) {
+  if (entry.path == null) {
+    return const [_EntryOption.info, _EntryOption.delete];
+  }
+  final canCopy = canCopyImageToClipboard(
+    path: entry.path,
+    fileType: entry.fileType,
+    isDesktop: isDesktop,
+  );
+  return [
+    _EntryOption.open,
+    _EntryOption.showInFolder,
+    if (canCopy) _EntryOption.copy,
+    _EntryOption.info,
+    _EntryOption.delete,
+  ];
+}
 
 class ReceiveHistoryPage extends StatelessWidget {
   const ReceiveHistoryPage({super.key});
@@ -63,6 +83,7 @@ class ReceiveHistoryPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final entries = context.watch(receiveHistoryProvider);
+    final isDesktop = checkPlatformIsDesktop();
     return Scaffold(
       appBar: basicLocalSendAppbar(t.receiveHistoryPage.title),
       body: ResponsiveListView(
@@ -219,10 +240,16 @@ class ReceiveHistoryPage extends StatelessWidget {
                               // ignore: use_build_context_synchronously
                               await context.redux(receiveHistoryProvider).dispatchAsync(RemoveHistoryEntryAction(entry.id));
                               break;
+                            case _EntryOption.copy:
+                              final ok = await copyImageToClipboard(entry.path!);
+                              if (ok) {
+                                context.showSnackBar(t.general.copiedToClipboard);
+                              }
+                              break;
                           }
                         },
                         itemBuilder: (BuildContext context) {
-                          return (entry.path != null ? _optionsAll : _optionsWithoutOpen).map((e) {
+                          return _optionsFor(entry, isDesktop).map((e) {
                             return PopupMenuItem<_EntryOption>(
                               value: e,
                               child: Text(e.label),

--- a/app/lib/pages/receive_history_page.dart
+++ b/app/lib/pages/receive_history_page.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:common/model/device.dart';
-import 'package:common/model/file_type.dart';
 import 'package:common/model/session_status.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/config/theme.dart';
@@ -243,6 +242,7 @@ class ReceiveHistoryPage extends StatelessWidget {
                             case _EntryOption.copy:
                               final ok = await copyImageToClipboard(entry.path!);
                               if (ok) {
+                                // ignore: use_build_context_synchronously
                                 context.showSnackBar(t.general.copiedToClipboard);
                               }
                               break;

--- a/app/lib/util/native/clipboard.dart
+++ b/app/lib/util/native/clipboard.dart
@@ -1,0 +1,21 @@
+import 'package:common/model/file_type.dart';
+import 'package:pasteboard/pasteboard.dart';
+
+bool canCopyImageToClipboard({
+  required String? path,
+  required FileType fileType,
+  required bool isDesktop,
+}) {
+  if (!isDesktop) return false;
+  if (path == null || path.isEmpty) return false;
+  return fileType == FileType.image;
+}
+
+Future<bool> copyImageToClipboard(String filePath) async {
+  try {
+    await Pasteboard.writeFiles([filePath]);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/app/test/unit/util/native/clipboard_test.dart
+++ b/app/test/unit/util/native/clipboard_test.dart
@@ -1,0 +1,65 @@
+import 'package:common/model/file_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localsend_app/util/native/clipboard.dart';
+
+void main() {
+  group('canCopyImageToClipboard', () {
+    test('desktop + image + path → true', () {
+      expect(
+        canCopyImageToClipboard(
+          path: '/tmp/photo.png',
+          fileType: FileType.image,
+          isDesktop: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('mobile + image + path → false', () {
+      expect(
+        canCopyImageToClipboard(
+          path: '/tmp/photo.png',
+          fileType: FileType.image,
+          isDesktop: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('desktop + non‑image + path → false', () {
+      for (final type in [FileType.video, FileType.pdf, FileType.text, FileType.apk, FileType.other]) {
+        expect(
+          canCopyImageToClipboard(
+            path: '/tmp/file',
+            fileType: type,
+            isDesktop: true,
+          ),
+          isFalse,
+          reason: '$type must not match',
+        );
+      }
+    });
+
+    test('desktop + image + null path → false', () {
+      expect(
+        canCopyImageToClipboard(
+          path: null,
+          fileType: FileType.image,
+          isDesktop: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('desktop + image + empty path → false', () {
+      expect(
+        canCopyImageToClipboard(
+          path: '',
+          fileType: FileType.image,
+          isDesktop: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/app/test/unit/util/native/clipboard_test.dart
+++ b/app/test/unit/util/native/clipboard_test.dart
@@ -1,6 +1,6 @@
 import 'package:common/model/file_type.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:localsend_app/util/native/clipboard.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('canCopyImageToClipboard', () {


### PR DESCRIPTION
## Summary
- Add a copy-to-clipboard icon button on the receive progress page for completed images
- Add a "Copy image to clipboard" entry in the receive history page popup menu
- Both gated to desktop platforms + image file type + non-null file path only

## Changes
- New `app/lib/util/native/clipboard.dart` — `canCopyImageToClipboard()` predicate + `copyImageToClipboard()` async util wrapping `Pasteboard.writeFiles` (already a dependency)
- New `app/test/unit/util/native/clipboard_test.dart` — unit tests for the pure predicate
- `app/assets/i18n/en.json` — added `receiveHistoryPage.entryActions.copy` key
- `app/lib/gen/strings_en.g.dart` — regenerated getter for the new key
- `app/lib/pages/progress_page.dart` — copy IconButton in file row when image is finished
- `app/lib/pages/receive_history_page.dart` — copy entry in popup menu for image history entries

## Test plan
- [x] Unit tests for visibility predicate (5 cases)
- [ ] Manual: receive an image on desktop → tap copy icon → paste into another app
- [ ] Manual: open receive history → right-click an image entry → Copy image to clipboard

Closes #3105