### PR TITLE
feat: custom save locations

### DIFF
--- a/app/assets/i18n/cs.json
+++ b/app/assets/i18n/cs.json
@@ -122,6 +122,14 @@
       "saveToGallery": "Uložit média do galerie",
       "saveToHistory": "Uložit do historie"
     },
+    "save": {
+      "title": "Ukládání",
+      "saveLocation": "Rozdílné umístění pro různé typy souborů.",
+      "defaultLocation": "Výchozí",
+      "documentsLocation": "Dokumenty",
+      "mediaLocation": "Obrázky a videa",
+      "musicLocation": "Hudba"
+    },
     "send": {
       "title": "Poslat",
       "shareViaLinkAutoAccept": "Automaticky přijímat požadavky v režimu \"Sdílet přes odkaz\"."
@@ -217,7 +225,8 @@
     "destination": "@:settingsTab.receive.destination",
     "appDirectory": "(LocalSend folder)",
     "saveToGallery": "@:settingsTab.receive.saveToGallery",
-    "saveToGalleryOff": "Automaticky vypnuto, protože existují adresáře."
+    "saveToGalleryOff": "Automaticky vypnuto, protože existují adresáře.",
+    "editDirectoryInSettings": "Složka pro ukladání je určena automaticky podle typu souboru."
   },
   "sendPage": {
     "waiting": "Čekání na odpověď...",
@@ -228,6 +237,8 @@
   "progressPage": {
     "titleSending": "Odesílání souborů",
     "titleReceiving": "Přijímání souborů",
+    "titleSent": "Soubory odeslány",
+    "titleReceived": "Soubory přijaty",
     "savedToGallery": "Uloženo ve Fotkách",
     "total": {
       "title": {

--- a/app/assets/i18n/de.json
+++ b/app/assets/i18n/de.json
@@ -122,6 +122,14 @@
       "saveToGallery": "Medien in die Galerie speichern",
       "saveToHistory": "In Verlauf speichern"
     },
+     "save": {
+      "title": "Speichern",
+      "saveLocation": "Unterschiedliche Speicherorte basierend auf dem Dateityp",
+      "defaultLocation": "Standard",
+      "documentsLocation": "Dokumente",
+      "mediaLocation": "Bilder und Videos",
+      "musicLocation": "Musik"
+    },
     "send": {
       "title": "Senden",
       "shareViaLinkAutoAccept": "Link teilen: Autom. akzeptieren"
@@ -217,7 +225,8 @@
     "destination": "@:settingsTab.receive.destination",
     "appDirectory": "(LocalSend-Ordner)",
     "saveToGallery": "@:settingsTab.receive.saveToGallery",
-    "saveToGalleryOff": "Aufgrund von Ordnern automatisch ausgeschaltet."
+    "saveToGalleryOff": "Aufgrund von Ordnern automatisch ausgeschaltet.",
+    "editDirectoryInSettings": "Der Speicherort hängt vom Dateityp ab."
   },
   "sendPage": {
     "waiting": "Warte auf Antwort…",
@@ -228,6 +237,8 @@
   "progressPage": {
     "titleSending": "Sende Dateien",
     "titleReceiving": "Empfange Dateien",
+    "titleSent": "Gesendete Dateien",
+    "titleReceived": "Eingegangene Dateien",
     "savedToGallery": "in Fotos gespeichert",
     "total": {
       "title": {

--- a/app/assets/i18n/en-IN.json
+++ b/app/assets/i18n/en-IN.json
@@ -122,6 +122,14 @@
       "saveToGallery": "Save media to gallery",
       "saveToHistory": "Save to history"
     },
+    "save": {
+      "title": "Save",
+      "saveLocation": "Different save locations based on file type",
+      "defaultLocation": "Default",
+      "documentsLocation": "Documents",
+      "mediaLocation": "Images and Videos",
+      "musicLocation": "Music"
+    },
     "send": {
       "title": "Send",
       "shareViaLinkAutoAccept": "Share via link: Auto accept"
@@ -210,7 +218,8 @@
     "destination": "@:settingsTab.receive.destination",
     "appDirectory": "(LocalSend folder)",
     "saveToGallery": "@:settingsTab.receive.saveToGallery",
-    "saveToGalleryOff": "Turned off automatically because there are directories."
+    "saveToGalleryOff": "Turned off automatically because there are folders.",
+    "editDirectoryInSettings": "The save location is determined by the file type."
   },
   "sendPage": {
     "waiting": "Waiting for response…",
@@ -221,6 +230,8 @@
   "progressPage": {
     "titleSending": "Sending files",
     "titleReceiving": "Receiving files",
+    "titleSent": "Files sent",
+    "titleReceived": "Files received",
     "savedToGallery": "Saved in Photos",
     "total": {
       "title": {

--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -122,6 +122,14 @@
       "saveToGallery": "Save media to gallery",
       "saveToHistory": "Save to history"
     },
+    "save": {
+      "title": "Save",
+      "saveLocation": "Different save locations based on file type",
+      "defaultLocation": "Default",
+      "documentsLocation": "Documents",
+      "mediaLocation": "Images and Videos",
+      "musicLocation": "Music"
+    },
     "send": {
       "title": "Send",
       "shareViaLinkAutoAccept": "Automatically accept requests in \"Share via link\" mode"
@@ -217,7 +225,8 @@
     "destination": "@:settingsTab.receive.destination",
     "appDirectory": "(LocalSend folder)",
     "saveToGallery": "@:settingsTab.receive.saveToGallery",
-    "saveToGalleryOff": "Turned off automatically because there are folders."
+    "saveToGalleryOff": "Turned off automatically because there are folders.",
+    "editDirectoryInSettings": "The save location is determined by the file type."
   },
   "sendPage": {
     "waiting": "Waiting for response…",
@@ -228,6 +237,8 @@
   "progressPage": {
     "titleSending": "Sending files",
     "titleReceiving": "Receiving files",
+    "titleSent": "Files sent",
+    "titleReceived": "Files received",
     "savedToGallery": "Saved in Photos",
     "total": {
       "title": {

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 53
-/// Strings: 17825 (336 per locale)
+/// Strings: 17861 (337 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_cs.g.dart
+++ b/app/lib/gen/strings_cs.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsTabCs extends TranslationsSettingsTabEn {
   @override
   late final _TranslationsSettingsTabReceiveCs receive = _TranslationsSettingsTabReceiveCs._(_root);
   @override
+  late final _TranslationsSettingsTabSaveCs save = _TranslationsSettingsTabSaveCs._(_root);
+  @override
   late final _TranslationsSettingsTabSendCs send = _TranslationsSettingsTabSendCs._(_root);
   @override
   late final _TranslationsSettingsTabNetworkCs network = _TranslationsSettingsTabNetworkCs._(_root);
@@ -375,6 +377,8 @@ class _TranslationsReceiveOptionsPageCs extends TranslationsReceiveOptionsPageEn
   String get saveToGallery => _root.settingsTab.receive.saveToGallery;
   @override
   String get saveToGalleryOff => 'Automaticky vypnuto, protože existují adresáře.';
+  @override
+  String get editDirectoryInSettings => 'Složka pro ukladání je určena automaticky podle typu souboru.';
 }
 
 // Path: sendPage
@@ -405,6 +409,10 @@ class _TranslationsProgressPageCs extends TranslationsProgressPageEn {
   String get titleSending => 'Odesílání souborů';
   @override
   String get titleReceiving => 'Přijímání souborů';
+  @override
+  String get titleSent => 'Soubory odeslány';
+  @override
+  String get titleReceived => 'Soubory přijaty';
   @override
   String get savedToGallery => 'Uloženo ve Fotkách';
   @override
@@ -827,6 +835,27 @@ class _TranslationsSettingsTabReceiveCs extends TranslationsSettingsTabReceiveEn
   String get saveToGallery => 'Uložit média do galerie';
   @override
   String get saveToHistory => 'Uložit do historie';
+}
+
+// Path: settingsTab.save
+class _TranslationsSettingsTabSaveCs extends TranslationsSettingsTabSaveEn {
+  _TranslationsSettingsTabSaveCs._(TranslationsCs root) : this._root = root, super.internal(root);
+
+  final TranslationsCs _root; // ignore: unused_field
+
+  // Translations
+  @override
+  String get title => 'Ukládání';
+  @override
+  String get saveLocation => 'Rozdílné umístění pro různé typy souborů.';
+  @override
+  String get defaultLocation => 'Výchozí';
+  @override
+  String get documentsLocation => 'Dokumenty';
+  @override
+  String get mediaLocation => 'Obrázky a videa';
+  @override
+  String get musicLocation => 'Hudba';
 }
 
 // Path: settingsTab.send

--- a/app/lib/gen/strings_de.g.dart
+++ b/app/lib/gen/strings_de.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsTabDe extends TranslationsSettingsTabEn {
   @override
   late final _TranslationsSettingsTabReceiveDe receive = _TranslationsSettingsTabReceiveDe._(_root);
   @override
+  late final _TranslationsSettingsTabSaveDe save = _TranslationsSettingsTabSaveDe._(_root);
+  @override
   late final _TranslationsSettingsTabSendDe send = _TranslationsSettingsTabSendDe._(_root);
   @override
   late final _TranslationsSettingsTabNetworkDe network = _TranslationsSettingsTabNetworkDe._(_root);
@@ -375,6 +377,8 @@ class _TranslationsReceiveOptionsPageDe extends TranslationsReceiveOptionsPageEn
   String get saveToGallery => _root.settingsTab.receive.saveToGallery;
   @override
   String get saveToGalleryOff => 'Aufgrund von Ordnern automatisch ausgeschaltet.';
+  @override
+  String get editDirectoryInSettings => 'Der Speicherort hängt vom Dateityp ab.';
 }
 
 // Path: sendPage
@@ -405,6 +409,10 @@ class _TranslationsProgressPageDe extends TranslationsProgressPageEn {
   String get titleSending => 'Sende Dateien';
   @override
   String get titleReceiving => 'Empfange Dateien';
+  @override
+  String get titleSent => 'Gesendete Dateien';
+  @override
+  String get titleReceived => 'Eingegangene Dateien';
   @override
   String get savedToGallery => 'in Fotos gespeichert';
   @override
@@ -830,6 +838,27 @@ class _TranslationsSettingsTabReceiveDe extends TranslationsSettingsTabReceiveEn
   String get saveToGallery => 'Medien in die Galerie speichern';
   @override
   String get saveToHistory => 'In Verlauf speichern';
+}
+
+// Path: settingsTab.save
+class _TranslationsSettingsTabSaveDe extends TranslationsSettingsTabSaveEn {
+  _TranslationsSettingsTabSaveDe._(TranslationsDe root) : this._root = root, super.internal(root);
+
+  final TranslationsDe _root; // ignore: unused_field
+
+  // Translations
+  @override
+  String get title => 'Speichern';
+  @override
+  String get saveLocation => 'Unterschiedliche Speicherorte basierend auf dem Dateityp';
+  @override
+  String get defaultLocation => 'Standard';
+  @override
+  String get documentsLocation => 'Dokumente';
+  @override
+  String get mediaLocation => 'Bilder und Videos';
+  @override
+  String get musicLocation => 'Musik';
 }
 
 // Path: settingsTab.send

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -269,6 +269,7 @@ class TranslationsSettingsTabEn {
 
   late final TranslationsSettingsTabGeneralEn general = TranslationsSettingsTabGeneralEn.internal(_root);
   late final TranslationsSettingsTabReceiveEn receive = TranslationsSettingsTabReceiveEn.internal(_root);
+  late final TranslationsSettingsTabSaveEn save = TranslationsSettingsTabSaveEn.internal(_root);
   late final TranslationsSettingsTabSendEn send = TranslationsSettingsTabSendEn.internal(_root);
   late final TranslationsSettingsTabNetworkEn network = TranslationsSettingsTabNetworkEn.internal(_root);
   late final TranslationsSettingsTabOtherEn other = TranslationsSettingsTabOtherEn.internal(_root);
@@ -430,6 +431,9 @@ class TranslationsReceiveOptionsPageEn {
 
   /// en: 'Turned off automatically because there are folders.'
   String get saveToGalleryOff => 'Turned off automatically because there are folders.';
+
+  /// en: 'The save location is determined by the file type.'
+  String get editDirectoryInSettings => 'The save location is determined by the file type.';
 }
 
 // Path: sendPage
@@ -466,6 +470,12 @@ class TranslationsProgressPageEn {
 
   /// en: 'Receiving files'
   String get titleReceiving => 'Receiving files';
+
+  /// en: 'Files sent'
+  String get titleSent => 'Files sent';
+
+  /// en: 'Files received'
+  String get titleReceived => 'Files received';
 
   /// en: 'Saved in Photos'
   String get savedToGallery => 'Saved in Photos';
@@ -1049,6 +1059,33 @@ class TranslationsSettingsTabReceiveEn {
 
   /// en: 'Save to history'
   String get saveToHistory => 'Save to history';
+}
+
+// Path: settingsTab.save
+class TranslationsSettingsTabSaveEn {
+  TranslationsSettingsTabSaveEn.internal(this._root);
+
+  final Translations _root; // ignore: unused_field
+
+  // Translations
+
+  /// en: 'Save'
+  String get title => 'Save';
+
+  /// en: 'Different save locations based on file type'
+  String get saveLocation => 'Different save locations based on file type';
+
+  /// en: 'Default'
+  String get defaultLocation => 'Default';
+
+  /// en: 'Documents'
+  String get documentsLocation => 'Documents';
+
+  /// en: 'Images and Videos'
+  String get mediaLocation => 'Images and Videos';
+
+  /// en: 'Music'
+  String get musicLocation => 'Music';
 }
 
 // Path: settingsTab.send

--- a/app/lib/gen/strings_en_IN.g.dart
+++ b/app/lib/gen/strings_en_IN.g.dart
@@ -240,6 +240,8 @@ class _TranslationsSettingsTabEnIn extends TranslationsSettingsTabEn {
   @override
   late final _TranslationsSettingsTabReceiveEnIn receive = _TranslationsSettingsTabReceiveEnIn._(_root);
   @override
+  late final _TranslationsSettingsTabSaveEnIn save = _TranslationsSettingsTabSaveEnIn._(_root);
+  @override
   late final _TranslationsSettingsTabSendEnIn send = _TranslationsSettingsTabSendEnIn._(_root);
   @override
   late final _TranslationsSettingsTabNetworkEnIn network = _TranslationsSettingsTabNetworkEnIn._(_root);
@@ -356,7 +358,9 @@ class _TranslationsReceiveOptionsPageEnIn extends TranslationsReceiveOptionsPage
   @override
   String get saveToGallery => _root.settingsTab.receive.saveToGallery;
   @override
-  String get saveToGalleryOff => 'Turned off automatically because there are directories.';
+  String get saveToGalleryOff => 'Turned off automatically because there are folders.';
+  @override
+  String get editDirectoryInSettings => 'The save location is determined by the file type.';
 }
 
 // Path: sendPage
@@ -387,6 +391,10 @@ class _TranslationsProgressPageEnIn extends TranslationsProgressPageEn {
   String get titleSending => 'Sending files';
   @override
   String get titleReceiving => 'Receiving files';
+  @override
+  String get titleSent => 'Files sent';
+  @override
+  String get titleReceived => 'Files received';
   @override
   String get savedToGallery => 'Saved in Photos';
   @override
@@ -913,6 +921,27 @@ class _TranslationsSettingsTabReceiveEnIn extends TranslationsSettingsTabReceive
   String get saveToGallery => 'Save media to gallery';
   @override
   String get saveToHistory => 'Save to history';
+}
+
+// Path: settingsTab.save
+class _TranslationsSettingsTabSaveEnIn extends TranslationsSettingsTabSaveEn {
+  _TranslationsSettingsTabSaveEnIn._(TranslationsEnIn root) : this._root = root, super.internal(root);
+
+  final TranslationsEnIn _root; // ignore: unused_field
+
+  // Translations
+  @override
+  String get title => 'Save';
+  @override
+  String get saveLocation => 'Different save locations based on file type';
+  @override
+  String get defaultLocation => 'Default';
+  @override
+  String get documentsLocation => 'Documents';
+  @override
+  String get mediaLocation => 'Images and Videos';
+  @override
+  String get musicLocation => 'Music';
 }
 
 // Path: settingsTab.send

--- a/app/lib/model/state/server/receiving_file.dart
+++ b/app/lib/model/state/server/receiving_file.dart
@@ -11,6 +11,7 @@ class ReceivingFile with ReceivingFileMappable {
   final String? token;
   final String? desiredName; // not null when accepted
   final String? path; // when finished
+  final String? destinationDir;
   final bool savedToGallery; // when finished
   final String? errorMessage; // when status == failed
 
@@ -20,6 +21,7 @@ class ReceivingFile with ReceivingFileMappable {
     required this.token,
     required this.desiredName,
     required this.path,
+    required this.destinationDir,
     required this.savedToGallery,
     required this.errorMessage,
   });

--- a/app/lib/model/state/server/receiving_file.mapper.dart
+++ b/app/lib/model/state/server/receiving_file.mapper.dart
@@ -37,6 +37,11 @@ class ReceivingFileMapper extends ClassMapperBase<ReceivingFile> {
   );
   static String? _$path(ReceivingFile v) => v.path;
   static const Field<ReceivingFile, String> _f$path = Field('path', _$path);
+  static String? _$destinationDir(ReceivingFile v) => v.destinationDir;
+  static const Field<ReceivingFile, String> _f$destinationDir = Field(
+    'destinationDir',
+    _$destinationDir,
+  );
   static bool _$savedToGallery(ReceivingFile v) => v.savedToGallery;
   static const Field<ReceivingFile, bool> _f$savedToGallery = Field(
     'savedToGallery',
@@ -55,6 +60,7 @@ class ReceivingFileMapper extends ClassMapperBase<ReceivingFile> {
     #token: _f$token,
     #desiredName: _f$desiredName,
     #path: _f$path,
+    #destinationDir: _f$destinationDir,
     #savedToGallery: _f$savedToGallery,
     #errorMessage: _f$errorMessage,
   };
@@ -66,6 +72,7 @@ class ReceivingFileMapper extends ClassMapperBase<ReceivingFile> {
       token: data.dec(_f$token),
       desiredName: data.dec(_f$desiredName),
       path: data.dec(_f$path),
+      destinationDir: data.dec(_f$destinationDir),
       savedToGallery: data.dec(_f$savedToGallery),
       errorMessage: data.dec(_f$errorMessage),
     );
@@ -139,6 +146,7 @@ abstract class ReceivingFileCopyWith<$R, $In extends ReceivingFile, $Out>
     String? token,
     String? desiredName,
     String? path,
+    String? destinationDir,
     bool? savedToGallery,
     String? errorMessage,
   });
@@ -160,6 +168,7 @@ class _ReceivingFileCopyWithImpl<$R, $Out>
     Object? token = $none,
     Object? desiredName = $none,
     Object? path = $none,
+    Object? destinationDir = $none,
     bool? savedToGallery,
     Object? errorMessage = $none,
   }) => $apply(
@@ -169,6 +178,7 @@ class _ReceivingFileCopyWithImpl<$R, $Out>
       if (token != $none) #token: token,
       if (desiredName != $none) #desiredName: desiredName,
       if (path != $none) #path: path,
+      if (destinationDir != $none) #destinationDir: destinationDir,
       if (savedToGallery != null) #savedToGallery: savedToGallery,
       if (errorMessage != $none) #errorMessage: errorMessage,
     }),
@@ -180,6 +190,7 @@ class _ReceivingFileCopyWithImpl<$R, $Out>
     token: data.get(#token, or: $value.token),
     desiredName: data.get(#desiredName, or: $value.desiredName),
     path: data.get(#path, or: $value.path),
+    destinationDir: data.get(#destinationDir, or: $value.destinationDir),
     savedToGallery: data.get(#savedToGallery, or: $value.savedToGallery),
     errorMessage: data.get(#errorMessage, or: $value.errorMessage),
   );

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -38,7 +38,7 @@ class SettingsState with SettingsStateMappable {
   final bool saveLocationBasedOnFileType; // whether to allow different save location based on file type
   final String? documentsDestination;
   final String? mediaDestination;
-  final String? musicDestination;
+  final String? audioDestination;
 
   const SettingsState({
     required this.showToken,
@@ -70,6 +70,6 @@ class SettingsState with SettingsStateMappable {
     required this.saveLocationBasedOnFileType,
     required this.documentsDestination,
     required this.mediaDestination,
-    required this.musicDestination,
+    required this.audioDestination,
   });
 }

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -35,6 +35,10 @@ class SettingsState with SettingsStateMappable {
   final bool shareViaLinkAutoAccept;
   final int discoveryTimeout;
   final bool advancedSettings;
+  final bool saveLocationBasedOnFileType; // whether to allow different save location based on file type
+  final String? documentsDestination;
+  final String? mediaDestination;
+  final String? musicDestination;
 
   const SettingsState({
     required this.showToken,
@@ -63,5 +67,9 @@ class SettingsState with SettingsStateMappable {
     required this.shareViaLinkAutoAccept,
     required this.discoveryTimeout,
     required this.advancedSettings,
+    required this.saveLocationBasedOnFileType,
+    required this.documentsDestination,
+    required this.mediaDestination,
+    required this.musicDestination,
   });
 }

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -147,6 +147,26 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     'advancedSettings',
     _$advancedSettings,
   );
+  static bool _$saveLocationBasedOnFileType(SettingsState v) =>
+      v.saveLocationBasedOnFileType;
+  static const Field<SettingsState, bool> _f$saveLocationBasedOnFileType =
+      Field('saveLocationBasedOnFileType', _$saveLocationBasedOnFileType);
+  static String? _$documentsDestination(SettingsState v) =>
+      v.documentsDestination;
+  static const Field<SettingsState, String> _f$documentsDestination = Field(
+    'documentsDestination',
+    _$documentsDestination,
+  );
+  static String? _$mediaDestination(SettingsState v) => v.mediaDestination;
+  static const Field<SettingsState, String> _f$mediaDestination = Field(
+    'mediaDestination',
+    _$mediaDestination,
+  );
+  static String? _$musicDestination(SettingsState v) => v.musicDestination;
+  static const Field<SettingsState, String> _f$musicDestination = Field(
+    'musicDestination',
+    _$musicDestination,
+  );
 
   @override
   final MappableFields<SettingsState> fields = const {
@@ -176,6 +196,10 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #shareViaLinkAutoAccept: _f$shareViaLinkAutoAccept,
     #discoveryTimeout: _f$discoveryTimeout,
     #advancedSettings: _f$advancedSettings,
+    #saveLocationBasedOnFileType: _f$saveLocationBasedOnFileType,
+    #documentsDestination: _f$documentsDestination,
+    #mediaDestination: _f$mediaDestination,
+    #musicDestination: _f$musicDestination,
   };
 
   static SettingsState _instantiate(DecodingData data) {
@@ -206,6 +230,10 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
       shareViaLinkAutoAccept: data.dec(_f$shareViaLinkAutoAccept),
       discoveryTimeout: data.dec(_f$discoveryTimeout),
       advancedSettings: data.dec(_f$advancedSettings),
+      saveLocationBasedOnFileType: data.dec(_f$saveLocationBasedOnFileType),
+      documentsDestination: data.dec(_f$documentsDestination),
+      mediaDestination: data.dec(_f$mediaDestination),
+      musicDestination: data.dec(_f$musicDestination),
     );
   }
 
@@ -302,6 +330,10 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out>
     bool? shareViaLinkAutoAccept,
     int? discoveryTimeout,
     bool? advancedSettings,
+    bool? saveLocationBasedOnFileType,
+    String? documentsDestination,
+    String? mediaDestination,
+    String? musicDestination,
   });
   SettingsStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
@@ -360,6 +392,10 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     bool? shareViaLinkAutoAccept,
     int? discoveryTimeout,
     bool? advancedSettings,
+    bool? saveLocationBasedOnFileType,
+    Object? documentsDestination = $none,
+    Object? mediaDestination = $none,
+    Object? musicDestination = $none,
   }) => $apply(
     FieldCopyWithData({
       if (showToken != null) #showToken: showToken,
@@ -391,6 +427,12 @@ class _SettingsStateCopyWithImpl<$R, $Out>
         #shareViaLinkAutoAccept: shareViaLinkAutoAccept,
       if (discoveryTimeout != null) #discoveryTimeout: discoveryTimeout,
       if (advancedSettings != null) #advancedSettings: advancedSettings,
+      if (saveLocationBasedOnFileType != null)
+        #saveLocationBasedOnFileType: saveLocationBasedOnFileType,
+      if (documentsDestination != $none)
+        #documentsDestination: documentsDestination,
+      if (mediaDestination != $none) #mediaDestination: mediaDestination,
+      if (musicDestination != $none) #musicDestination: musicDestination,
     }),
   );
   @override
@@ -430,6 +472,16 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     ),
     discoveryTimeout: data.get(#discoveryTimeout, or: $value.discoveryTimeout),
     advancedSettings: data.get(#advancedSettings, or: $value.advancedSettings),
+    saveLocationBasedOnFileType: data.get(
+      #saveLocationBasedOnFileType,
+      or: $value.saveLocationBasedOnFileType,
+    ),
+    documentsDestination: data.get(
+      #documentsDestination,
+      or: $value.documentsDestination,
+    ),
+    mediaDestination: data.get(#mediaDestination, or: $value.mediaDestination),
+    musicDestination: data.get(#musicDestination, or: $value.musicDestination),
   );
 
   @override

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -162,10 +162,10 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     'mediaDestination',
     _$mediaDestination,
   );
-  static String? _$musicDestination(SettingsState v) => v.musicDestination;
-  static const Field<SettingsState, String> _f$musicDestination = Field(
-    'musicDestination',
-    _$musicDestination,
+  static String? _$audioDestination(SettingsState v) => v.audioDestination;
+  static const Field<SettingsState, String> _f$audioDestination = Field(
+    'audioDestination',
+    _$audioDestination,
   );
 
   @override
@@ -199,7 +199,7 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #saveLocationBasedOnFileType: _f$saveLocationBasedOnFileType,
     #documentsDestination: _f$documentsDestination,
     #mediaDestination: _f$mediaDestination,
-    #musicDestination: _f$musicDestination,
+    #audioDestination: _f$audioDestination,
   };
 
   static SettingsState _instantiate(DecodingData data) {
@@ -233,7 +233,7 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
       saveLocationBasedOnFileType: data.dec(_f$saveLocationBasedOnFileType),
       documentsDestination: data.dec(_f$documentsDestination),
       mediaDestination: data.dec(_f$mediaDestination),
-      musicDestination: data.dec(_f$musicDestination),
+      audioDestination: data.dec(_f$audioDestination),
     );
   }
 
@@ -333,7 +333,7 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out>
     bool? saveLocationBasedOnFileType,
     String? documentsDestination,
     String? mediaDestination,
-    String? musicDestination,
+    String? audioDestination,
   });
   SettingsStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
@@ -395,7 +395,7 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     bool? saveLocationBasedOnFileType,
     Object? documentsDestination = $none,
     Object? mediaDestination = $none,
-    Object? musicDestination = $none,
+    Object? audioDestination = $none,
   }) => $apply(
     FieldCopyWithData({
       if (showToken != null) #showToken: showToken,
@@ -432,7 +432,7 @@ class _SettingsStateCopyWithImpl<$R, $Out>
       if (documentsDestination != $none)
         #documentsDestination: documentsDestination,
       if (mediaDestination != $none) #mediaDestination: mediaDestination,
-      if (musicDestination != $none) #musicDestination: musicDestination,
+      if (audioDestination != $none) #audioDestination: audioDestination,
     }),
   );
   @override
@@ -481,7 +481,7 @@ class _SettingsStateCopyWithImpl<$R, $Out>
       or: $value.documentsDestination,
     ),
     mediaDestination: data.get(#mediaDestination, or: $value.mediaDestination),
-    musicDestination: data.get(#musicDestination, or: $value.musicDestination),
+    audioDestination: data.get(#audioDestination, or: $value.audioDestination),
   );
 
   @override

--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -186,6 +186,7 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
       (prev, curr) => prev + ((progressNotifier.getProgress(sessionId: widget.sessionId, fileId: curr.id) * curr.size).round()),
     );
 
+    final settings = ref.watch(settingsProvider);
     final receiveSession = ref.watch(serverProvider.select((s) => s?.session));
     final sendSession = ref.watch(sendProvider)[widget.sessionId];
 
@@ -208,7 +209,13 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
       TaskbarHelper.visualizeStatus(status);
     }
 
-    final title = receiveSession != null ? t.progressPage.titleReceiving : t.progressPage.titleSending;
+    String title = '';
+    if (receiveSession != null) {
+      title = receiveSession.status == SessionStatus.sending ? t.progressPage.titleReceiving : t.progressPage.titleReceived;
+    } else if (sendSession != null) {
+      title = sendSession.status == SessionStatus.sending ? t.progressPage.titleSending : t.progressPage.titleSent;
+    }
+
     final startTime = commonSessionState.startTime;
     final endTime = commonSessionState.endTime;
     final int? speedInBytes;
@@ -262,7 +269,7 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(title, style: Theme.of(context).textTheme.titleLarge),
-                        if (checkPlatformWithFileSystem() && receiveSession != null)
+                        if (receiveSession != null && checkPlatformWithFileSystem() && !settings.saveLocationBasedOnFileType)
                           Padding(
                             padding: const EdgeInsets.only(bottom: 10),
                             child: Text.rich(
@@ -384,12 +391,40 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                               else
                                 Row(
                                   children: [
-                                    Flexible(
-                                      child: Text(
+                                    if (receiveSession != null && checkPlatformWithFileSystem() && settings.saveLocationBasedOnFileType)
+                                      Flexible(
+                                        child: Text.rich(
+                                          TextSpan(
+                                            children: [
+                                              TextSpan(
+                                                text: 'Saved in ',
+                                                style: const TextStyle(color: Colors.grey),
+                                              ),
+                                              TextSpan(
+                                                text: filePath?.substring(0, filePath.lastIndexOf('/') + 1) ?? receiveSession.destinationDirectory,
+                                                style: TextStyle(
+                                                  color: checkPlatform([TargetPlatform.iOS]) ? Colors.grey : Theme.of(context).colorScheme.primary,
+                                                ),
+                                                recognizer: !checkPlatform([TargetPlatform.iOS])
+                                                    ? (TapGestureRecognizer()
+                                                        ..onTap = () async {
+                                                          await openFolder(
+                                                            folderPath:
+                                                                filePath?.substring(0, filePath.lastIndexOf('/') + 1) ??
+                                                                receiveSession.destinationDirectory,
+                                                          );
+                                                        })
+                                                    : null,
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      )
+                                    else
+                                      Text(
                                         savedToGallery ? t.progressPage.savedToGallery : fileStatus.label,
                                         style: TextStyle(color: fileStatus.getColor(context), height: 1),
                                       ),
-                                    ),
                                     if (errorMessage != null) ...[
                                       const SizedBox(width: 5),
                                       InkWell(

--- a/app/lib/pages/receive_options_page.dart
+++ b/app/lib/pages/receive_options_page.dart
@@ -3,6 +3,7 @@ import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/pages/receive_page.dart';
 import 'package:localsend_app/provider/network/server/server_provider.dart';
 import 'package:localsend_app/provider/selection/selected_receiving_files_provider.dart';
+import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/file_size_helper.dart';
 import 'package:localsend_app/util/file_type_ext.dart';
 import 'package:localsend_app/util/native/pick_directory_path.dart';
@@ -23,6 +24,7 @@ class ReceiveOptionsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final ref = context.ref;
     final receiveSession = ref.watch(serverProvider.select((s) => s?.session));
+    final settings = ref.read(settingsProvider);
     if (receiveSession == null) {
       return Scaffold(
         body: Container(),
@@ -40,7 +42,7 @@ class ReceiveOptionsPage extends StatelessWidget {
           Row(
             children: [
               Text(t.receiveOptionsPage.destination, style: Theme.of(context).textTheme.titleLarge),
-              if (checkPlatformWithFileSystem())
+              if (checkPlatformWithFileSystem() && !settings.saveLocationBasedOnFileType)
                 Padding(
                   padding: const EdgeInsets.only(left: 10),
                   child: CustomIconButton(
@@ -56,7 +58,13 @@ class ReceiveOptionsPage extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 5),
-          Text(checkPlatformWithFileSystem() ? receiveSession.destinationDirectory : t.receiveOptionsPage.appDirectory),
+          Text(
+            checkPlatformWithFileSystem()
+                ? settings.saveLocationBasedOnFileType
+                      ? t.receiveOptionsPage.editDirectoryInSettings
+                      : receiveSession.destinationDirectory
+                : t.receiveOptionsPage.appDirectory,
+          ),
           if (checkPlatformWithGallery())
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -226,14 +226,14 @@ class SettingsTab extends StatelessWidget {
                             await ref.notifier(settingsProvider).setSaveToGallery(b);
                           },
                         ),
-                      if (checkPlatformWithFileSystem()) 
-                      _BooleanEntry(
-                        label: t.settingsTab.save.saveLocation,
-                        value: vm.settings.saveLocationBasedOnFileType,
-                        onChanged: (b) async {
-                          await ref.notifier(settingsProvider).setSaveLocationBasedOnFileType(b);
-                        },
-                      ),
+                      if (checkPlatformWithFileSystem())
+                        _BooleanEntry(
+                          label: t.settingsTab.save.saveLocation,
+                          value: vm.settings.saveLocationBasedOnFileType,
+                          onChanged: (b) async {
+                            await ref.notifier(settingsProvider).setSaveLocationBasedOnFileType(b);
+                          },
+                        ),
                       _SettingsEntry(
                         label: t.settingsTab.save.defaultLocation,
                         child: TextButton(
@@ -345,8 +345,8 @@ class SettingsTab extends StatelessWidget {
                               foregroundColor: Theme.of(context).colorScheme.onSurface,
                             ),
                             onPressed: () async {
-                              if (vm.settings.musicDestination != null) {
-                                await ref.notifier(settingsProvider).setMusicDestination(null);
+                              if (vm.settings.audioDestination != null) {
+                                await ref.notifier(settingsProvider).setAudioDestination(null);
                                 if (defaultTargetPlatform == TargetPlatform.macOS) {
                                   await removeExistingDestinationAccess();
                                 }
@@ -358,13 +358,13 @@ class SettingsTab extends StatelessWidget {
                                 if (defaultTargetPlatform == TargetPlatform.macOS) {
                                   await persistDestinationFolderAccess(directory);
                                 }
-                                await ref.notifier(settingsProvider).setMusicDestination(directory);
+                                await ref.notifier(settingsProvider).setAudioDestination(directory);
                               }
                             },
                             child: Padding(
                               padding: const EdgeInsets.symmetric(vertical: 5),
                               child: Text(
-                                vm.settings.musicDestination ?? t.settingsTab.receive.downloads,
+                                vm.settings.audioDestination ?? t.settingsTab.receive.downloads,
                                 style: Theme.of(context).textTheme.titleMedium,
                               ),
                             ),

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -56,6 +56,7 @@ class SettingsTab extends StatelessWidget {
                   SizedBox(height: 30 + MediaQuery.of(context).padding.top),
                   _SettingsSection(
                     title: t.settingsTab.general.title,
+                    icon: Icons.settings,
                     children: [
                       _SettingsEntry(
                         label: t.settingsTab.general.brightness,
@@ -151,6 +152,7 @@ class SettingsTab extends StatelessWidget {
                   ),
                   _SettingsSection(
                     title: t.settingsTab.receive.title,
+                    icon: Icons.wifi,
                     children: [
                       _BooleanEntry(
                         label: t.settingsTab.receive.quickSave,
@@ -196,46 +198,6 @@ class SettingsTab extends StatelessWidget {
                           }
                         },
                       ),
-                      if (checkPlatformWithFileSystem())
-                        _SettingsEntry(
-                          label: t.settingsTab.receive.destination,
-                          child: TextButton(
-                            style: TextButton.styleFrom(
-                              backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
-                              shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
-                              foregroundColor: Theme.of(context).colorScheme.onSurface,
-                            ),
-                            onPressed: () async {
-                              if (vm.settings.destination != null) {
-                                await ref.notifier(settingsProvider).setDestination(null);
-                                if (defaultTargetPlatform == TargetPlatform.macOS) {
-                                  await removeExistingDestinationAccess();
-                                }
-                                return;
-                              }
-
-                              final directory = await pickDirectoryPath();
-                              if (directory != null) {
-                                if (defaultTargetPlatform == TargetPlatform.macOS) {
-                                  await persistDestinationFolderAccess(directory);
-                                }
-                                await ref.notifier(settingsProvider).setDestination(directory);
-                              }
-                            },
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(vertical: 5),
-                              child: Text(vm.settings.destination ?? t.settingsTab.receive.downloads, style: Theme.of(context).textTheme.titleMedium),
-                            ),
-                          ),
-                        ),
-                      if (checkPlatformWithGallery())
-                        _BooleanEntry(
-                          label: t.settingsTab.receive.saveToGallery,
-                          value: vm.settings.saveToGallery,
-                          onChanged: (b) async {
-                            await ref.notifier(settingsProvider).setSaveToGallery(b);
-                          },
-                        ),
                       _BooleanEntry(
                         label: t.settingsTab.receive.autoFinish,
                         value: vm.settings.autoFinish,
@@ -252,9 +214,168 @@ class SettingsTab extends StatelessWidget {
                       ),
                     ],
                   ),
+                  _SettingsSection(
+                    title: t.settingsTab.save.title,
+                    icon: Icons.save,
+                    children: [
+                      if (checkPlatformWithGallery())
+                        _BooleanEntry(
+                          label: t.settingsTab.receive.saveToGallery,
+                          value: vm.settings.saveToGallery,
+                          onChanged: (b) async {
+                            await ref.notifier(settingsProvider).setSaveToGallery(b);
+                          },
+                        ),
+                      if (checkPlatformWithFileSystem()) 
+                      _BooleanEntry(
+                        label: t.settingsTab.save.saveLocation,
+                        value: vm.settings.saveLocationBasedOnFileType,
+                        onChanged: (b) async {
+                          await ref.notifier(settingsProvider).setSaveLocationBasedOnFileType(b);
+                        },
+                      ),
+                      _SettingsEntry(
+                        label: t.settingsTab.save.defaultLocation,
+                        child: TextButton(
+                          style: TextButton.styleFrom(
+                            backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
+                            shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
+                            foregroundColor: Theme.of(context).colorScheme.onSurface,
+                          ),
+                          onPressed: () async {
+                            if (vm.settings.destination != null) {
+                              await ref.notifier(settingsProvider).setDestination(null);
+                              if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                await removeExistingDestinationAccess();
+                              }
+                              return;
+                            }
+
+                            final directory = await pickDirectoryPath();
+                            if (directory != null) {
+                              if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                await persistDestinationFolderAccess(directory);
+                              }
+                              await ref.notifier(settingsProvider).setDestination(directory);
+                            }
+                          },
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 5),
+                            child: Text(vm.settings.destination ?? t.settingsTab.receive.downloads, style: Theme.of(context).textTheme.titleMedium),
+                          ),
+                        ),
+                      ),
+                      if (vm.settings.saveLocationBasedOnFileType)
+                        _SettingsEntry(
+                          label: t.settingsTab.save.documentsLocation,
+                          child: TextButton(
+                            style: TextButton.styleFrom(
+                              backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
+                              shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
+                              foregroundColor: Theme.of(context).colorScheme.onSurface,
+                            ),
+                            onPressed: () async {
+                              if (vm.settings.documentsDestination != null) {
+                                await ref.notifier(settingsProvider).setDocumentsDestination(null);
+                                if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                  await removeExistingDestinationAccess();
+                                }
+                                return;
+                              }
+
+                              final directory = await pickDirectoryPath();
+                              if (directory != null) {
+                                if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                  await persistDestinationFolderAccess(directory);
+                                }
+                                await ref.notifier(settingsProvider).setDocumentsDestination(directory);
+                              }
+                            },
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 5),
+                              child: Text(
+                                vm.settings.documentsDestination ?? t.settingsTab.receive.downloads,
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                            ),
+                          ),
+                        ),
+                      if (vm.settings.saveLocationBasedOnFileType)
+                        _SettingsEntry(
+                          label: t.settingsTab.save.mediaLocation,
+                          child: TextButton(
+                            style: TextButton.styleFrom(
+                              backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
+                              shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
+                              foregroundColor: Theme.of(context).colorScheme.onSurface,
+                            ),
+                            onPressed: () async {
+                              if (vm.settings.mediaDestination != null) {
+                                await ref.notifier(settingsProvider).setMediaDestination(null);
+                                if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                  await removeExistingDestinationAccess();
+                                }
+                                return;
+                              }
+
+                              final directory = await pickDirectoryPath();
+                              if (directory != null) {
+                                if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                  await persistDestinationFolderAccess(directory);
+                                }
+                                await ref.notifier(settingsProvider).setMediaDestination(directory);
+                              }
+                            },
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 5),
+                              child: Text(
+                                vm.settings.mediaDestination ?? t.settingsTab.receive.downloads,
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                            ),
+                          ),
+                        ),
+                      if (vm.settings.saveLocationBasedOnFileType)
+                        _SettingsEntry(
+                          label: t.settingsTab.save.musicLocation,
+                          child: TextButton(
+                            style: TextButton.styleFrom(
+                              backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
+                              shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
+                              foregroundColor: Theme.of(context).colorScheme.onSurface,
+                            ),
+                            onPressed: () async {
+                              if (vm.settings.musicDestination != null) {
+                                await ref.notifier(settingsProvider).setMusicDestination(null);
+                                if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                  await removeExistingDestinationAccess();
+                                }
+                                return;
+                              }
+
+                              final directory = await pickDirectoryPath();
+                              if (directory != null) {
+                                if (defaultTargetPlatform == TargetPlatform.macOS) {
+                                  await persistDestinationFolderAccess(directory);
+                                }
+                                await ref.notifier(settingsProvider).setMusicDestination(directory);
+                              }
+                            },
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 5),
+                              child: Text(
+                                vm.settings.musicDestination ?? t.settingsTab.receive.downloads,
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
                   if (vm.advanced)
                     _SettingsSection(
                       title: t.settingsTab.send.title,
+                      icon: Icons.send,
                       children: [
                         _BooleanEntry(
                           label: t.settingsTab.send.shareViaLinkAutoAccept,
@@ -267,6 +388,7 @@ class SettingsTab extends StatelessWidget {
                     ),
                   _SettingsSection(
                     title: t.settingsTab.network.title,
+                    icon: Icons.account_tree_outlined,
                     children: [
                       AnimatedCrossFade(
                         crossFadeState:
@@ -490,6 +612,7 @@ class SettingsTab extends StatelessWidget {
                   ),
                   _SettingsSection(
                     title: t.settingsTab.other.title,
+                    icon: Icons.more_horiz,
                     padding: const EdgeInsets.only(bottom: 0),
                     children: [
                       _ButtonEntry(
@@ -715,11 +838,13 @@ class _ButtonEntry extends StatelessWidget {
 
 class _SettingsSection extends StatelessWidget {
   final String title;
+  final IconData? icon;
   final List<Widget> children;
   final EdgeInsets padding;
 
   const _SettingsSection({
     required this.title,
+    this.icon,
     required this.children,
     this.padding = const EdgeInsets.only(bottom: 15),
   });
@@ -734,7 +859,15 @@ class _SettingsSection extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(title, style: Theme.of(context).textTheme.titleMedium),
+              Row(
+                children: [
+                  Text(title, style: Theme.of(context).textTheme.titleMedium),
+                  if (icon != null) ...[
+                    const SizedBox(width: 8),
+                    Icon(icon),
+                  ],
+                ],
+              ),
               const SizedBox(height: 10),
               ...children,
             ],

--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -242,11 +242,11 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     } else {
       try {
         fileMap = response.response!.files;
-        final sessionId = response.response!.sessionId;
+        final receiverSessionId = response.response!.sessionId;
         state = state.updateSession(
           sessionId: sessionId,
           state: (s) => s?.copyWith(
-            remoteSessionId: sessionId,
+            remoteSessionId: receiverSessionId,
           ),
         );
       } catch (e) {

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -221,8 +221,7 @@ class ReceiveController {
     }
 
     final settings = server.ref.read(settingsProvider);
-    var fileType = request.headers.contentType?.mimeType;
-    final destinationDir = settings.destination ?? await getDefaultDestinationDirectory(fileMimeTypel: fileType);
+    final destinationDir = settings.destination ?? await getDefaultDestinationDirectory();
     final cacheDir = await getCacheDirectory();
     final sessionId = _uuid.v4();
 
@@ -498,6 +497,17 @@ class ReceiveController {
     );
     final fileType = receivingFile.file.fileType;
     final shouldSaveToGallery = receiveState.saveToGallery && (fileType == FileType.image || fileType == FileType.video);
+
+    if (server.ref.read(settingsProvider).saveLocationBasedOnFileType) {
+      final destinationDir = await getDestionationDirectoryByFileType(receivingFile.file.fileName, server.ref.read(settingsProvider));
+      server.setState(
+        (oldState) => oldState?.copyWith(
+          session: oldState.session?.copyWith(
+            destinationDirectory: destinationDir,
+          ),
+        ),
+      );
+    }
 
     String? filePath;
     bool savedToGallery = false;

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -221,12 +221,35 @@ class ReceiveController {
     }
 
     final settings = server.ref.read(settingsProvider);
-    final destinationDir = settings.destination ?? await getDefaultDestinationDirectory();
+    final defaultDestinationDir = await getDefaultDestinationDirectory();
     final cacheDir = await getCacheDirectory();
     final sessionId = _uuid.v4();
 
+    final fileEntries = await Future.wait(
+      dto.files.values.map((file) async {
+        final destinationDir = settings.saveLocationBasedOnFileType
+            ? await getDestinationDirectoryByFileType(file.fileName, settings)
+            : defaultDestinationDir;
+        _logger.info('For ${file.fileName} specific  directiory is $destinationDir');
+
+        return MapEntry(
+          file.id,
+          ReceivingFile(
+            file: file,
+            status: FileStatus.queue,
+            token: null,
+            desiredName: null,
+            path: null,
+            destinationDir: destinationDir,
+            savedToGallery: false,
+            errorMessage: null,
+          ),
+        );
+      }),
+    );
+
     _logger.info('Session Id: $sessionId');
-    _logger.info('Destination Directory: $destinationDir');
+    _logger.info('Default destination Directory: $defaultDestinationDir');
 
     final streamController = StreamController<Map<String, String>?>();
     server.setState(
@@ -236,21 +259,10 @@ class ReceiveController {
           status: SessionStatus.waiting,
           sender: dto.info.toDevice(request.ip, port, https, null),
           senderAlias: server.ref.read(favoritesProvider).firstWhereOrNull((e) => e.fingerprint == dto.info.fingerprint)?.alias ?? dto.info.alias,
-          files: {
-            for (final file in dto.files.values)
-              file.id: ReceivingFile(
-                file: file,
-                status: FileStatus.queue,
-                token: null,
-                desiredName: null,
-                path: null,
-                savedToGallery: false,
-                errorMessage: null,
-              ),
-          },
+          files: Map.fromEntries(fileEntries),
           startTime: null,
           endTime: null,
-          destinationDirectory: destinationDir,
+          destinationDirectory: defaultDestinationDir,
           cacheDirectory: cacheDir,
           saveToGallery: checkPlatformWithGallery() && settings.saveToGallery && dto.files.values.every((f) => !f.fileName.contains('/')),
           createdDirectories: {},
@@ -380,6 +392,7 @@ class ReceiveController {
                     token: desiredName != null ? _uuid.v4() : null,
                     desiredName: desiredName,
                     path: null,
+                    destinationDir: fileEntries.firstWhere((file) => file.key == entry.file.id.toString()).value.destinationDir,
                     savedToGallery: false,
                     errorMessage: null,
                   ),
@@ -498,24 +511,13 @@ class ReceiveController {
     final fileType = receivingFile.file.fileType;
     final shouldSaveToGallery = receiveState.saveToGallery && (fileType == FileType.image || fileType == FileType.video);
 
-    if (server.ref.read(settingsProvider).saveLocationBasedOnFileType) {
-      final destinationDir = await getDestionationDirectoryByFileType(receivingFile.file.fileName, server.ref.read(settingsProvider));
-      server.setState(
-        (oldState) => oldState?.copyWith(
-          session: oldState.session?.copyWith(
-            destinationDirectory: destinationDir,
-          ),
-        ),
-      );
-    }
-
     String? filePath;
     bool savedToGallery = false;
     try {
       _logger.info('Saving ${receivingFile.file.fileName}');
 
       (savedToGallery, filePath) = await saveFile(
-        destinationDirectory: receiveState.destinationDirectory,
+        destinationDirectory: receivingFile.destinationDir ?? receiveState.destinationDirectory,
         fileName: receivingFile.desiredName!,
         saveToGallery: shouldSaveToGallery,
         isImage: fileType == FileType.image,

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -221,7 +221,8 @@ class ReceiveController {
     }
 
     final settings = server.ref.read(settingsProvider);
-    final destinationDir = settings.destination ?? await getDefaultDestinationDirectory();
+    var fileType = request.headers.contentType?.mimeType;
+    final destinationDir = settings.destination ?? await getDefaultDestinationDirectory(fileMimeTypel: fileType);
     final cacheDir = await getCacheDirectory();
     final sessionId = _uuid.v4();
 

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -67,7 +67,7 @@ const _saveWindowPlacement = 'ls_save_window_placement';
 // Multiple save destinations based on file type
 const _documentsDestination = 'ls_documents_destination';
 const _mediaDestination = 'ls_media_destination';
-const _musicDestination = 'ls_music_destination';
+const _audioDestination = 'ls_audio_destination';
 
 // Settings
 const _showToken = 'ls_show_token';
@@ -417,15 +417,15 @@ class PersistenceService {
     }
   }
 
-  String? getMusicDestination() {
-    return _prefs.getString(_musicDestination);
+  String? getAudioDestination() {
+    return _prefs.getString(_audioDestination);
   }
 
-  Future<void> setMusicDestination(String? destination) async {
+  Future<void> setAudioDestination(String? destination) async {
     if (destination == null) {
-      await _prefs.remove(_musicDestination);
+      await _prefs.remove(_audioDestination);
     } else {
-      await _prefs.setString(_musicDestination, destination);
+      await _prefs.setString(_audioDestination, destination);
     }
   }
 

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -64,6 +64,11 @@ const _windowWidth = 'ls_window_width';
 const _windowHeight = 'ls_window_height';
 const _saveWindowPlacement = 'ls_save_window_placement';
 
+// Multiple save destinations based on file type
+const _documentsDestination = 'ls_documents_destination';
+const _mediaDestination = 'ls_media_destination';
+const _musicDestination = 'ls_music_destination';
+
 // Settings
 const _showToken = 'ls_show_token';
 const _aliasKey = 'ls_alias';
@@ -89,6 +94,7 @@ const _enableAnimations = 'ls_enable_animations';
 const _deviceType = 'ls_device_type';
 const _deviceModel = 'ls_device_model';
 const _shareViaLinkAutoAccept = 'ls_share_via_link_auto_accept';
+const _saveLocationBasedOnFileType = 'ls_save_location_based_on_file_type';
 const _advancedSettingsKey = 'ls_advanced_settings';
 
 final persistenceProvider = Provider<PersistenceService>((ref) {
@@ -387,6 +393,42 @@ class PersistenceService {
     }
   }
 
+  String? getDocumentsDestination() {
+    return _prefs.getString(_documentsDestination);
+  }
+
+  Future<void> setDocumentsDestination(String? destination) async {
+    if (destination == null) {
+      await _prefs.remove(_documentsDestination);
+    } else {
+      await _prefs.setString(_documentsDestination, destination);
+    }
+  }
+
+  String? getMediaDestination() {
+    return _prefs.getString(_mediaDestination);
+  }
+
+  Future<void> setMediaDestination(String? destination) async {
+    if (destination == null) {
+      await _prefs.remove(_mediaDestination);
+    } else {
+      await _prefs.setString(_mediaDestination, destination);
+    }
+  }
+
+  String? getMusicDestination() {
+    return _prefs.getString(_musicDestination);
+  }
+
+  Future<void> setMusicDestination(String? destination) async {
+    if (destination == null) {
+      await _prefs.remove(_musicDestination);
+    } else {
+      await _prefs.setString(_musicDestination, destination);
+    }
+  }
+
   bool isSaveToGallery() {
     return _prefs.getBool(_saveToGallery) ?? true;
   }
@@ -425,6 +467,14 @@ class PersistenceService {
 
   Future<void> setQuickSaveFromFavorites(bool quickSaveFromFavorites) async {
     await _prefs.setBool(_quickSaveFromFavorites, quickSaveFromFavorites);
+  }
+
+  Future<void> setSaveLocationBasedOnFileType(bool saveLocationBasedOnFileType) async {
+    await _prefs.setBool(_saveLocationBasedOnFileType, saveLocationBasedOnFileType);
+  }
+
+  bool isSaveLocationBasedOnFileType() {
+    return _prefs.getBool(_saveLocationBasedOnFileType) ?? false;
   }
 
   String? getReceivePin() {

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -73,7 +73,7 @@ class SettingsService extends PureNotifier<SettingsState> {
     saveLocationBasedOnFileType: _persistence.isSaveLocationBasedOnFileType(),
     documentsDestination: _persistence.getDocumentsDestination(),
     mediaDestination: _persistence.getMediaDestination(),
-    musicDestination: _persistence.getMusicDestination(),
+    audioDestination: _persistence.getAudioDestination(),
   );
 
   Future<void> setAlias(String alias) async {
@@ -167,10 +167,10 @@ class SettingsService extends PureNotifier<SettingsState> {
     );
   }
 
-  Future<void> setMusicDestination(String? destination) async {
-    await _persistence.setMusicDestination(destination);
+  Future<void> setAudioDestination(String? destination) async {
+    await _persistence.setAudioDestination(destination);
     state = state.copyWith(
-      musicDestination: destination,
+      audioDestination: destination,
     );
   }
 

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -70,6 +70,10 @@ class SettingsService extends PureNotifier<SettingsState> {
     shareViaLinkAutoAccept: _persistence.getShareViaLinkAutoAccept(),
     discoveryTimeout: _persistence.getDiscoveryTimeout(),
     advancedSettings: _persistence.getAdvancedSettingsEnabled(),
+    saveLocationBasedOnFileType: _persistence.isSaveLocationBasedOnFileType(),
+    documentsDestination: _persistence.getDocumentsDestination(),
+    mediaDestination: _persistence.getMediaDestination(),
+    musicDestination: _persistence.getMusicDestination(),
   );
 
   Future<void> setAlias(String alias) async {
@@ -146,6 +150,27 @@ class SettingsService extends PureNotifier<SettingsState> {
     await _persistence.setDestination(destination);
     state = state.copyWith(
       destination: destination,
+    );
+  }
+
+  Future<void> setDocumentsDestination(String? destination) async {
+    await _persistence.setDocumentsDestination(destination);
+    state = state.copyWith(
+      documentsDestination: destination,
+    );
+  }
+
+  Future<void> setMediaDestination(String? destination) async {
+    await _persistence.setMediaDestination(destination);
+    state = state.copyWith(
+      mediaDestination: destination,
+    );
+  }
+
+  Future<void> setMusicDestination(String? destination) async {
+    await _persistence.setMusicDestination(destination);
+    state = state.copyWith(
+      musicDestination: destination,
     );
   }
 
@@ -245,6 +270,14 @@ class SettingsService extends PureNotifier<SettingsState> {
 
     state = state.copyWith(
       shareViaLinkAutoAccept: shareViaLinkAutoAccept,
+    );
+  }
+
+  Future<void> setSaveLocationBasedOnFileType(bool saveLocationBasedOnFileType) async {
+    await _persistence.setSaveLocationBasedOnFileType(saveLocationBasedOnFileType);
+
+    state = state.copyWith(
+      saveLocationBasedOnFileType: saveLocationBasedOnFileType,
     );
   }
 }

--- a/app/lib/util/native/directories.dart
+++ b/app/lib/util/native/directories.dart
@@ -38,10 +38,10 @@ Future<String> getCacheDirectory() async {
   return (await path.getTemporaryDirectory()).path;
 }
 
-Future<String> getDestionationDirectoryByFileType(String fileName, SettingsState settings) async {
+Future<String> getDestinationDirectoryByFileType(String fileName, SettingsState settings) async {
   final defaultDestination = await getDefaultDestinationDirectory();
   final String? rawMime = lookupMimeType(fileName);
-  print('fileName: $fileName, rawMime: $rawMime');
+
   if (rawMime == null) {
     return settings.destination ?? defaultDestination;
   }
@@ -54,12 +54,10 @@ Future<String> getDestionationDirectoryByFileType(String fileName, SettingsState
 
   // other types has "correct" type in first part
   switch (rawMime.split('/').first) {
-    case 'text':
-      return settings.documentsDestination ?? defaultDestination;
     case 'image' || 'video':
       return settings.mediaDestination ?? defaultDestination;
     case 'audio':
-      return settings.destination ?? defaultDestination;
+      return settings.audioDestination ?? defaultDestination;
     default:
       return settings.destination ?? defaultDestination;
   }

--- a/app/lib/util/native/directories.dart
+++ b/app/lib/util/native/directories.dart
@@ -1,6 +1,8 @@
 import 'dart:io' show Directory, Platform;
 
 import 'package:flutter/foundation.dart';
+import 'package:localsend_app/model/state/settings_state.dart';
+import 'package:mime/mime.dart';
 import 'package:path_provider/path_provider.dart' as path;
 
 Future<String> getDefaultDestinationDirectory() async {
@@ -34,4 +36,31 @@ Future<String> getDefaultDestinationDirectory() async {
 
 Future<String> getCacheDirectory() async {
   return (await path.getTemporaryDirectory()).path;
+}
+
+Future<String> getDestionationDirectoryByFileType(String fileName, SettingsState settings) async {
+  final defaultDestination = await getDefaultDestinationDirectory();
+  final String? rawMime = lookupMimeType(fileName);
+  print('fileName: $fileName, rawMime: $rawMime');
+  if (rawMime == null) {
+    return settings.destination ?? defaultDestination;
+  }
+
+  // some mime types are "application" but users see it as documents
+  // "application/vnd.openxmlformats-officedocument.wordprocessingml.document" is docx
+  if (rawMime.contains('document') || rawMime.contains('pdf')) {
+    return settings.documentsDestination ?? defaultDestination;
+  }
+
+  // other types has "correct" type in first part
+  switch (rawMime.split('/').first) {
+    case 'text':
+      return settings.documentsDestination ?? defaultDestination;
+    case 'image' || 'video':
+      return settings.mediaDestination ?? defaultDestination;
+    case 'audio':
+      return settings.destination ?? defaultDestination;
+    default:
+      return settings.destination ?? defaultDestination;
+  }
 }


### PR DESCRIPTION
Closes #2839 implementing new feature.

> [!IMPORTANT]
> Changes made in `app/lib/provider/network/send_provider.dart` (renaming the `sessionId` variable) are important because without them the send process finishes with error. The name of variable is covered up, which result in returning null value. 

## Summary
This PR adds new feature that allow user to choose multiple save locations that are automatically assing based on file type. I added 4 rules - default, documents, images and videos, music (audio)

## Changes
- Added new section in setting for toggling this feature and choosing locations.
- Added icons to sections in settings.
- Added destionation directory field for each receiving file.
- Added required backend logic for this feature.
- Updated title on progress page to be more descriptive (Files sending -> Files sent, ...).
- Updated some translation for this feature (en, cs, de).

## Showcase
<img width="410" alt="Screenshot-save-01" src="https://github.com/user-attachments/assets/c2728103-f474-4127-8c0e-5033f1f994d9" />
<img width="321" alt="Screenshot-save-02" src="https://github.com/user-attachments/assets/c00f60a0-8290-4656-a1c5-809da1571c70" />


## Future ideas
Maybe it would be nice to put together more of the mimeType functions used and divide files into more categories. It would get us more locations for saving and also different icons that represent transfered file.



