### PR TITLE
Fix mutually exclusive Quick Save settings

### DIFF
--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -165,6 +165,7 @@ class SettingsTab extends StatelessWidget {
                       ),
                       _BooleanEntry(
                         label: t.settingsTab.receive.quickSaveFromFavorites,
+                        enabled: !vm.settings.quickSave,
                         value: vm.settings.quickSaveFromFavorites,
                         onChanged: (b) async {
                           final old = vm.settings.quickSaveFromFavorites;
@@ -636,12 +637,14 @@ class _SettingsEntry extends StatelessWidget {
 class _BooleanEntry extends StatelessWidget {
   final String label;
   final bool value;
+  final bool enabled;
   final ValueChanged<bool> onChanged;
 
   const _BooleanEntry({
     required this.label,
     required this.value,
     required this.onChanged,
+    this.enabled = true,
   });
 
   @override
@@ -663,7 +666,7 @@ class _BooleanEntry extends StatelessWidget {
             child: Center(
               child: Switch(
                 value: value,
-                onChanged: onChanged,
+                onChanged: enabled ? onChanged : null,
                 activeTrackColor: theme.colorScheme.primary,
                 activeThumbColor: theme.colorScheme.onPrimary,
                 inactiveThumbColor: theme.colorScheme.outline,

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -165,8 +165,12 @@ class SettingsService extends PureNotifier<SettingsState> {
 
   Future<void> setQuickSave(bool quickSave) async {
     await _persistence.setQuickSave(quickSave);
+    if (quickSave) {
+      await _persistence.setQuickSaveFromFavorites(false);
+    }
     state = state.copyWith(
       quickSave: quickSave,
+      quickSaveFromFavorites: quickSave ? false : state.quickSaveFromFavorites,
     );
   }
 


### PR DESCRIPTION
Fixes #3163

## Summary

- This PR prevents the invalid state where both **Quick Save** and **Quick Save for "Favorites"** can be enabled simultaneously.
- Since **Quick Save** is a superset of **Quick Save for "Favorites"**, the two settings should be mutually exclusive.
- Enabling **Quick Save** now disables and clears **Quick Save for "Favorites"**, preventing a confusing and inconsistent configuration.

## Changes

- Added support for disabling `_BooleanEntry` controls.
- Disabled the **Quick Save for "Favorites"** toggle whenever **Quick Save** is enabled.
- Cleared the **Quick Save for "Favorites"** setting while **Quick Save** is enabled, preventing the invalid state from being persisted.

## Result

- The two Quick Save options are now mutually exclusive.
- The Receive page now correctly reflects the selected Quick Save mode.

## Screenshots

(both off - No Quick Save)
<img width="408" height="307" alt="screenshot_2026-07-06_02-27-19" src="https://github.com/user-attachments/assets/4b0fe9dc-7f7f-47c6-965d-d0605796c0d1" />

(only Quick Save for Favorites switched on)
<img width="411" height="310" alt="screenshot_2026-07-06_02-27-01" src="https://github.com/user-attachments/assets/e6b66165-f3fe-4f18-8ccc-fef86d754bbb" />

(Quick Save switched on - Quick Save for Favorites option disabled / greyed out)
<img width="410" height="309" alt="screenshot_2026-07-06_02-25-12" src="https://github.com/user-attachments/assets/9c7855fe-5a64-4374-a492-33e8e89f04c1" />
