### PR TITLE
feat: display transfer time

### DIFF
--- a/app/assets/i18n/cs.json
+++ b/app/assets/i18n/cs.json
@@ -231,7 +231,7 @@
     "savedToGallery": "Uloženo ve Fotkách",
     "total": {
       "title": {
-        "sending": "Celkový průběh ({time})",
+        "sending": "Celkový průběh (zbývá {time})",
         "finishedSuccess": "Dokončeno za {time}",
         "finishedError": "Dokončeno s chybou",
         "canceledSender": "Zrušeno odesílatelem",

--- a/app/assets/i18n/cs.json
+++ b/app/assets/i18n/cs.json
@@ -232,13 +232,16 @@
     "total": {
       "title": {
         "sending": "Celkový průběh ({time})",
+        "finishedSuccess": "Dokončeno za {time}",
         "finishedError": "Dokončeno s chybou",
         "canceledSender": "Zrušeno odesílatelem",
         "canceledReceiver": "Zrušeno příjemcem"
       },
       "count": "Soubory: {curr} / {n}",
       "size": "Velikost: {curr} / {n}",
-      "speed": "Rychlost: {speed}/s"
+      "speed": "Rychlost: {speed}/s",
+      "elapsedTime": "Uplynulý čas: {time}",
+      "transferTime": "Čas přenosu: {time}"
     }
   },
   "webSharePage": {

--- a/app/assets/i18n/de.json
+++ b/app/assets/i18n/de.json
@@ -231,7 +231,7 @@
     "savedToGallery": "in Fotos gespeichert",
     "total": {
       "title": {
-        "sending": "Gesamtfortschritt ({time})",
+        "sending": "Gesamtfortschritt (verbleibende {time})",
         "finishedSuccess": "In {time} abgeschlossen",
         "finishedError": "Abgeschlossen mit Fehler",
         "canceledSender": "Abgebrochen durch Absender",

--- a/app/assets/i18n/de.json
+++ b/app/assets/i18n/de.json
@@ -232,13 +232,16 @@
     "total": {
       "title": {
         "sending": "Gesamtfortschritt ({time})",
+        "finishedSuccess": "In {time} abgeschlossen",
         "finishedError": "Abgeschlossen mit Fehler",
         "canceledSender": "Abgebrochen durch Absender",
         "canceledReceiver": "Abgebrochen durch Empfänger"
       },
       "count": "Dateien: {curr} / {n}",
       "size": "Größe: {curr} / {n}",
-      "speed": "Geschwindigkeit: {speed}/s"
+      "speed": "Geschwindigkeit: {speed}/s",
+      "elapsedTime": "Verstrichene Zeit: {time}",
+      "transferTime": "Transferzeit: {time}"
     },
     "remainingTime": {
       "@hours": "Benutze 'h' als Abkürzung für Stunden und 'm' für Minuten",

--- a/app/assets/i18n/en-IN.json
+++ b/app/assets/i18n/en-IN.json
@@ -225,13 +225,16 @@
     "total": {
       "title": {
         "sending": "Total progress ({time})",
+        "finishedSuccess": "Finished in {time}",
         "finishedError": "Finished with error",
         "canceledSender": "Cancelled by sender",
         "canceledReceiver": "Cancelled by receiver"
       },
       "count": "Files: {curr} / {n}",
       "size": "Size: {curr} / {n}",
-      "speed": "Speed: {speed}/s"
+      "speed": "Speed: {speed}/s",
+      "elapsedTime": "Elapsed time: {time}",
+      "transferTime": "Transfer time: {time}"
     },
     "remainingTime": {
       "seconds": "{n}:{ss}",

--- a/app/assets/i18n/en-IN.json
+++ b/app/assets/i18n/en-IN.json
@@ -224,7 +224,7 @@
     "savedToGallery": "Saved in Photos",
     "total": {
       "title": {
-        "sending": "Total progress ({time})",
+        "sending": "Total progress (remaining {time})",
         "finishedSuccess": "Finished in {time}",
         "finishedError": "Finished with error",
         "canceledSender": "Cancelled by sender",

--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -232,13 +232,16 @@
     "total": {
       "title": {
         "sending": "Total progress ({time})",
+        "finishedSuccess": "Finished in {time}",
         "finishedError": "Finished with error",
         "canceledSender": "Canceled by sender",
         "canceledReceiver": "Canceled by receiver"
       },
       "count": "Files: {curr} / {n}",
       "size": "Size: {curr} / {n}",
-      "speed": "Speed: {speed}/s"
+      "speed": "Speed: {speed}/s",
+      "elapsedTime": "Elapsed time: {time} min",
+      "transferTime": "Transfer time: {time} min"
     },
     "remainingTime": {
       "seconds": "{n}:{ss}",

--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -231,7 +231,7 @@
     "savedToGallery": "Saved in Photos",
     "total": {
       "title": {
-        "sending": "Total progress ({time})",
+        "sending": "Total progress (remaining {time})",
         "finishedSuccess": "Finished in {time}",
         "finishedError": "Finished with error",
         "canceledSender": "Canceled by sender",

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 53
-/// Strings: 17825 (336 per locale)
+/// Strings: 17837 (336 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_cs.g.dart
+++ b/app/lib/gen/strings_cs.g.dart
@@ -981,6 +981,10 @@ class _Translations$progressPage$total$cs extends Translations$progressPage$tota
   String size({required Object curr, required Object n}) => 'Velikost: ${curr} / ${n}';
   @override
   String speed({required Object speed}) => 'Rychlost: ${speed}/s';
+  @override
+  String elapsedTime({required Object time}) => 'Uplynulý čas: ${time}';
+  @override
+  String transferTime({required Object time}) => 'Čas přenosu: ${time}';
 }
 
 // Path: dialogs.addFile
@@ -1402,6 +1406,8 @@ class _Translations$progressPage$total$title$cs extends Translations$progressPag
   // Translations
   @override
   String sending({required Object time}) => 'Celkový průběh (${time})';
+  @override
+  String finishedSuccess({required Object time}) => 'Dokončeno za ${time}';
   @override
   String get finishedError => 'Dokončeno s chybou';
   @override

--- a/app/lib/gen/strings_cs.g.dart
+++ b/app/lib/gen/strings_cs.g.dart
@@ -1405,7 +1405,7 @@ class _Translations$progressPage$total$title$cs extends Translations$progressPag
 
   // Translations
   @override
-  String sending({required Object time}) => 'Celkový průběh (${time})';
+  String sending({required Object time}) => 'Celkový průběh (zbývá ${time})';
   @override
   String finishedSuccess({required Object time}) => 'Dokončeno za ${time}';
   @override

--- a/app/lib/gen/strings_de.g.dart
+++ b/app/lib/gen/strings_de.g.dart
@@ -1432,7 +1432,7 @@ class _Translations$progressPage$total$title$de extends Translations$progressPag
 
   // Translations
   @override
-  String sending({required Object time}) => 'Gesamtfortschritt (${time})';
+  String sending({required Object time}) => 'Gesamtfortschritt (verbleibende ${time})';
   @override
   String finishedSuccess({required Object time}) => 'In ${time} abgeschlossen';
   @override

--- a/app/lib/gen/strings_de.g.dart
+++ b/app/lib/gen/strings_de.g.dart
@@ -984,6 +984,10 @@ class _Translations$progressPage$total$de extends Translations$progressPage$tota
   String size({required Object curr, required Object n}) => 'Größe: ${curr} / ${n}';
   @override
   String speed({required Object speed}) => 'Geschwindigkeit: ${speed}/s';
+  @override
+  String elapsedTime({required Object time}) => 'Verstrichene Zeit: ${time}';
+  @override
+  String transferTime({required Object time}) => 'Transferzeit: ${time}';
 }
 
 // Path: progressPage.remainingTime
@@ -1429,6 +1433,8 @@ class _Translations$progressPage$total$title$de extends Translations$progressPag
   // Translations
   @override
   String sending({required Object time}) => 'Gesamtfortschritt (${time})';
+  @override
+  String finishedSuccess({required Object time}) => 'In ${time} abgeschlossen';
   @override
   String get finishedError => 'Abgeschlossen mit Fehler';
   @override

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -1245,6 +1245,12 @@ class Translations$progressPage$total$en {
 
   /// en: 'Speed: {speed}/s'
   String speed({required Object speed}) => 'Speed: ${speed}/s';
+
+  /// en: 'Elapsed time: {time} min'
+  String elapsedTime({required Object time}) => 'Elapsed time: ${time} min';
+
+  /// en: 'Transfer time: {time} min'
+  String transferTime({required Object time}) => 'Transfer time: ${time} min';
 }
 
 // Path: progressPage.remainingTime
@@ -1763,6 +1769,9 @@ class Translations$progressPage$total$title$en {
 
   /// en: 'Total progress ({time})'
   String sending({required Object time}) => 'Total progress (${time})';
+
+  /// en: 'Finished in {time}'
+  String finishedSuccess({required Object time}) => 'Finished in ${time}';
 
   /// en: 'Finished with error'
   String get finishedError => 'Finished with error';

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -1767,8 +1767,8 @@ class Translations$progressPage$total$title$en {
 
   // Translations
 
-  /// en: 'Total progress ({time})'
-  String sending({required Object time}) => 'Total progress (${time})';
+  /// en: 'Total progress (remaining {time})'
+  String sending({required Object time}) => 'Total progress (remaining ${time})';
 
   /// en: 'Finished in {time}'
   String finishedSuccess({required Object time}) => 'Finished in ${time}';

--- a/app/lib/gen/strings_en_IN.g.dart
+++ b/app/lib/gen/strings_en_IN.g.dart
@@ -1073,6 +1073,10 @@ class _Translations$progressPage$total$en_IN extends Translations$progressPage$t
   String size({required Object curr, required Object n}) => 'Size: ${curr} / ${n}';
   @override
   String speed({required Object speed}) => 'Speed: ${speed}/s';
+  @override
+  String elapsedTime({required Object time}) => 'Elapsed time: ${time}';
+  @override
+  String transferTime({required Object time}) => 'Transfer time: ${time}';
 }
 
 // Path: progressPage.remainingTime
@@ -1515,6 +1519,8 @@ class _Translations$progressPage$total$title$en_IN extends Translations$progress
   // Translations
   @override
   String sending({required Object time}) => 'Total progress (${time})';
+  @override
+  String finishedSuccess({required Object time}) => 'Finished in ${time}';
   @override
   String get finishedError => 'Finished with error';
   @override

--- a/app/lib/gen/strings_en_IN.g.dart
+++ b/app/lib/gen/strings_en_IN.g.dart
@@ -1518,7 +1518,7 @@ class _Translations$progressPage$total$title$en_IN extends Translations$progress
 
   // Translations
   @override
-  String sending({required Object time}) => 'Total progress (${time})';
+  String sending({required Object time}) => 'Total progress (remaining ${time})';
   @override
   String finishedSuccess({required Object time}) => 'Finished in ${time}';
   @override

--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -58,6 +58,7 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
   int _finishCounter = 3;
   Timer? _finishTimer;
   Timer? _wakelockPlusTimer;
+  Timer? _elapsedTimer;
 
   bool _advanced = false;
 
@@ -107,6 +108,26 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
           }
         });
       }
+
+      _elapsedTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+        final receiveSession = ref.read(serverProvider)?.session;
+        final sendSession = ref.read(sendProvider)[widget.sessionId];
+        final sessionState = receiveSession ?? sendSession;
+
+        if (!mounted) {
+          timer.cancel();
+          return;
+        }
+
+        if (sessionState?.startTime != null && sessionState?.endTime == null) {
+          setState(() {});
+        } else if (sessionState?.endTime != null) {
+          timer.cancel();
+          if (mounted) {
+            setState(() {});
+          }
+        }
+      });
 
       setState(() {
         final receiveSession = ref.read(serverProvider)?.session;
@@ -172,10 +193,33 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
     super.dispose();
     _finishTimer?.cancel();
     _wakelockPlusTimer?.cancel();
+    _elapsedTimer?.cancel();
     TaskbarHelper.clearProgressBar(); // ignore: discarded_futures
     try {
       WakelockPlus.disable(); // ignore: discarded_futures
     } catch (_) {}
+  }
+
+  String? _formatElapsedTime(int? startTime, int? endTime) {
+    if (startTime == null) {
+      return null;
+    }
+
+    final elapsedMilliseconds = (endTime ?? DateTime.now().millisecondsSinceEpoch) - startTime;
+    if (elapsedMilliseconds < 0) {
+      return null;
+    }
+
+    final elapsed = Duration(milliseconds: elapsedMilliseconds);
+    final hours = elapsed.inHours;
+    final minutes = elapsed.inMinutes.remainder(60);
+    final seconds = elapsed.inSeconds.remainder(60);
+
+    if (hours > 0) {
+      return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+    }
+
+    return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
   }
 
   @override
@@ -211,6 +255,7 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
     final title = receiveSession != null ? t.progressPage.titleReceiving : t.progressPage.titleSending;
     final startTime = commonSessionState.startTime;
     final endTime = commonSessionState.endTime;
+    final elapsedTime = _formatElapsedTime(startTime, endTime);
     final int? speedInBytes;
     if (startTime != null && currBytes >= 500 * 1024) {
       speedInBytes = getFileSpeed(start: startTime, end: endTime ?? DateTime.now().millisecondsSinceEpoch, bytes: currBytes);
@@ -377,8 +422,24 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                               if (fileStatus == FileStatus.sending)
                                 Padding(
                                   padding: const EdgeInsets.only(top: 5),
-                                  child: CustomProgressBar(
-                                    progress: progressNotifier.getProgress(sessionId: widget.sessionId, fileId: file.id),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      CustomProgressBar(
+                                        progress: progressNotifier.getProgress(sessionId: widget.sessionId, fileId: file.id),
+                                      ),
+                                      if (_advanced && elapsedTime != null)
+                                        Padding(
+                                          padding: const EdgeInsets.only(top: 5),
+                                          child: Text(
+                                            elapsedTime,
+                                            style: TextStyle(
+                                              color: Theme.of(context).colorScheme.secondary,
+                                              height: 1,
+                                            ),
+                                          ),
+                                        ),
+                                    ],
                                   ),
                                 )
                               else
@@ -443,9 +504,11 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Text(
-                            status.getLabel(
-                              remainingTime: _remainingTime ?? '-',
-                            ),
+                            _lastStatus == SessionStatus.finished
+                                ? status.getLabel(remainingTime: elapsedTime ?? '-')
+                                : status.getLabel(
+                                    remainingTime: _remainingTime ?? elapsedTime ?? '-',
+                                  ),
                             style: const TextStyle(fontSize: 20),
                           ),
                           const SizedBox(height: 5),
@@ -487,6 +550,12 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                                       t.progressPage.total.speed(
                                         speed: speedInBytes.asReadableFileSize,
                                       ),
+                                    ),
+                                  if (elapsedTime != null)
+                                    Text(
+                                      _lastStatus == SessionStatus.sending
+                                          ? t.progressPage.total.elapsedTime(time: elapsedTime)
+                                          : t.progressPage.total.transferTime(time: elapsedTime),
                                     ),
                                 ],
                               ),
@@ -581,7 +650,9 @@ extension on SessionStatus {
           time: remainingTime,
         );
       case SessionStatus.finished:
-        return t.general.finished;
+        return t.progressPage.total.title.finishedSuccess(
+          time: remainingTime,
+        );
       case SessionStatus.finishedWithErrors:
         return t.progressPage.total.title.finishedError;
       case SessionStatus.canceledBySender:


### PR DESCRIPTION
Closes #2242 implementing small new feature.


## Summary
This pull request enhances the progress page by adding real-time display of elapsed time during file transfer and also time the transfer took after finishing. 


## Changes
- Added time the transfer took after finishing next to informative text.
- Added real-time updated elapsed time into advanced part of progress page.
- Updated translation for this feature (en, cs, de).

## Showcase
_\* In brackets in front of the time there is new word "remaining" which is missing on screenshots. It will distinguish the meaning of 2 visible times._
<img width="600" alt="Screenshot-time-01" src="https://github.com/user-attachments/assets/963443c6-40fb-4905-82f4-00992c64c8d0" />
<img width="600" alt="Screenshot-time-02" src="https://github.com/user-attachments/assets/8ccee6e8-0276-455b-bb5e-73b8d35e7638" />




