### PR TITLE
fix: rename sessionId to receiverSessionId

### DIFF
--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -242,11 +242,11 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
     } else {
       try {
         fileMap = response.response!.files;
-        final sessionId = response.response!.sessionId;
+        final receiverSessionId = response.response!.sessionId;
         state = state.updateSession(
           sessionId: sessionId,
           state: (s) => s?.copyWith(
-            remoteSessionId: sessionId,
+            remoteSessionId: receiverSessionId,
           ),
         );
       } catch (e) {


### PR DESCRIPTION
Fixed a critical error that prevented the transfer from completing due to an improperly named variable. The name sessionId was obscured, causing a null to be returned.