### PR TITLE
fix: reuse connectivity listener across app resumes

### DIFF
--- a/app/lib/provider/local_ip_provider.dart
+++ b/app/lib/provider/local_ip_provider.dart
@@ -16,15 +16,19 @@ final _logger = Logger('NetworkInfo');
 final localIpProvider = ReduxProvider<LocalIpService, NetworkState>((ref) {
   return LocalIpService(
     ref.notifier(settingsProvider),
+    connectivityChangesFactory: () => Connectivity().onConnectivityChanged,
   );
 });
 
-StreamSubscription? _subscription;
-
 class LocalIpService extends ReduxNotifier<NetworkState> {
   final SettingsService _settingsService;
+  final Stream<List<ConnectivityResult>> Function() _connectivityChangesFactory;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
 
-  LocalIpService(this._settingsService);
+  LocalIpService(
+    this._settingsService, {
+    required Stream<List<ConnectivityResult>> Function() connectivityChangesFactory,
+  }) : _connectivityChangesFactory = connectivityChangesFactory;
 
   @override
   NetworkState init() {
@@ -36,24 +40,25 @@ class LocalIpService extends ReduxNotifier<NetworkState> {
 
   @override
   get initialAction => InitLocalIpAction();
+
+  @override
+  void dispose() {
+    unawaited(_connectivitySubscription?.cancel());
+    super.dispose();
+  }
 }
 
 /// Fetches the local IP address and registers a listener to update the IP address
 class InitLocalIpAction extends ReduxAction<LocalIpService, NetworkState> {
   @override
   NetworkState reduce() {
-    if (!kIsWeb) {
-      // ignore: discarded_futures
-      _subscription?.cancel();
-
-      if (checkPlatform([TargetPlatform.windows])) {
-        // https://github.com/localsend/localsend/issues/12
-        // https://github.com/localsend/localsend/issues/78
-      } else {
-        _subscription = Connectivity().onConnectivityChanged.listen((_) async {
-          await dispatchAsync(FetchLocalIpAction());
-        });
-      }
+    // connectivity_plus is not used on Windows:
+    // https://github.com/localsend/localsend/issues/12
+    // https://github.com/localsend/localsend/issues/78
+    if (!kIsWeb && !checkPlatform([TargetPlatform.windows])) {
+      notifier._connectivitySubscription ??= notifier._connectivityChangesFactory().listen((_) async {
+        await dispatchAsync(FetchLocalIpAction());
+      });
     }
 
     return state;

--- a/app/test/unit/provider/network_info_provider_test.dart
+++ b/app/test/unit/provider/network_info_provider_test.dart
@@ -1,7 +1,44 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
+import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:refena_flutter/refena_flutter.dart';
 import 'package:test/test.dart';
 
+import '../../mocks.mocks.dart';
+
 void main() {
+  test('should keep one connectivity listener when reinitialized', () async {
+    var listenCount = 0;
+    final subscriptionCanceled = Completer<void>();
+    final connectivityChanges = StreamController<List<ConnectivityResult>>.broadcast(
+      onListen: () => listenCount++,
+      onCancel: () {
+        if (!subscriptionCanceled.isCompleted) {
+          subscriptionCanceled.complete();
+        }
+      },
+    );
+    addTearDown(connectivityChanges.close);
+    final notifier = _TestLocalIpService(
+      SettingsService(MockPersistenceService()),
+      connectivityChangesFactory: () => connectivityChanges.stream,
+    );
+    final service = ReduxNotifier.test(
+      redux: notifier,
+    );
+
+    service.dispatch(_InitLocalIpActionWithoutFetch());
+    service.dispatch(_InitLocalIpActionWithoutFetch());
+
+    expect(listenCount, 1);
+
+    notifier.disposeForTest();
+    await subscriptionCanceled.future;
+    expect(connectivityChanges.hasListener, isFalse);
+  });
+
   group('rankIpAddresses', () {
     test('should only sort list if no primary', () {
       expect(rankIpAddresses(['123.456', '222.1', '321.222'], null), ['123.456', '321.222', '222.1']);
@@ -19,4 +56,18 @@ void main() {
       expect(rankIpAddresses(['123.456', '123.123', '222.1', '222.1', '321.222'], '123.123'), ['123.123', '123.456', '321.222', '222.1']);
     });
   });
+}
+
+class _InitLocalIpActionWithoutFetch extends InitLocalIpAction {
+  @override
+  void after() {}
+}
+
+class _TestLocalIpService extends LocalIpService {
+  _TestLocalIpService(
+    super.settingsService, {
+    required super.connectivityChangesFactory,
+  });
+
+  void disposeForTest() => dispose();
 }


### PR DESCRIPTION
## Summary

- keep a single `connectivity_plus` listener for the lifetime of `LocalIpService`;
- continue refreshing local IP addresses whenever the app resumes;
- cancel the connectivity subscription when the provider is disposed;
- add a regression test for repeated initialization and cleanup.

## Motivation

`InitLocalIpAction` previously canceled and immediately recreated the connectivity listener every time the app resumed. Recreating the listener is unnecessary because the action already fetches the current IP state in `after()`.

On Linux, rapid cancellation and re-subscription can also overlap the plugin's asynchronous listener cleanup. The underlying `connectivity_plus` lifecycle race is addressed by fluttercommunity/plus_plugins#3929; this change independently avoids triggering that fragile lifecycle pattern and gives the subscription an explicit owner.

The connectivity stream is injected as a lazy factory so Windows and web behavior remain unchanged and the lifecycle can be tested without a platform plugin.

## Validation

Using the repository-pinned Flutter 3.41.9 / Dart 3.11.5:

- `flutter analyze`
- `flutter test` (66 tests)
- CI-equivalent formatting check for all non-generated files under `lib` and `test`
