### PR TITLE
fix: escape special characters in IP filters

### DIFF
--- a/app/lib/isolate/util/network_interfaces.dart
+++ b/app/lib/isolate/util/network_interfaces.dart
@@ -47,7 +47,8 @@ bool isNetworkIgnoredRaw({
 /// - '123.123.124.*' -> '^123\.123\.124\.[^.]+$'
 /// - '1::1:*:3' -> '^1::1:[^.]+:3$'
 RegExp buildRegExpFromIpFilter(String ip) {
-  return RegExp('^${ip.replaceAll('.', '\\.').replaceAll('*', '[^.]+')}\$');
+  final pattern = ip.split('*').map(RegExp.escape).join('[^.]+');
+  return RegExp('^$pattern\$');
 }
 
 /// Returns true if the given IP should be ignored.

--- a/app/test/unit/util/network_interfaces_test.dart
+++ b/app/test/unit/util/network_interfaces_test.dart
@@ -46,4 +46,18 @@ void main() {
     expect(ignored('3.3.3.4'), true);
     expect(ignored('4.3.3.3'), false);
   });
+
+  test('Should treat regular expression syntax as literal text', () {
+    final filter = buildRegExpFromIpFilter('10.0.0.(');
+
+    expect(filter.hasMatch('10.0.0.1'), false);
+    expect(filter.hasMatch('10.0.0.('), true);
+  });
+
+  test('Should preserve wildcard matching while escaping surrounding text', () {
+    final filter = buildRegExpFromIpFilter(r'10.0.$.*');
+
+    expect(filter.hasMatch(r'10.0.$.42'), true);
+    expect(filter.hasMatch('10.0.1.42'), false);
+  });
 }


### PR DESCRIPTION
## Summary
- escape regex syntax in network whitelist and blacklist values
- preserve the existing asterisk wildcard behavior
- add regression coverage for malformed regex input

## Verification
- flutter test --no-pub test/unit/util/network_interfaces_test.dart: 8 passed
- flutter analyze --no-pub for the changed files: no issues

Fixes #2374