### PR TITLE
test: cover sub-second timestamp metadata

### DIFF
--- a/packages/core/src/http/dto_v2.rs
+++ b/packages/core/src/http/dto_v2.rs
@@ -245,7 +245,10 @@ mod tests {
                     file_type: "image/png".to_string(),
                     sha256: None,
                     preview: None,
-                    metadata: None,
+                    metadata: Some(crate::model::transfer::FileMetadata {
+                        modified: Some("1970-01-01T00:00:00.123456789Z".to_string()),
+                        accessed: None,
+                    }),
                 },
             )]),
         };
@@ -254,5 +257,6 @@ mod tests {
         assert!(json.contains("\"info\""));
         assert!(json.contains("\"files\""));
         assert!(json.contains("\"fingerprint\":\"sender-fingerprint\""));
+        assert!(json.contains("\"modified\":\"1970-01-01T00:00:00.123456789Z\""));
     }
 }

--- a/packages/core/src/model/transfer.rs
+++ b/packages/core/src/model/transfer.rs
@@ -172,11 +172,12 @@ mod tests {
 
     #[test]
     fn parses_fractional_seconds() {
-        // The Dart implementation sends `DateTime.toIso8601String()` of a UTC
-        // value, which includes fractional seconds: 1970-01-01T00:00:00.500Z.
+        // Preserve all fractional-second digits from the RFC3339 value. The
+        // reported regression shifted the digits in `123456789` by three
+        // places, producing `000123000` on the receiving device.
         assert_eq!(
-            metadata("1970-01-01T00:00:00.500Z").modified_time(),
-            Some(SystemTime::UNIX_EPOCH + Duration::from_millis(500)),
+            metadata("1970-01-01T00:00:00.123456789Z").modified_time(),
+            Some(SystemTime::UNIX_EPOCH + Duration::from_nanos(123_456_789)),
         );
     }
 

--- a/packages/core/tests/v2_server.rs
+++ b/packages/core/tests/v2_server.rs
@@ -396,7 +396,7 @@ async fn test_upload_applies_file_timestamps() {
     let bytes = b"hello".to_vec();
     let mut file = file_dto("file-a", "a.bin", bytes.len() as u64);
     file.metadata = Some(FileMetadata {
-        modified: Some("2020-08-15T10:20:30.500Z".to_string()),
+        modified: Some("1970-01-01T00:00:00.123456789Z".to_string()),
         accessed: None,
     });
 
@@ -433,7 +433,7 @@ async fn test_upload_applies_file_timestamps() {
         .unwrap();
     assert_eq!(
         modified,
-        std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(1_597_486_830_500),
+        std::time::SystemTime::UNIX_EPOCH + Duration::from_nanos(123_456_789),
     );
 
     tokio::fs::remove_dir_all(&save_dir).await.unwrap();


### PR DESCRIPTION
Addresses #3177 with regression coverage for the current file-metadata path.

The original branch conflicted because the old PrepareUploadRequestDto and its Dart test were removed from main. This refresh is rebased onto current main and keeps the coverage in the active Rust implementation.

### What is covered

- RFC3339 fractional seconds preserve all nine digits (123456789) when parsed.
- The v2 prepare-upload payload preserves the exact timestamp string.
- An end-to-end v2 upload applies the exact nanosecond timestamp to the received file.
- This specifically guards against the reported 123456789 -> 000123000 digit shift.

### Validation

- rustfmt --check --edition 2021 on all changed Rust files
- cargo test --features http --lib - 53 passed
- cargo test --features http --test v2_server test_upload_applies_file_timestamps - 1 passed
- git diff --check