### PR TITLE
fix: propagate alias changes to connected signaling servers

### DIFF
--- a/app/lib/provider/network/server/server_provider.dart
+++ b/app/lib/provider/network/server/server_provider.dart
@@ -6,12 +6,16 @@ import 'package:common/isolate.dart';
 import 'package:common/model/dto/multicast_dto.dart';
 import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/model/state/server/server_state.dart';
+import 'package:localsend_app/provider/device_info_provider.dart';
 import 'package:localsend_app/provider/network/server/controller/receive_controller.dart';
 import 'package:localsend_app/provider/network/server/controller/send_controller.dart';
 import 'package:localsend_app/provider/network/server/server_utils.dart';
+import 'package:localsend_app/provider/network/webrtc/signaling_provider.dart';
 import 'package:localsend_app/provider/security_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/rust/api/webrtc.dart';
 import 'package:localsend_app/util/alias_generator.dart';
+import 'package:localsend_app/util/rust.dart';
 import 'package:localsend_app/util/simple_server.dart';
 import 'package:logging/logging.dart';
 import 'package:refena_flutter/refena_flutter.dart';
@@ -53,6 +57,26 @@ final serverProvider = NotifierProvider<ServerService, ServerState?>(
             download: syncStateNext.$5,
           ),
         );
+
+    if (syncStateNext.$1.isNotEmpty && syncStatePrev.$1 != syncStateNext.$1) {
+      // Multicast and HTTP discovery pick up the new alias from the sync state above,
+      // but peers connected to a signaling server would keep seeing the old alias
+      // until the app restarts, so the new alias is pushed explicitly.
+      final deviceInfo = ref.read(deviceInfoProvider);
+      ref
+          .redux(signalingProvider)
+          // ignore: discarded_futures
+          .dispatchAsync(
+            UpdateClientInfoAction(
+              info: ProposingClientInfo(
+                alias: syncStateNext.$1,
+                version: protocolVersion,
+                deviceModel: deviceInfo.deviceModel,
+                deviceType: deviceInfo.deviceType.toRust(),
+              ),
+            ),
+          );
+    }
   },
 );
 

--- a/app/lib/provider/network/webrtc/signaling_provider.dart
+++ b/app/lib/provider/network/webrtc/signaling_provider.dart
@@ -14,9 +14,12 @@ import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/rust/api/crypto.dart' as crypto;
 import 'package:localsend_app/rust/api/model.dart' as rust;
 import 'package:localsend_app/rust/api/webrtc.dart';
+import 'package:logging/logging.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 
 part 'signaling_provider.mapper.dart';
+
+final _logger = Logger('Signaling');
 
 @MappableClass()
 class SignalingState with SignalingStateMappable {
@@ -162,6 +165,26 @@ class _SetupSignalingConnection extends AsyncGlobalAction {
       ref.redux(signalingProvider).dispatch(_RemoveConnectionAction(signalingServer: signalingServer));
     }
 
+    return state;
+  }
+}
+
+/// Sends the current client info to all connected signaling servers
+/// so that already connected peers are notified (e.g. when the alias changes).
+class UpdateClientInfoAction extends AsyncReduxAction<SignalingService, SignalingState> {
+  final ProposingClientInfo info;
+
+  UpdateClientInfoAction({required this.info});
+
+  @override
+  Future<SignalingState> reduce() async {
+    for (final entry in state.connections.entries) {
+      try {
+        await entry.value.updateInfo(info: info);
+      } catch (e) {
+        _logger.warning('Could not send client info to signaling server: ${entry.key}', e);
+      }
+    }
     return state;
   }
 }

--- a/app/lib/rust/api/webrtc.dart
+++ b/app/lib/rust/api/webrtc.dart
@@ -12,6 +12,7 @@ import 'package:uuid/uuid.dart';
 part 'webrtc.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `sign`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `ClientInfoWithoutId`
 
 Stream<WsServerMessage> connect({
   required String uri,
@@ -44,7 +45,7 @@ abstract class LsSignalingConnection implements RustOpaqueInterface {
     required List<FileDto> files,
   });
 
-  Future<void> updateInfo({required ClientInfoWithoutId info});
+  Future<void> updateInfo({required ProposingClientInfo info});
 }
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RTCFileReceiver>>
@@ -117,36 +118,6 @@ class ClientInfo {
       other is ClientInfo &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          alias == other.alias &&
-          version == other.version &&
-          deviceModel == other.deviceModel &&
-          deviceType == other.deviceType &&
-          token == other.token;
-}
-
-class ClientInfoWithoutId {
-  final String alias;
-  final String version;
-  final String? deviceModel;
-  final DeviceType? deviceType;
-  final String token;
-
-  const ClientInfoWithoutId({
-    required this.alias,
-    required this.version,
-    this.deviceModel,
-    this.deviceType,
-    required this.token,
-  });
-
-  @override
-  int get hashCode => alias.hashCode ^ version.hashCode ^ deviceModel.hashCode ^ deviceType.hashCode ^ token.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ClientInfoWithoutId &&
-          runtimeType == other.runtimeType &&
           alias == other.alias &&
           version == other.version &&
           deviceModel == other.deviceModel &&

--- a/app/lib/rust/frb_generated.dart
+++ b/app/lib/rust/frb_generated.dart
@@ -107,7 +107,7 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiWebrtcLsSignalingConnectionUpdateInfo({
     required LsSignalingConnection that,
-    required ClientInfoWithoutId info,
+    required ProposingClientInfo info,
   });
 
   Future<void> crateApiHttpRsHttpClientCancel({
@@ -467,7 +467,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @override
   Future<void> crateApiWebrtcLsSignalingConnectionUpdateInfo({
     required LsSignalingConnection that,
-    required ClientInfoWithoutId info,
+    required ProposingClientInfo info,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -477,7 +477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          sse_encode_box_autoadd_client_info_without_id(info, serializer);
+          sse_encode_box_autoadd_proposing_client_info(info, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1914,14 +1914,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  ClientInfoWithoutId dco_decode_box_autoadd_client_info_without_id(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_client_info_without_id(raw);
-  }
-
-  @protected
   DeviceType dco_decode_box_autoadd_device_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_device_type(raw);
@@ -2001,20 +1993,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       deviceModel: dco_decode_opt_String(arr[3]),
       deviceType: dco_decode_opt_box_autoadd_device_type(arr[4]),
       token: dco_decode_String(arr[5]),
-    );
-  }
-
-  @protected
-  ClientInfoWithoutId dco_decode_client_info_without_id(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
-    return ClientInfoWithoutId(
-      alias: dco_decode_String(arr[0]),
-      version: dco_decode_String(arr[1]),
-      deviceModel: dco_decode_opt_String(arr[2]),
-      deviceType: dco_decode_opt_box_autoadd_device_type(arr[3]),
-      token: dco_decode_String(arr[4]),
     );
   }
 
@@ -2853,14 +2831,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  ClientInfoWithoutId sse_decode_box_autoadd_client_info_without_id(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_client_info_without_id(deserializer));
-  }
-
-  @protected
   DeviceType sse_decode_box_autoadd_device_type(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_device_type(deserializer));
@@ -2947,25 +2917,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_token = sse_decode_String(deserializer);
     return ClientInfo(
       id: var_id,
-      alias: var_alias,
-      version: var_version,
-      deviceModel: var_deviceModel,
-      deviceType: var_deviceType,
-      token: var_token,
-    );
-  }
-
-  @protected
-  ClientInfoWithoutId sse_decode_client_info_without_id(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_alias = sse_decode_String(deserializer);
-    var var_version = sse_decode_String(deserializer);
-    var var_deviceModel = sse_decode_opt_String(deserializer);
-    var var_deviceType = sse_decode_opt_box_autoadd_device_type(deserializer);
-    var var_token = sse_decode_String(deserializer);
-    return ClientInfoWithoutId(
       alias: var_alias,
       version: var_version,
       deviceModel: var_deviceModel,
@@ -3996,15 +3947,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_box_autoadd_client_info_without_id(
-    ClientInfoWithoutId self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_client_info_without_id(self, serializer);
-  }
-
-  @protected
   void sse_encode_box_autoadd_device_type(
     DeviceType self,
     SseSerializer serializer,
@@ -4098,19 +4040,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_client_info(ClientInfo self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_Uuid(self.id, serializer);
-    sse_encode_String(self.alias, serializer);
-    sse_encode_String(self.version, serializer);
-    sse_encode_opt_String(self.deviceModel, serializer);
-    sse_encode_opt_box_autoadd_device_type(self.deviceType, serializer);
-    sse_encode_String(self.token, serializer);
-  }
-
-  @protected
-  void sse_encode_client_info_without_id(
-    ClientInfoWithoutId self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.alias, serializer);
     sse_encode_String(self.version, serializer);
     sse_encode_opt_String(self.deviceModel, serializer);
@@ -4695,7 +4624,7 @@ class LsSignalingConnectionImpl extends RustOpaque implements LsSignalingConnect
     files: files,
   );
 
-  Future<void> updateInfo({required ClientInfoWithoutId info}) =>
+  Future<void> updateInfo({required ProposingClientInfo info}) =>
       RustLib.instance.api.crateApiWebrtcLsSignalingConnectionUpdateInfo(that: this, info: info);
 }
 

--- a/app/lib/rust/frb_generated.io.dart
+++ b/app/lib/rust/frb_generated.io.dart
@@ -226,11 +226,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ClientInfo dco_decode_box_autoadd_client_info(dynamic raw);
 
   @protected
-  ClientInfoWithoutId dco_decode_box_autoadd_client_info_without_id(
-    dynamic raw,
-  );
-
-  @protected
   DeviceType dco_decode_box_autoadd_device_type(dynamic raw);
 
   @protected
@@ -268,9 +263,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientInfo dco_decode_client_info(dynamic raw);
-
-  @protected
-  ClientInfoWithoutId dco_decode_client_info_without_id(dynamic raw);
 
   @protected
   DeviceType dco_decode_device_type(dynamic raw);
@@ -586,11 +578,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ClientInfo sse_decode_box_autoadd_client_info(SseDeserializer deserializer);
 
   @protected
-  ClientInfoWithoutId sse_decode_box_autoadd_client_info_without_id(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   DeviceType sse_decode_box_autoadd_device_type(SseDeserializer deserializer);
 
   @protected
@@ -636,11 +623,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientInfo sse_decode_client_info(SseDeserializer deserializer);
-
-  @protected
-  ClientInfoWithoutId sse_decode_client_info_without_id(
-    SseDeserializer deserializer,
-  );
 
   @protected
   DeviceType sse_decode_device_type(SseDeserializer deserializer);
@@ -1038,12 +1020,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_box_autoadd_client_info_without_id(
-    ClientInfoWithoutId self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_box_autoadd_device_type(
     DeviceType self,
     SseSerializer serializer,
@@ -1105,12 +1081,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_client_info(ClientInfo self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_client_info_without_id(
-    ClientInfoWithoutId self,
-    SseSerializer serializer,
-  );
 
   @protected
   void sse_encode_device_type(DeviceType self, SseSerializer serializer);

--- a/app/lib/rust/frb_generated.web.dart
+++ b/app/lib/rust/frb_generated.web.dart
@@ -228,11 +228,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ClientInfo dco_decode_box_autoadd_client_info(dynamic raw);
 
   @protected
-  ClientInfoWithoutId dco_decode_box_autoadd_client_info_without_id(
-    dynamic raw,
-  );
-
-  @protected
   DeviceType dco_decode_box_autoadd_device_type(dynamic raw);
 
   @protected
@@ -270,9 +265,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientInfo dco_decode_client_info(dynamic raw);
-
-  @protected
-  ClientInfoWithoutId dco_decode_client_info_without_id(dynamic raw);
 
   @protected
   DeviceType dco_decode_device_type(dynamic raw);
@@ -588,11 +580,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ClientInfo sse_decode_box_autoadd_client_info(SseDeserializer deserializer);
 
   @protected
-  ClientInfoWithoutId sse_decode_box_autoadd_client_info_without_id(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   DeviceType sse_decode_box_autoadd_device_type(SseDeserializer deserializer);
 
   @protected
@@ -638,11 +625,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientInfo sse_decode_client_info(SseDeserializer deserializer);
-
-  @protected
-  ClientInfoWithoutId sse_decode_client_info_without_id(
-    SseDeserializer deserializer,
-  );
 
   @protected
   DeviceType sse_decode_device_type(SseDeserializer deserializer);
@@ -1040,12 +1022,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_box_autoadd_client_info_without_id(
-    ClientInfoWithoutId self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_box_autoadd_device_type(
     DeviceType self,
     SseSerializer serializer,
@@ -1107,12 +1083,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_client_info(ClientInfo self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_client_info_without_id(
-    ClientInfoWithoutId self,
-    SseSerializer serializer,
-  );
 
   @protected
   void sse_encode_device_type(DeviceType self, SseSerializer serializer);

--- a/app/lib/widget/dialogs/favorite_dialog.dart
+++ b/app/lib/widget/dialogs/favorite_dialog.dart
@@ -40,11 +40,11 @@ class _FavoritesDialogState extends State<FavoritesDialog> with Refena {
           .read(httpProvider)
           .v2
           .register(
-        protocol: https ? ProtocolType.https : ProtocolType.http,
-        ip: favorite.ip,
-        port: favorite.port,
-        payload: payload,
-      );
+            protocol: https ? ProtocolType.https : ProtocolType.http,
+            ip: favorite.ip,
+            port: favorite.port,
+            payload: payload,
+          );
 
       final device = response.body.toDevice(favorite.ip, favorite.port, https, HttpDiscovery(ip: favorite.ip));
 

--- a/app/lib/widget/dialogs/favorite_edit_dialog.dart
+++ b/app/lib/widget/dialogs/favorite_edit_dialog.dart
@@ -193,11 +193,11 @@ class _FavoriteEditDialogState extends State<FavoriteEditDialog> with Refena {
                           .read(httpProvider)
                           .v2
                           .register(
-                        protocol: https ? ProtocolType.https : ProtocolType.http,
-                        ip: ip,
-                        port: port,
-                        payload: payload,
-                      );
+                            protocol: https ? ProtocolType.https : ProtocolType.http,
+                            ip: ip,
+                            port: port,
+                            payload: payload,
+                          );
 
                       final name = _aliasController.text.trim();
 

--- a/app/rust/src/api/webrtc.rs
+++ b/app/rust/src/api/webrtc.rs
@@ -65,6 +65,7 @@ pub async fn connect(
     let (managed_connection, mut rx) = connection.start_listener();
     on_connection(LsSignalingConnection {
         inner: Arc::new(managed_connection),
+        signing_key: Arc::new(signing_key),
     })
     .await;
 
@@ -75,10 +76,12 @@ pub async fn connect(
 
 pub struct LsSignalingConnection {
     inner: Arc<ManagedSignalingConnection>,
+    signing_key: Arc<SigningTokenKey>,
 }
 
 impl LsSignalingConnection {
-    pub async fn update_info(&self, info: ClientInfoWithoutId) -> anyhow::Result<()> {
+    pub async fn update_info(&self, info: ProposingClientInfo) -> anyhow::Result<()> {
+        let info = info.sign(&self.signing_key)?;
         self.inner.send_update(info).await?;
         Ok(())
     }

--- a/app/rust/src/frb_generated.rs
+++ b/app/rust/src/frb_generated.rs
@@ -273,7 +273,7 @@ fn wire__crate__api__webrtc__LsSignalingConnection_update_info_impl(
             let api_that = <RustOpaqueMoi<
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LsSignalingConnection>,
             >>::sse_decode(&mut deserializer);
-            let api_info = <crate::api::webrtc::ClientInfoWithoutId>::sse_decode(&mut deserializer);
+            let api_info = <crate::api::webrtc::ProposingClientInfo>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -1761,14 +1761,6 @@ const _: fn() = || {
         let _: String = ClientInfo.token;
     }
     {
-        let ClientInfoWithoutId = None::<crate::api::webrtc::ClientInfoWithoutId>.unwrap();
-        let _: String = ClientInfoWithoutId.alias;
-        let _: String = ClientInfoWithoutId.version;
-        let _: Option<String> = ClientInfoWithoutId.device_model;
-        let _: Option<crate::api::model::DeviceType> = ClientInfoWithoutId.device_type;
-        let _: String = ClientInfoWithoutId.token;
-    }
-    {
         let FileDto = None::<crate::api::model::FileDto>.unwrap();
         let _: String = FileDto.id;
         let _: String = FileDto.file_name;
@@ -2227,24 +2219,6 @@ impl SseDecode for crate::api::webrtc::ClientInfo {
         let mut var_token = <String>::sse_decode(deserializer);
         return crate::api::webrtc::ClientInfo {
             id: var_id,
-            alias: var_alias,
-            version: var_version,
-            device_model: var_deviceModel,
-            device_type: var_deviceType,
-            token: var_token,
-        };
-    }
-}
-
-impl SseDecode for crate::api::webrtc::ClientInfoWithoutId {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_alias = <String>::sse_decode(deserializer);
-        let mut var_version = <String>::sse_decode(deserializer);
-        let mut var_deviceModel = <Option<String>>::sse_decode(deserializer);
-        let mut var_deviceType = <Option<crate::api::model::DeviceType>>::sse_decode(deserializer);
-        let mut var_token = <String>::sse_decode(deserializer);
-        return crate::api::webrtc::ClientInfoWithoutId {
             alias: var_alias,
             version: var_version,
             device_model: var_deviceModel,
@@ -3175,30 +3149,6 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::api::webrtc::ClientInfo
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::api::webrtc::ClientInfoWithoutId> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.0.alias.into_into_dart().into_dart(),
-            self.0.version.into_into_dart().into_dart(),
-            self.0.device_model.into_into_dart().into_dart(),
-            self.0.device_type.into_into_dart().into_dart(),
-            self.0.token.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<crate::api::webrtc::ClientInfoWithoutId>
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::api::webrtc::ClientInfoWithoutId>>
-    for crate::api::webrtc::ClientInfoWithoutId
-{
-    fn into_into_dart(self) -> FrbWrapper<crate::api::webrtc::ClientInfoWithoutId> {
-        self.into()
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::api::model::DeviceType> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self.0 {
@@ -3981,17 +3931,6 @@ impl SseEncode for crate::api::webrtc::ClientInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <uuid::Uuid>::sse_encode(self.id, serializer);
-        <String>::sse_encode(self.alias, serializer);
-        <String>::sse_encode(self.version, serializer);
-        <Option<String>>::sse_encode(self.device_model, serializer);
-        <Option<crate::api::model::DeviceType>>::sse_encode(self.device_type, serializer);
-        <String>::sse_encode(self.token, serializer);
-    }
-}
-
-impl SseEncode for crate::api::webrtc::ClientInfoWithoutId {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.alias, serializer);
         <String>::sse_encode(self.version, serializer);
         <Option<String>>::sse_encode(self.device_model, serializer);

--- a/app/test/mocks.dart
+++ b/app/test/mocks.dart
@@ -1,9 +1,11 @@
 import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:localsend_app/rust/api/webrtc.dart';
 import 'package:mockito/annotations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 @GenerateNiceMocks([
   MockSpec<PersistenceService>(),
   MockSpec<SharedPreferences>(),
+  MockSpec<LsSignalingConnection>(),
 ])
 void main() {}

--- a/app/test/mocks.mocks.dart
+++ b/app/test/mocks.mocks.dart
@@ -3,20 +3,23 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
-import 'package:common/model/device.dart' as _i12;
+import 'package:common/model/device.dart' as _i13;
 import 'package:common/model/stored_security_context.dart' as _i2;
-import 'package:flutter/material.dart' as _i8;
-import 'package:localsend_app/gen/strings.g.dart' as _i10;
-import 'package:localsend_app/model/persistence/color_mode.dart' as _i9;
-import 'package:localsend_app/model/persistence/favorite_device.dart' as _i6;
-import 'package:localsend_app/model/persistence/receive_history_entry.dart' as _i5;
-import 'package:localsend_app/model/send_mode.dart' as _i11;
-import 'package:localsend_app/provider/persistence_provider.dart' as _i3;
+import 'package:flutter/material.dart' as _i9;
+import 'package:localsend_app/gen/strings.g.dart' as _i11;
+import 'package:localsend_app/model/persistence/color_mode.dart' as _i10;
+import 'package:localsend_app/model/persistence/favorite_device.dart' as _i7;
+import 'package:localsend_app/model/persistence/receive_history_entry.dart' as _i6;
+import 'package:localsend_app/model/send_mode.dart' as _i12;
+import 'package:localsend_app/provider/persistence_provider.dart' as _i4;
+import 'package:localsend_app/rust/api/model.dart' as _i16;
+import 'package:localsend_app/rust/api/webrtc.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i7;
-import 'package:shared_preferences/shared_preferences.dart' as _i13;
+import 'package:mockito/src/dummies.dart' as _i8;
+import 'package:shared_preferences/shared_preferences.dart' as _i14;
+import 'package:uuid/uuid.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -36,10 +39,18 @@ class _FakeStoredSecurityContext_0 extends _i1.SmartFake implements _i2.StoredSe
   _FakeStoredSecurityContext_0(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
+class _FakeRtcReceiveController_1 extends _i1.SmartFake implements _i3.RtcReceiveController {
+  _FakeRtcReceiveController_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakeRtcSendController_2 extends _i1.SmartFake implements _i3.RtcSendController {
+  _FakeRtcSendController_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
 /// A class which mocks [PersistenceService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService {
+class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService {
   @override
   bool get isFirstAppStart =>
       (super.noSuchMethod(
@@ -74,77 +85,77 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as _i2.StoredSecurityContext);
 
   @override
-  _i4.Future<void> setSecurityContext(_i2.StoredSecurityContext? context) =>
+  _i5.Future<void> setSecurityContext(_i2.StoredSecurityContext? context) =>
       (super.noSuchMethod(
             Invocation.method(#setSecurityContext, [context]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setSignalingServers(List<String>? servers) =>
+  _i5.Future<void> setSignalingServers(List<String>? servers) =>
       (super.noSuchMethod(
             Invocation.method(#setSignalingServers, [servers]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setStunServers(List<String>? servers) =>
+  _i5.Future<void> setStunServers(List<String>? servers) =>
       (super.noSuchMethod(
             Invocation.method(#setStunServers, [servers]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  List<_i5.ReceiveHistoryEntry> getReceiveHistory() =>
+  List<_i6.ReceiveHistoryEntry> getReceiveHistory() =>
       (super.noSuchMethod(
             Invocation.method(#getReceiveHistory, []),
-            returnValue: <_i5.ReceiveHistoryEntry>[],
-            returnValueForMissingStub: <_i5.ReceiveHistoryEntry>[],
+            returnValue: <_i6.ReceiveHistoryEntry>[],
+            returnValueForMissingStub: <_i6.ReceiveHistoryEntry>[],
           )
-          as List<_i5.ReceiveHistoryEntry>);
+          as List<_i6.ReceiveHistoryEntry>);
 
   @override
-  _i4.Future<void> setReceiveHistory(List<_i5.ReceiveHistoryEntry>? entries) =>
+  _i5.Future<void> setReceiveHistory(List<_i6.ReceiveHistoryEntry>? entries) =>
       (super.noSuchMethod(
             Invocation.method(#setReceiveHistory, [entries]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  List<_i6.FavoriteDevice> getFavorites() =>
+  List<_i7.FavoriteDevice> getFavorites() =>
       (super.noSuchMethod(
             Invocation.method(#getFavorites, []),
-            returnValue: <_i6.FavoriteDevice>[],
-            returnValueForMissingStub: <_i6.FavoriteDevice>[],
+            returnValue: <_i7.FavoriteDevice>[],
+            returnValueForMissingStub: <_i7.FavoriteDevice>[],
           )
-          as List<_i6.FavoriteDevice>);
+          as List<_i7.FavoriteDevice>);
 
   @override
-  _i4.Future<void> setFavorites(List<_i6.FavoriteDevice>? entries) =>
+  _i5.Future<void> setFavorites(List<_i7.FavoriteDevice>? entries) =>
       (super.noSuchMethod(
             Invocation.method(#setFavorites, [entries]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   String getShowToken() =>
       (super.noSuchMethod(
             Invocation.method(#getShowToken, []),
-            returnValue: _i7.dummyValue<String>(
+            returnValue: _i8.dummyValue<String>(
               this,
               Invocation.method(#getShowToken, []),
             ),
-            returnValueForMissingStub: _i7.dummyValue<String>(
+            returnValueForMissingStub: _i8.dummyValue<String>(
               this,
               Invocation.method(#getShowToken, []),
             ),
@@ -155,11 +166,11 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
   String getAlias() =>
       (super.noSuchMethod(
             Invocation.method(#getAlias, []),
-            returnValue: _i7.dummyValue<String>(
+            returnValue: _i8.dummyValue<String>(
               this,
               Invocation.method(#getAlias, []),
             ),
-            returnValueForMissingStub: _i7.dummyValue<String>(
+            returnValueForMissingStub: _i8.dummyValue<String>(
               this,
               Invocation.method(#getAlias, []),
             ),
@@ -167,58 +178,58 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as String);
 
   @override
-  _i4.Future<void> setAlias(String? alias) =>
+  _i5.Future<void> setAlias(String? alias) =>
       (super.noSuchMethod(
             Invocation.method(#setAlias, [alias]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i8.ThemeMode getTheme() =>
+  _i9.ThemeMode getTheme() =>
       (super.noSuchMethod(
             Invocation.method(#getTheme, []),
-            returnValue: _i8.ThemeMode.system,
-            returnValueForMissingStub: _i8.ThemeMode.system,
+            returnValue: _i9.ThemeMode.system,
+            returnValueForMissingStub: _i9.ThemeMode.system,
           )
-          as _i8.ThemeMode);
+          as _i9.ThemeMode);
 
   @override
-  _i4.Future<void> setTheme(_i8.ThemeMode? theme) =>
+  _i5.Future<void> setTheme(_i9.ThemeMode? theme) =>
       (super.noSuchMethod(
             Invocation.method(#setTheme, [theme]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i9.ColorMode getColorMode() =>
+  _i10.ColorMode getColorMode() =>
       (super.noSuchMethod(
             Invocation.method(#getColorMode, []),
-            returnValue: _i9.ColorMode.system,
-            returnValueForMissingStub: _i9.ColorMode.system,
+            returnValue: _i10.ColorMode.system,
+            returnValueForMissingStub: _i10.ColorMode.system,
           )
-          as _i9.ColorMode);
+          as _i10.ColorMode);
 
   @override
-  _i4.Future<void> setColorMode(_i9.ColorMode? color) =>
+  _i5.Future<void> setColorMode(_i10.ColorMode? color) =>
       (super.noSuchMethod(
             Invocation.method(#setColorMode, [color]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setLocale(_i10.AppLocale? locale) =>
+  _i5.Future<void> setLocale(_i11.AppLocale? locale) =>
       (super.noSuchMethod(
             Invocation.method(#setLocale, [locale]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   int getPort() =>
@@ -230,31 +241,31 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as int);
 
   @override
-  _i4.Future<void> setPort(int? port) =>
+  _i5.Future<void> setPort(int? port) =>
       (super.noSuchMethod(
             Invocation.method(#setPort, [port]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setNetworkWhitelist(List<String>? whitelist) =>
+  _i5.Future<void> setNetworkWhitelist(List<String>? whitelist) =>
       (super.noSuchMethod(
             Invocation.method(#setNetworkWhitelist, [whitelist]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setNetworkBlacklist(List<String>? blacklist) =>
+  _i5.Future<void> setNetworkBlacklist(List<String>? blacklist) =>
       (super.noSuchMethod(
             Invocation.method(#setNetworkBlacklist, [blacklist]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   int getDiscoveryTimeout() =>
@@ -266,13 +277,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as int);
 
   @override
-  _i4.Future<void> setDiscoveryTimeout(int? timeout) =>
+  _i5.Future<void> setDiscoveryTimeout(int? timeout) =>
       (super.noSuchMethod(
             Invocation.method(#setDiscoveryTimeout, [timeout]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool getShareViaLinkAutoAccept() =>
@@ -284,25 +295,25 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setShareViaLinkAutoAccept(bool? shareViaLinkAutoAccept) =>
+  _i5.Future<void> setShareViaLinkAutoAccept(bool? shareViaLinkAutoAccept) =>
       (super.noSuchMethod(
             Invocation.method(#setShareViaLinkAutoAccept, [
               shareViaLinkAutoAccept,
             ]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   String getMulticastGroup() =>
       (super.noSuchMethod(
             Invocation.method(#getMulticastGroup, []),
-            returnValue: _i7.dummyValue<String>(
+            returnValue: _i8.dummyValue<String>(
               this,
               Invocation.method(#getMulticastGroup, []),
             ),
-            returnValueForMissingStub: _i7.dummyValue<String>(
+            returnValueForMissingStub: _i8.dummyValue<String>(
               this,
               Invocation.method(#getMulticastGroup, []),
             ),
@@ -310,22 +321,22 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as String);
 
   @override
-  _i4.Future<void> setMulticastGroup(String? group) =>
+  _i5.Future<void> setMulticastGroup(String? group) =>
       (super.noSuchMethod(
             Invocation.method(#setMulticastGroup, [group]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setDestination(String? destination) =>
+  _i5.Future<void> setDestination(String? destination) =>
       (super.noSuchMethod(
             Invocation.method(#setDestination, [destination]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool isSaveToGallery() =>
@@ -337,13 +348,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setSaveToGallery(bool? saveToGallery) =>
+  _i5.Future<void> setSaveToGallery(bool? saveToGallery) =>
       (super.noSuchMethod(
             Invocation.method(#setSaveToGallery, [saveToGallery]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool isSaveToHistory() =>
@@ -355,13 +366,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setSaveToHistory(bool? saveToHistory) =>
+  _i5.Future<void> setSaveToHistory(bool? saveToHistory) =>
       (super.noSuchMethod(
             Invocation.method(#setSaveToHistory, [saveToHistory]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool getAdvancedSettingsEnabled() =>
@@ -373,13 +384,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setAdvancedSettingsEnabled(bool? isEnabled) =>
+  _i5.Future<void> setAdvancedSettingsEnabled(bool? isEnabled) =>
       (super.noSuchMethod(
             Invocation.method(#setAdvancedSettingsEnabled, [isEnabled]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool isQuickSave() =>
@@ -391,13 +402,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setQuickSave(bool? quickSave) =>
+  _i5.Future<void> setQuickSave(bool? quickSave) =>
       (super.noSuchMethod(
             Invocation.method(#setQuickSave, [quickSave]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool isQuickSaveFromFavorites() =>
@@ -409,24 +420,24 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setQuickSaveFromFavorites(bool? quickSaveFromFavorites) =>
+  _i5.Future<void> setQuickSaveFromFavorites(bool? quickSaveFromFavorites) =>
       (super.noSuchMethod(
             Invocation.method(#setQuickSaveFromFavorites, [
               quickSaveFromFavorites,
             ]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setReceivePin(String? pin) =>
+  _i5.Future<void> setReceivePin(String? pin) =>
       (super.noSuchMethod(
             Invocation.method(#setReceivePin, [pin]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool isAutoFinish() =>
@@ -438,13 +449,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setAutoFinish(bool? autoFinish) =>
+  _i5.Future<void> setAutoFinish(bool? autoFinish) =>
       (super.noSuchMethod(
             Invocation.method(#setAutoFinish, [autoFinish]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool isMinimizeToTray() =>
@@ -456,13 +467,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setMinimizeToTray(bool? minimizeToTray) =>
+  _i5.Future<void> setMinimizeToTray(bool? minimizeToTray) =>
       (super.noSuchMethod(
             Invocation.method(#setMinimizeToTray, [minimizeToTray]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool isHttps() =>
@@ -474,76 +485,76 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setHttps(bool? https) =>
+  _i5.Future<void> setHttps(bool? https) =>
       (super.noSuchMethod(
             Invocation.method(#setHttps, [https]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i11.SendMode getSendMode() =>
+  _i12.SendMode getSendMode() =>
       (super.noSuchMethod(
             Invocation.method(#getSendMode, []),
-            returnValue: _i11.SendMode.single,
-            returnValueForMissingStub: _i11.SendMode.single,
+            returnValue: _i12.SendMode.single,
+            returnValueForMissingStub: _i12.SendMode.single,
           )
-          as _i11.SendMode);
+          as _i12.SendMode);
 
   @override
-  _i4.Future<void> setSendMode(_i11.SendMode? mode) =>
+  _i5.Future<void> setSendMode(_i12.SendMode? mode) =>
       (super.noSuchMethod(
             Invocation.method(#setSendMode, [mode]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setWindowOffsetX(double? x) =>
+  _i5.Future<void> setWindowOffsetX(double? x) =>
       (super.noSuchMethod(
             Invocation.method(#setWindowOffsetX, [x]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setWindowOffsetY(double? y) =>
+  _i5.Future<void> setWindowOffsetY(double? y) =>
       (super.noSuchMethod(
             Invocation.method(#setWindowOffsetY, [y]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setWindowHeight(double? height) =>
+  _i5.Future<void> setWindowHeight(double? height) =>
       (super.noSuchMethod(
             Invocation.method(#setWindowHeight, [height]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setWindowWidth(double? width) =>
+  _i5.Future<void> setWindowWidth(double? width) =>
       (super.noSuchMethod(
             Invocation.method(#setWindowWidth, [width]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setSaveWindowPlacement(bool? savePlacement) =>
+  _i5.Future<void> setSaveWindowPlacement(bool? savePlacement) =>
       (super.noSuchMethod(
             Invocation.method(#setSaveWindowPlacement, [savePlacement]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool getSaveWindowPlacement() =>
@@ -555,13 +566,13 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setEnableAnimations(bool? enableAnimations) =>
+  _i5.Future<void> setEnableAnimations(bool? enableAnimations) =>
       (super.noSuchMethod(
             Invocation.method(#setEnableAnimations, [enableAnimations]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
   bool getEnableAnimations() =>
@@ -573,37 +584,37 @@ class MockPersistenceService extends _i1.Mock implements _i3.PersistenceService 
           as bool);
 
   @override
-  _i4.Future<void> setDeviceType(_i12.DeviceType? deviceType) =>
+  _i5.Future<void> setDeviceType(_i13.DeviceType? deviceType) =>
       (super.noSuchMethod(
             Invocation.method(#setDeviceType, [deviceType]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> setDeviceModel(String? deviceModel) =>
+  _i5.Future<void> setDeviceModel(String? deviceModel) =>
       (super.noSuchMethod(
             Invocation.method(#setDeviceModel, [deviceModel]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<void> clear() =>
+  _i5.Future<void> clear() =>
       (super.noSuchMethod(
             Invocation.method(#clear, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 }
 
 /// A class which mocks [SharedPreferences].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSharedPreferences extends _i1.Mock implements _i13.SharedPreferences {
+class MockSharedPreferences extends _i1.Mock implements _i14.SharedPreferences {
   @override
   Set<String> getKeys() =>
       (super.noSuchMethod(
@@ -671,83 +682,202 @@ class MockSharedPreferences extends _i1.Mock implements _i13.SharedPreferences {
           as List<String>?);
 
   @override
-  _i4.Future<bool> setBool(String? key, bool? value) =>
+  _i5.Future<bool> setBool(String? key, bool? value) =>
       (super.noSuchMethod(
             Invocation.method(#setBool, [key, value]),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> setInt(String? key, int? value) =>
+  _i5.Future<bool> setInt(String? key, int? value) =>
       (super.noSuchMethod(
             Invocation.method(#setInt, [key, value]),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> setDouble(String? key, double? value) =>
+  _i5.Future<bool> setDouble(String? key, double? value) =>
       (super.noSuchMethod(
             Invocation.method(#setDouble, [key, value]),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> setString(String? key, String? value) =>
+  _i5.Future<bool> setString(String? key, String? value) =>
       (super.noSuchMethod(
             Invocation.method(#setString, [key, value]),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> setStringList(String? key, List<String>? value) =>
+  _i5.Future<bool> setStringList(String? key, List<String>? value) =>
       (super.noSuchMethod(
             Invocation.method(#setStringList, [key, value]),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> remove(String? key) =>
+  _i5.Future<bool> remove(String? key) =>
       (super.noSuchMethod(
             Invocation.method(#remove, [key]),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> commit() =>
+  _i5.Future<bool> commit() =>
       (super.noSuchMethod(
             Invocation.method(#commit, []),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> clear() =>
+  _i5.Future<bool> clear() =>
       (super.noSuchMethod(
             Invocation.method(#clear, []),
-            returnValue: _i4.Future<bool>.value(false),
-            returnValueForMissingStub: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
+            returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<void> reload() =>
+  _i5.Future<void> reload() =>
       (super.noSuchMethod(
             Invocation.method(#reload, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
+}
+
+/// A class which mocks [LsSignalingConnection].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockLsSignalingConnection extends _i1.Mock implements _i3.LsSignalingConnection {
+  @override
+  bool get isDisposed =>
+      (super.noSuchMethod(
+            Invocation.getter(#isDisposed),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
+
+  @override
+  _i5.Future<_i3.RtcReceiveController> acceptOffer({
+    required List<String>? stunServers,
+    required _i3.WsServerSdpMessage? offer,
+    required String? privateKey,
+    _i3.ExpectingPublicKey? expectingPublicKey,
+    _i3.PinConfig? pin,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#acceptOffer, [], {
+              #stunServers: stunServers,
+              #offer: offer,
+              #privateKey: privateKey,
+              #expectingPublicKey: expectingPublicKey,
+              #pin: pin,
+            }),
+            returnValue: _i5.Future<_i3.RtcReceiveController>.value(
+              _FakeRtcReceiveController_1(
+                this,
+                Invocation.method(#acceptOffer, [], {
+                  #stunServers: stunServers,
+                  #offer: offer,
+                  #privateKey: privateKey,
+                  #expectingPublicKey: expectingPublicKey,
+                  #pin: pin,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i5.Future<_i3.RtcReceiveController>.value(
+              _FakeRtcReceiveController_1(
+                this,
+                Invocation.method(#acceptOffer, [], {
+                  #stunServers: stunServers,
+                  #offer: offer,
+                  #privateKey: privateKey,
+                  #expectingPublicKey: expectingPublicKey,
+                  #pin: pin,
+                }),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.RtcReceiveController>);
+
+  @override
+  _i5.Future<_i3.RtcSendController> sendOffer({
+    required List<String>? stunServers,
+    required _i15.UuidValue? target,
+    required String? privateKey,
+    _i3.ExpectingPublicKey? expectingPublicKey,
+    _i3.PinConfig? pin,
+    required List<_i16.FileDto>? files,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#sendOffer, [], {
+              #stunServers: stunServers,
+              #target: target,
+              #privateKey: privateKey,
+              #expectingPublicKey: expectingPublicKey,
+              #pin: pin,
+              #files: files,
+            }),
+            returnValue: _i5.Future<_i3.RtcSendController>.value(
+              _FakeRtcSendController_2(
+                this,
+                Invocation.method(#sendOffer, [], {
+                  #stunServers: stunServers,
+                  #target: target,
+                  #privateKey: privateKey,
+                  #expectingPublicKey: expectingPublicKey,
+                  #pin: pin,
+                  #files: files,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i5.Future<_i3.RtcSendController>.value(
+              _FakeRtcSendController_2(
+                this,
+                Invocation.method(#sendOffer, [], {
+                  #stunServers: stunServers,
+                  #target: target,
+                  #privateKey: privateKey,
+                  #expectingPublicKey: expectingPublicKey,
+                  #pin: pin,
+                  #files: files,
+                }),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.RtcSendController>);
+
+  @override
+  _i5.Future<void> updateInfo({required _i3.ProposingClientInfo? info}) =>
+      (super.noSuchMethod(
+            Invocation.method(#updateInfo, [], {#info: info}),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+    Invocation.method(#dispose, []),
+    returnValueForMissingStub: null,
+  );
 }

--- a/app/test/unit/provider/signaling_provider_test.dart
+++ b/app/test/unit/provider/signaling_provider_test.dart
@@ -1,0 +1,56 @@
+import 'package:localsend_app/provider/network/webrtc/signaling_provider.dart';
+import 'package:localsend_app/rust/api/model.dart' as rust;
+import 'package:localsend_app/rust/api/webrtc.dart';
+import 'package:mockito/mockito.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+import 'package:test/test.dart';
+
+import '../../mocks.mocks.dart';
+
+void main() {
+  const info = ProposingClientInfo(
+    alias: 'New Alias',
+    version: '2.1',
+    deviceModel: 'macOS',
+    deviceType: rust.DeviceType.desktop,
+  );
+
+  test('Should send client info to all connected signaling servers', () async {
+    final connectionA = MockLsSignalingConnection();
+    final connectionB = MockLsSignalingConnection();
+    final service = _createService({
+      'wss://a.localsend.org/v1/ws': connectionA,
+      'wss://b.localsend.org/v1/ws': connectionB,
+    });
+
+    await service.dispatchAsync(UpdateClientInfoAction(info: info));
+
+    verify(connectionA.updateInfo(info: info)).called(1);
+    verify(connectionB.updateInfo(info: info)).called(1);
+  });
+
+  test('Should keep sending to remaining connections when one fails', () async {
+    final connectionA = MockLsSignalingConnection();
+    final connectionB = MockLsSignalingConnection();
+    when(connectionA.updateInfo(info: anyNamed('info'))).thenAnswer((_) async => throw Exception('connection lost'));
+    final service = _createService({
+      'wss://a.localsend.org/v1/ws': connectionA,
+      'wss://b.localsend.org/v1/ws': connectionB,
+    });
+
+    await service.dispatchAsync(UpdateClientInfoAction(info: info));
+
+    verify(connectionB.updateInfo(info: info)).called(1);
+  });
+}
+
+ReduxNotifierTester<SignalingState> _createService(Map<String, LsSignalingConnection> connections) {
+  return ReduxNotifier.test(
+    redux: SignalingService(persistence: MockPersistenceService()),
+    initialState: SignalingState(
+      signalingServers: connections.keys.toList(),
+      stunServers: [],
+      connections: connections,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #3158

When a device is renamed and the server is restarted, the new alias is synced to the local discovery isolates (multicast/HTTP), but the WebSocket connection to the signaling server keeps announcing the client info captured at app start. Peers connected to the same signaling server keep showing the outdated name until the app restarts. Refreshing *Nearby devices* does not help because `ClearFoundDevicesAction` only clears locally discovered devices, while signaling devices stay in the state — this is why the old (random) name reappears and sometimes never gets replaced.

The protocol already supports live updates: clients can send `WsClientMessage::Update`, the signaling server broadcasts `WsServerMessage::Update`, and the app already handles incoming updates via `RegisterSignalingDeviceAction`. The missing piece was that `LsSignalingConnection.updateInfo` was never called.

## Changes

- `app/rust/src/api/webrtc.rs`: `LsSignalingConnection` keeps the signing key from `connect`, and `update_info` now accepts a `ProposingClientInfo` and signs a fresh token internally (mirroring `connect`). The previous `ClientInfoWithoutId` parameter was not usable from Dart because the token can only be signed on the Rust side. Bindings regenerated with the pinned `flutter_rust_bridge_codegen` 2.11.1.
- `signaling_provider.dart`: new `UpdateClientInfoAction` that sends the current client info to all connected signaling servers, continuing with the remaining connections if one fails.
- `server_provider.dart`: when the effective alias changes (same condition already used for the isolate sync), the new client info is pushed to the signaling connections.
- Unit tests for `UpdateClientInfoAction`.
- Separate commit `style: fix formatting of favorite dialogs`: `dart format` on current `main` reports these two files, so the *format* CI job currently fails on `main`; this restores a green check.

## Behavior after this change

1. Device A is renamed and its server restarts.
2. `serverProvider.onChanged` detects the alias change and dispatches `UpdateClientInfoAction`.
3. Each `LsSignalingConnection` sends `WsClientMessage::Update` with a freshly signed token.
4. The signaling server broadcasts `WsServerMessage::Update` and peers replace the entry via the existing `RegisterSignalingDeviceAction`, so the new name shows up immediately without rescanning or restarting.

## Testing

- `flutter test`: 59 tests pass, including 2 new ones covering `UpdateClientInfoAction`
- `flutter analyze`: no new issues in the touched files
- `cargo check` in `app/rust` passes
- `dart format lib test`: no changes