### PR TITLE
feat: configurable upload concurrency, auto retry, folder tree view

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -68,11 +68,20 @@ android {
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            signingConfig signingConfigs.release.storeFile ? signingConfigs.release : signingConfigs.debug
         }
         debug {
             applicationIdSuffix ".debug"
         }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
     }
 
     // Required by F-Droid

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -19,7 +19,20 @@ subprojects {
             project.android {
                 compileSdkVersion 36
                 buildToolsVersion "36.0.0"
+                compileOptions {
+                    sourceCompatibility JavaVersion.VERSION_17
+                    targetCompatibility JavaVersion.VERSION_17
+                }
             }
+        }
+        try {
+            project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    jvmTarget = '17'
+                }
+            }
+        } catch (Exception e) {
+            // ignore - not all projects have kotlin plugin
         }
     }
 }

--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -10,6 +10,7 @@ import 'package:localsend_app/isolate/model/dto/file_dto.dart';
 import 'package:localsend_app/isolate/model/file_status.dart';
 import 'package:localsend_app/isolate/model/session_status.dart';
 import 'package:localsend_app/model/state/server/receive_session_state.dart';
+import 'package:localsend_app/model/state/send/send_session_state.dart';
 import 'package:localsend_app/provider/network/send_provider.dart';
 import 'package:localsend_app/provider/network/server/server_provider.dart';
 import 'package:localsend_app/provider/progress_provider.dart';
@@ -26,6 +27,9 @@ import 'package:localsend_app/widget/custom_progress_bar.dart';
 import 'package:localsend_app/widget/dialogs/cancel_session_dialog.dart';
 import 'package:localsend_app/widget/dialogs/error_dialog.dart';
 import 'package:localsend_app/widget/file_thumbnail.dart';
+import 'package:localsend_app/widget/folder_tree_view.dart';
+import 'package:localsend_app/model/cross_file.dart';
+import 'package:localsend_app/isolate/model/file_type.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:routerino/routerino.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -60,6 +64,7 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
   Timer? _wakelockPlusTimer;
 
   bool _advanced = false;
+  bool _showTreeView = true; // Default to tree view
 
   @override
   void initState() {
@@ -241,194 +246,9 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
         appBar: widget.showAppBar ? basicLocalSendAppbar(title) : null,
         body: Stack(
           children: [
-            ListView.builder(
-              padding: EdgeInsets.only(
-                top: MediaQuery.of(context).padding.top + 20,
-                bottom: 150 + getNavBarPadding(context),
-                left: 15,
-                right: 30,
-              ),
-              itemCount: _files.length + 2,
-              itemBuilder: (context, index) {
-                if (index == 0) {
-                  // title
-                  if (widget.showAppBar) {
-                    return Container();
-                  }
-
-                  return Padding(
-                    padding: const EdgeInsets.only(bottom: 5),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(title, style: Theme.of(context).textTheme.titleLarge),
-                        if (checkPlatformWithFileSystem() && receiveSession != null)
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 10),
-                            child: Text.rich(
-                              TextSpan(
-                                children: [
-                                  TextSpan(
-                                    text: '${t.settingsTab.receive.destination}: ',
-                                    style: const TextStyle(color: Colors.grey),
-                                  ),
-                                  TextSpan(
-                                    text: receiveSession.destinationDirectory,
-                                    style: TextStyle(
-                                      color: checkPlatform([TargetPlatform.iOS]) ? Colors.grey : Theme.of(context).colorScheme.primary,
-                                    ),
-                                    recognizer: checkPlatform([TargetPlatform.iOS])
-                                        ? null
-                                        : (TapGestureRecognizer()
-                                            ..onTap = () async {
-                                              await openFolder(folderPath: receiveSession.destinationDirectory);
-                                            }),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                      ],
-                    ),
-                  );
-                }
-
-                if (index == 1) {
-                  // error card
-                  final errorMessage = sendSession?.errorMessage;
-                  if (errorMessage == null) {
-                    return Container();
-                  }
-
-                  return SelectableText(errorMessage, style: TextStyle(color: Theme.of(context).colorScheme.warning));
-                }
-
-                final file = _files[index - 2];
-                final String fileName = receiveSession?.files[file.id]?.desiredName ?? file.fileName;
-
-                final fileStatus = fileStatusMap[file.id]!;
-                final savedToGallery = receiveSession?.files[file.id]?.savedToGallery ?? false;
-
-                final String? filePath;
-                if (receiveSession != null && fileStatus == FileStatus.finished && !savedToGallery) {
-                  filePath = receiveSession.files[file.id]!.path;
-                } else if (sendSession != null) {
-                  filePath = sendSession.files[file.id]!.path;
-                } else {
-                  filePath = null;
-                }
-
-                final String? errorMessage;
-                if (receiveSession != null) {
-                  errorMessage = receiveSession.files[file.id]!.errorMessage;
-                } else if (sendSession != null) {
-                  errorMessage = sendSession.files[file.id]!.errorMessage;
-                } else {
-                  errorMessage = null;
-                }
-
-                final Uint8List? thumbnail;
-                final AssetEntity? asset;
-                if (sendSession != null) {
-                  thumbnail = sendSession.files[file.id]!.thumbnail;
-                  asset = sendSession.files[file.id]!.asset;
-                } else {
-                  thumbnail = null;
-                  asset = null;
-                }
-
-                return Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 5),
-                  child: InkWell(
-                    splashColor: Colors.transparent,
-                    splashFactory: NoSplash.splashFactory,
-                    highlightColor: Colors.transparent,
-                    hoverColor: Colors.transparent,
-                    onTap: filePath != null && receiveSession != null ? () async => openFile(context, file.fileType, filePath!) : null,
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        SmartFileThumbnail(
-                          bytes: thumbnail,
-                          asset: asset,
-                          path: filePath,
-                          fileType: file.fileType,
-                        ),
-                        const SizedBox(width: 10),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                children: [
-                                  Flexible(
-                                    child: Text(
-                                      fileName,
-                                      style: const TextStyle(fontSize: 16, height: 1),
-                                      maxLines: 1,
-                                      overflow: TextOverflow.fade,
-                                      softWrap: false,
-                                    ),
-                                  ),
-                                  Text(' (${file.size.asReadableFileSize})', style: const TextStyle(fontSize: 16, height: 1)),
-                                ],
-                              ),
-                              const SizedBox(height: 5),
-                              if (fileStatus == FileStatus.sending)
-                                Padding(
-                                  padding: const EdgeInsets.only(top: 5),
-                                  child: CustomProgressBar(
-                                    progress: progressNotifier.getProgress(sessionId: widget.sessionId, fileId: file.id),
-                                  ),
-                                )
-                              else
-                                Row(
-                                  children: [
-                                    Flexible(
-                                      child: Text(
-                                        savedToGallery ? t.progressPage.savedToGallery : fileStatus.label,
-                                        style: TextStyle(color: fileStatus.getColor(context), height: 1),
-                                      ),
-                                    ),
-                                    if (errorMessage != null) ...[
-                                      const SizedBox(width: 5),
-                                      InkWell(
-                                        onTap: () async {
-                                          await showDialog(
-                                            context: context,
-                                            builder: (_) => ErrorDialog(error: errorMessage!),
-                                          );
-                                        },
-                                        child: Padding(
-                                          padding: const EdgeInsets.symmetric(horizontal: 5),
-                                          child: Icon(Icons.info, color: Theme.of(context).colorScheme.warning, size: 20),
-                                        ),
-                                      ),
-                                    ],
-                                  ],
-                                ),
-                            ],
-                          ),
-                        ),
-                        if (sendSession != null && fileStatus == FileStatus.failed)
-                          IconButton(
-                            icon: const Icon(Icons.refresh),
-                            onPressed: () async {
-                              await ref
-                                  .notifier(sendProvider)
-                                  .sendFile(
-                                    sessionId: widget.sessionId,
-                                    file: sendSession.files[file.id]!,
-                                    isRetry: true,
-                                  );
-                            },
-                          ),
-                      ],
-                    ),
-                  ),
-                );
-              },
-            ),
+            _showTreeView
+                ? _buildTreeView(context, title, receiveSession, sendSession, fileStatusMap, progressNotifier)
+                : _buildFlatView(context, title, receiveSession, sendSession, fileStatusMap, progressNotifier),
             SafeArea(
               child: Align(
                 alignment: Alignment.bottomCenter,
@@ -498,6 +318,14 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                               TextButton.icon(
                                 style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
                                 onPressed: () {
+                                  setState(() => _showTreeView = !_showTreeView);
+                                },
+                                icon: Icon(_showTreeView ? Icons.view_list : Icons.folder),
+                                label: Text(_showTreeView ? 'Flat' : 'Tree'),
+                              ),
+                              TextButton.icon(
+                                style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
+                                onPressed: () {
                                   setState(() => _advanced = !_advanced);
                                 },
                                 icon: const Icon(Icons.info),
@@ -536,6 +364,277 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildTreeView(
+    BuildContext context,
+    String title,
+    ReceiveSessionState? receiveSession,
+    SendSessionState? sendSession,
+    Map<String, FileStatus> fileStatusMap,
+    ProgressNotifier progressNotifier,
+  ) {
+    // Convert FileDto to CrossFile for the tree view
+    final crossFiles = _files.map((f) => CrossFile(
+      name: receiveSession?.files[f.id]?.desiredName ?? f.fileName,
+      fileType: f.fileType,
+      size: f.size,
+      thumbnail: null,
+      asset: null,
+      path: null,
+      bytes: null,
+      lastModified: null,
+      lastAccessed: null,
+    )).toList();
+
+    return ListView(
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top + 20,
+        bottom: 150 + getNavBarPadding(context),
+        left: 15,
+        right: 30,
+      ),
+      children: [
+        if (!widget.showAppBar)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 5),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: Theme.of(context).textTheme.titleLarge),
+                if (checkPlatformWithFileSystem() && receiveSession != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: Text.rich(
+                      TextSpan(
+                        children: [
+                          TextSpan(
+                            text: '${t.settingsTab.receive.destination}: ',
+                            style: const TextStyle(color: Colors.grey),
+                          ),
+                          TextSpan(
+                            text: receiveSession.destinationDirectory,
+                            style: TextStyle(
+                              color: checkPlatform([TargetPlatform.iOS]) ? Colors.grey : Theme.of(context).colorScheme.primary,
+                            ),
+                            recognizer: checkPlatform([TargetPlatform.iOS])
+                                ? null
+                                : (TapGestureRecognizer()
+                                    ..onTap = () async {
+                                      await openFolder(folderPath: receiveSession.destinationDirectory);
+                                    }),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        FolderTreeView(
+          files: crossFiles,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFlatView(
+    BuildContext context,
+    String title,
+    ReceiveSessionState? receiveSession,
+    SendSessionState? sendSession,
+    Map<String, FileStatus> fileStatusMap,
+    ProgressNotifier progressNotifier,
+  ) {
+    return ListView.builder(
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top + 20,
+        bottom: 150 + getNavBarPadding(context),
+        left: 15,
+        right: 30,
+      ),
+      itemCount: _files.length + 2,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          // title
+          if (widget.showAppBar) {
+            return Container();
+          }
+
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 5),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: Theme.of(context).textTheme.titleLarge),
+                if (checkPlatformWithFileSystem() && receiveSession != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: Text.rich(
+                      TextSpan(
+                        children: [
+                          TextSpan(
+                            text: '${t.settingsTab.receive.destination}: ',
+                            style: const TextStyle(color: Colors.grey),
+                          ),
+                          TextSpan(
+                            text: receiveSession.destinationDirectory,
+                            style: TextStyle(
+                              color: checkPlatform([TargetPlatform.iOS]) ? Colors.grey : Theme.of(context).colorScheme.primary,
+                            ),
+                            recognizer: checkPlatform([TargetPlatform.iOS])
+                                ? null
+                                : (TapGestureRecognizer()
+                                    ..onTap = () async {
+                                      await openFolder(folderPath: receiveSession.destinationDirectory);
+                                    }),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          );
+        }
+
+        if (index == 1) {
+          // error card
+          final errorMessage = sendSession?.errorMessage;
+          if (errorMessage == null) {
+            return Container();
+          }
+
+          return SelectableText(errorMessage, style: TextStyle(color: Theme.of(context).colorScheme.warning));
+        }
+
+        final file = _files[index - 2];
+        final String fileName = receiveSession?.files[file.id]?.desiredName ?? file.fileName;
+
+        final fileStatus = fileStatusMap[file.id]!;
+        final savedToGallery = receiveSession?.files[file.id]?.savedToGallery ?? false;
+
+        final String? filePath;
+        if (receiveSession != null && fileStatus == FileStatus.finished && !savedToGallery) {
+          filePath = receiveSession.files[file.id]!.path;
+        } else if (sendSession != null) {
+          filePath = sendSession.files[file.id]!.path;
+        } else {
+          filePath = null;
+        }
+
+        final String? errorMessage;
+        if (receiveSession != null) {
+          errorMessage = receiveSession.files[file.id]!.errorMessage;
+        } else if (sendSession != null) {
+          errorMessage = sendSession.files[file.id]!.errorMessage;
+        } else {
+          errorMessage = null;
+        }
+
+        final Uint8List? thumbnail;
+        final AssetEntity? asset;
+        if (sendSession != null) {
+          thumbnail = sendSession.files[file.id]!.thumbnail;
+          asset = sendSession.files[file.id]!.asset;
+        } else {
+          thumbnail = null;
+          asset = null;
+        }
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 5),
+          child: InkWell(
+            splashColor: Colors.transparent,
+            splashFactory: NoSplash.splashFactory,
+            highlightColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            onTap: filePath != null && receiveSession != null ? () async => openFile(context, file.fileType, filePath!) : null,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SmartFileThumbnail(
+                  bytes: thumbnail,
+                  asset: asset,
+                  path: filePath,
+                  fileType: file.fileType,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              fileName,
+                              style: const TextStyle(fontSize: 16, height: 1),
+                              maxLines: 1,
+                              overflow: TextOverflow.fade,
+                              softWrap: false,
+                            ),
+                          ),
+                          Text(' (${file.size.asReadableFileSize})', style: const TextStyle(fontSize: 16, height: 1)),
+                        ],
+                      ),
+                      const SizedBox(height: 5),
+                      if (fileStatus == FileStatus.sending)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 5),
+                          child: CustomProgressBar(
+                            progress: progressNotifier.getProgress(sessionId: widget.sessionId, fileId: file.id),
+                          ),
+                        )
+                      else
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                savedToGallery ? t.progressPage.savedToGallery : fileStatus.label,
+                                style: TextStyle(color: fileStatus.getColor(context), height: 1),
+                              ),
+                            ),
+                            if (errorMessage != null) ...[
+                              const SizedBox(width: 5),
+                              InkWell(
+                                onTap: () async {
+                                  await showDialog(
+                                    context: context,
+                                    builder: (_) => ErrorDialog(error: errorMessage!),
+                                  );
+                                },
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(horizontal: 5),
+                                  child: Icon(Icons.info, color: Theme.of(context).colorScheme.warning, size: 20),
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+                if (sendSession != null && fileStatus == FileStatus.failed)
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () async {
+                      await ref
+                          .notifier(sendProvider)
+                          .sendFile(
+                            sessionId: widget.sessionId,
+                            isolateIndex: 0,
+                            file: sendSession.files[file.id]!,
+                            isRetry: true,
+                          );
+                    },
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -264,6 +264,16 @@ class SettingsTab extends StatelessWidget {
                             await ref.notifier(settingsProvider).setShareViaLinkAutoAccept(b);
                           },
                         ),
+                        _SliderEntry(
+                          label: '上传并发数（同时上传的文件数，推荐 4-8）',
+                          value: vm.settings.uploadConcurrency.toDouble(),
+                          min: 1,
+                          max: 16,
+                          divisions: 15,
+                          onChanged: (value) async {
+                            await ref.notifier(settingsProvider).setUploadConcurrency(value.round());
+                          },
+                        ),
                       ],
                     ),
                   _SettingsSection(
@@ -709,6 +719,54 @@ class _ButtonEntry extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// A specialized version of [_SettingsEntry] for slider values.
+class _SliderEntry extends StatelessWidget {
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final ValueChanged<double> onChanged;
+
+  const _SliderEntry({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 15),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(label),
+              ),
+              const SizedBox(width: 10),
+              Text('${value.round()}', style: Theme.of(context).textTheme.titleMedium),
+            ],
+          ),
+          Slider(
+            value: value,
+            min: min,
+            max: max,
+            divisions: divisions,
+            label: '${value.round()}',
+            onChanged: onChanged,
+          ),
+        ],
       ),
     );
   }

--- a/app/lib/widget/folder_tree_view.dart
+++ b/app/lib/widget/folder_tree_view.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:localsend_app/model/cross_file.dart';
+import 'package:localsend_app/model/folder_tree.dart';
+import 'package:localsend_app/util/file_size_helper.dart';
+import 'package:localsend_app/widget/file_thumbnail.dart';
+
+/// A widget that displays files in a collapsible folder tree structure.
+class FolderTreeView extends StatefulWidget {
+  final List<CrossFile> files;
+  final Widget Function(CrossFile file)? trailing;
+  final void Function(CrossFile file)? onTap;
+
+  const FolderTreeView({
+    super.key,
+    required this.files,
+    this.trailing,
+    this.onTap,
+  });
+
+  @override
+  State<FolderTreeView> createState() => _FolderTreeViewState();
+}
+
+class _FolderTreeViewState extends State<FolderTreeView> {
+  late final FolderNode _root;
+
+  @override
+  void initState() {
+    super.initState();
+    _root = buildFolderTree(widget.files);
+    // All folders collapsed by default - user taps to expand
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: _buildFolderChildren(_root, 0),
+    );
+  }
+
+  List<Widget> _buildFolderChildren(FolderNode node, int depth) {
+    final widgets = <Widget>[];
+
+    // Sort children: folders first, then by name
+    final sortedChildren = List<FolderNode>.from(node.children)
+      ..sort((a, b) => a.name.compareTo(b.name));
+
+    for (final child in sortedChildren) {
+      widgets.add(_buildFolderTile(child, depth));
+      if (child.isExpanded) {
+        widgets.addAll(_buildFolderChildren(child, depth + 1));
+      }
+    }
+
+    // Add files at this level
+    for (final file in node.files) {
+      widgets.add(_buildFileTile(file, depth));
+    }
+
+    return widgets;
+  }
+
+  Widget _buildFolderTile(FolderNode folder, int depth) {
+    return Padding(
+      padding: EdgeInsets.only(left: depth * 16.0),
+      child: InkWell(
+        onTap: () {
+          setState(() {
+            folder.isExpanded = !folder.isExpanded;
+          });
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+          child: Row(
+            children: [
+              Icon(
+                folder.isExpanded ? Icons.folder_open : Icons.folder,
+                color: Theme.of(context).colorScheme.primary,
+                size: 24,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      folder.name,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    Text(
+                      '${folder.totalFileCount} files, ${folder.totalSize.asReadableFileSize}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                folder.isExpanded ? Icons.expand_less : Icons.expand_more,
+                color: Colors.grey,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFileTile(CrossFile file, int depth) {
+    return Padding(
+      padding: EdgeInsets.only(left: (depth + 1) * 16.0),
+      child: InkWell(
+        onTap: widget.onTap != null ? () => widget.onTap!(file) : null,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+          child: Row(
+            children: [
+              SmartFileThumbnail.fromCrossFile(file),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      file.name.split('/').last,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontSize: 14),
+                    ),
+                    Text(
+                      file.size.asReadableFileSize,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+              if (widget.trailing != null) widget.trailing!(file),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/windows/runner/CMakeLists.txt
+++ b/app/windows/runner/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 # dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
 target_link_libraries(${BINARY_NAME} PRIVATE "dwmapi.lib")
+target_link_libraries(${BINARY_NAME} PRIVATE "windowsapp.lib")
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.


### PR DESCRIPTION
- Configurable upload concurrency (1-16, default 8)
- Auto retry on failed transfers (3 attempts, exponential backoff)
- Upload timeout (60s)
- Progress throttling for smoother UI
- Collapsible folder tree view for browsing files
- Chinese label for concurrency slider
- Windows build fix: add windowsapp.lib link
- Android build fix: JVM target 17, Kotlin incremental disabled