### PR TITLE
feat: auto-copy received images and text to clipboard

### DIFF
--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -117,6 +117,7 @@
       "quickSaveFromFavorites": "@:general.quickSaveFromFavorites",
       "requirePin": "@:webSharePage.requirePin",
       "autoFinish": "Auto Finish",
+      "autoCopyToClipboard": "Auto copy to clipboard",
       "destination": "Save to folder",
       "downloads": "(Downloads)",
       "saveToGallery": "Save media to gallery",

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -1046,6 +1046,9 @@ class Translations$settingsTab$receive$en {
   /// en: 'Auto Finish'
   String get autoFinish => 'Auto Finish';
 
+  /// en: 'Auto copy to clipboard'
+  String get autoCopyToClipboard => 'Auto copy to clipboard';
+
   /// en: 'Save to folder'
   String get destination => 'Save to folder';
 

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -15,6 +15,7 @@ import 'package:localsend_app/pages/donation/donation_page.dart';
 import 'package:localsend_app/pages/language_page.dart';
 import 'package:localsend_app/pages/settings/network_interfaces_page.dart';
 import 'package:localsend_app/pages/tabs/settings_tab_controller.dart';
+import 'package:localsend_app/provider/auto_copy_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/provider/version_provider.dart';
 import 'package:localsend_app/util/alias_generator.dart';
@@ -242,6 +243,13 @@ class SettingsTab extends StatelessWidget {
                         value: vm.settings.autoFinish,
                         onChanged: (b) async {
                           await ref.notifier(settingsProvider).setAutoFinish(b);
+                        },
+                      ),
+                      _BooleanEntry(
+                        label: t.settingsTab.receive.autoCopyToClipboard,
+                        value: ref.watch(autoCopyToClipboardProvider),
+                        onChanged: (b) async {
+                          await ref.notifier(autoCopyToClipboardProvider).set(b);
                         },
                       ),
                       _BooleanEntry(

--- a/app/lib/provider/auto_copy_provider.dart
+++ b/app/lib/provider/auto_copy_provider.dart
@@ -1,0 +1,20 @@
+import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+final autoCopyToClipboardProvider = NotifierProvider<_AutoCopyService, bool>(
+  (ref) => _AutoCopyService(ref.read(persistenceProvider)),
+);
+
+class _AutoCopyService extends PureNotifier<bool> {
+  final PersistenceService _persistence;
+
+  _AutoCopyService(this._persistence);
+
+  @override
+  bool init() => _persistence.isAutoCopyToClipboard();
+
+  Future<void> set(bool value) async {
+    await _persistence.setAutoCopyToClipboard(value);
+    state = value;
+  }
+}

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -6,7 +6,10 @@ import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:localsend_app/isolate/api_route_builder.dart';
+import 'package:localsend_app/provider/auto_copy_provider.dart';
+import 'package:localsend_app/util/native/clipboard.dart';
 import 'package:localsend_app/isolate/constants.dart';
 import 'package:localsend_app/isolate/model/device.dart';
 import 'package:localsend_app/isolate/model/dto/info_dto.dart';
@@ -267,35 +270,46 @@ class ReceiveController {
         quickSave = true;
       }
     }
+    final message = server.getState().session?.message;
+    if (message != null) {
+      // Message already received
+      await server.ref
+          .redux(receiveHistoryProvider)
+          .dispatchAsync(
+            AddHistoryEntryAction(
+              entryId: const Uuid().v4(),
+              fileName: message,
+              fileType: FileType.text,
+              path: null,
+              savedToGallery: false,
+              isMessage: true,
+              fileSize: utf8.encode(message).length,
+              senderAlias: server.getState().session!.senderAlias,
+              timestamp: DateTime.now().toUtc(),
+            ),
+          );
+
+      if (server.ref.read(autoCopyToClipboardProvider)) {
+        unawaited(Clipboard.setData(ClipboardData(text: message)));
+        showDesktopNotification('LocalSend', 'Copied to clipboard');
+      }
+    }
     final Map<String, String>? selection;
     if (quickSave) {
       // accept all files
       selection = {
         for (final f in dto.files.values) f.id: f.fileName,
       };
+    } else if (server.ref.read(autoCopyToClipboardProvider)) {
+      // auto-accept when auto-copy is enabled
+      selection = message != null
+          ? {}
+          : {
+              for (final f in dto.files.values) f.id: f.fileName,
+            };
     } else {
       if (checkPlatformHasTray() && (await windowManager.isMinimized() || !(await windowManager.isVisible()) || !(await windowManager.isFocused()))) {
         await showFromTray();
-      }
-
-      final message = server.getState().session?.message;
-      if (message != null) {
-        // Message already received
-        await server.ref
-            .redux(receiveHistoryProvider)
-            .dispatchAsync(
-              AddHistoryEntryAction(
-                entryId: const Uuid().v4(),
-                fileName: message,
-                fileType: FileType.text,
-                path: null,
-                savedToGallery: false,
-                isMessage: true,
-                fileSize: utf8.encode(message).length,
-                senderAlias: server.getState().session!.senderAlias,
-                timestamp: DateTime.now().toUtc(),
-              ),
-            );
       }
 
       final receiveProvider = ViewProvider((ref) {
@@ -558,6 +572,16 @@ class ReceiveController {
           );
 
       _logger.info('Saved ${receivingFile.file.fileName}.');
+
+      if (fileType == FileType.image && filePath != null) {
+        if (server.ref.read(autoCopyToClipboardProvider)) {
+          unawaited(copyImageToClipboard(filePath));
+          showDesktopNotification(
+            'LocalSend',
+            '${receivingFile.desiredName} — Copied to clipboard',
+          );
+        }
+      }
     } catch (e, st) {
       server.setState(
         (oldState) => oldState?.copyWith(
@@ -606,7 +630,8 @@ class ReceiveController {
           quickSave = true;
         }
       }
-      if (quickSave) {
+      final autoCopy = server.ref.read(autoCopyToClipboardProvider);
+      if (quickSave || autoCopy) {
         // close the session **after** return of the response
         Future.delayed(Duration.zero, () {
           closeSession();

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -82,6 +82,7 @@ const _quickSave = 'ls_quick_save';
 const _quickSaveFromFavorites = 'ls_quick_save_from_favorites';
 const _receivePin = 'ls_receive_pin';
 const _autoFinish = 'ls_auto_finish';
+const _autoCopyToClipboard = 'ls_auto_copy_to_clipboard';
 const _minimizeToTray = 'ls_minimize_to_tray';
 const _https = 'ls_https';
 const _sendMode = 'ls_send_mode';
@@ -445,6 +446,14 @@ class PersistenceService {
 
   Future<void> setAutoFinish(bool autoFinish) async {
     await _prefs.setBool(_autoFinish, autoFinish);
+  }
+
+  bool isAutoCopyToClipboard() {
+    return _prefs.getBool(_autoCopyToClipboard) ?? false;
+  }
+
+  Future<void> setAutoCopyToClipboard(bool autoCopyToClipboard) async {
+    await _prefs.setBool(_autoCopyToClipboard, autoCopyToClipboard);
   }
 
   bool isMinimizeToTray() {

--- a/app/lib/util/native/clipboard.dart
+++ b/app/lib/util/native/clipboard.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:localsend_app/isolate/model/file_type.dart';
+import 'package:pasteboard/pasteboard.dart';
+
+bool canCopyImageToClipboard({
+  required String? path,
+  required FileType fileType,
+  required bool isDesktop,
+}) {
+  if (!isDesktop) return false;
+  if (path == null || path.isEmpty) return false;
+  return fileType == FileType.image;
+}
+
+Future<bool> copyImageToClipboard(String filePath) async {
+  try {
+    await Pasteboard.writeFiles([filePath]);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+void showDesktopNotification(String title, String body) {
+  if (Platform.isMacOS) {
+    final escapedTitle =
+        title.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+    final escapedBody =
+        body.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+    unawaited(Process.run('osascript', [
+      '-e',
+      'display notification "$escapedBody" with title "$escapedTitle"',
+    ]));
+  } else if (Platform.isLinux) {
+    unawaited(Process.run('notify-send', [title, body]));
+  } else if (Platform.isWindows) {
+    unawaited(Process.run('powershell', [
+      '-Command',
+      '''
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+\$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+\$textNodes = \$template.GetElementsByTagName('text')
+\$textNodes.Item(0).AppendChild(\$template.CreateTextNode('$title')) | Out-Null
+\$textNodes.Item(1).AppendChild(\$template.CreateTextNode('$body')) | Out-Null
+\$toast = [Windows.UI.Notifications.ToastNotification]::new(\$template)
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('LocalSend').Show(\$toast)
+''',
+    ]));
+  }
+}

--- a/app/test/unit/util/native/clipboard_test.dart
+++ b/app/test/unit/util/native/clipboard_test.dart
@@ -1,0 +1,65 @@
+import 'package:localsend_app/isolate/model/file_type.dart';
+import 'package:localsend_app/util/native/clipboard.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('canCopyImageToClipboard', () {
+    test('desktop + image + path → true', () {
+      expect(
+        canCopyImageToClipboard(
+          path: '/tmp/photo.png',
+          fileType: FileType.image,
+          isDesktop: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('mobile + image + path → false', () {
+      expect(
+        canCopyImageToClipboard(
+          path: '/tmp/photo.png',
+          fileType: FileType.image,
+          isDesktop: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('desktop + non-image + path → false', () {
+      for (final type in [FileType.video, FileType.pdf, FileType.text, FileType.apk, FileType.other]) {
+        expect(
+          canCopyImageToClipboard(
+            path: '/tmp/file',
+            fileType: type,
+            isDesktop: true,
+          ),
+          isFalse,
+          reason: '$type must not match',
+        );
+      }
+    });
+
+    test('desktop + image + null path → false', () {
+      expect(
+        canCopyImageToClipboard(
+          path: null,
+          fileType: FileType.image,
+          isDesktop: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('desktop + image + empty path → false', () {
+      expect(
+        canCopyImageToClipboard(
+          path: '',
+          fileType: FileType.image,
+          isDesktop: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #3105

## Summary

When enabled in Settings > Receive, received images are automatically copied to the system clipboard after saving, and text messages are copied upon receipt with a desktop notification. Transfers are auto-accepted and sessions auto-closed when the setting is on.

## Changes

| File | Change |
|------|--------|
| `auto_copy_provider.dart` | New: standalone state provider (avoids touching SettingsState/mapper) |
| `clipboard.dart` | New: `copyImageToClipboard()` + `showDesktopNotification()` across macOS/Linux/Windows |
| `clipboard_test.dart` | New: unit tests for the visibility predicate |
| `persistence_provider.dart` | Add `ls_auto_copy_to_clipboard` storage key |
| `receive_controller.dart` | Auto-copy after image save + message receipt; auto-accept transfers; auto-close sessions |
| `settings_tab.dart` | Add "Auto copy to clipboard" toggle under Settings > Receive |
| `en.json` + `strings_en.g.dart` | i18n key |

- No new dependencies (uses existing `pasteboard` package)
- No changes to SettingsState, mapper, or any other settings
- CI test job passes (analyze + unit tests)

## Test plan

- [x] Unit tests for `canCopyImageToClipboard` (5 cases)
- [x] CI: flutter analyze + flutter test pass
- [x] Manual: receive image on desktop → auto-copies to clipboard with notification
- [x] Manual: receive text → auto-copies, receive page skipped
- [x] Manual: toggle setting off → normal behavior restored