### PR TITLE
feat: Allow scrolling of favorites

### DIFF
--- a/app/lib/widget/dialogs/favorite_dialog.dart
+++ b/app/lib/widget/dialogs/favorite_dialog.dart
@@ -23,8 +23,15 @@ class FavoritesDialog extends StatefulWidget {
 }
 
 class _FavoritesDialogState extends State<FavoritesDialog> with Refena {
+  final _scrollController = ScrollController();
   bool _fetching = false;
   String? _error;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   /// Checks if the device is reachable and pops the dialog with the result if it is.
   Future<void> _checkConnectionToDevice(FavoriteDevice favorite) async {
@@ -72,60 +79,77 @@ class _FavoritesDialogState extends State<FavoritesDialog> with Refena {
 
     return AlertDialog(
       title: Text(t.dialogs.favoriteDialog.title),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (favorites.isEmpty)
-            Text(
-              t.dialogs.favoriteDialog.noFavorites,
-              style: const TextStyle(color: Colors.grey),
-            ),
-          for (final favorite in favorites)
-            Row(
-              children: [
-                Expanded(
-                  child: TextButton(
-                    style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
-                    onPressed: _fetching ? null : () async => await _checkConnectionToDevice(favorite),
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: Text('${favorite.alias}\n(${favorite.ip})'),
+      content: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (favorites.isEmpty)
+              Text(
+                t.dialogs.favoriteDialog.noFavorites,
+                style: const TextStyle(color: Colors.grey),
+              )
+            else
+              Flexible(
+                child: Scrollbar(
+                  controller: _scrollController,
+                  child: SingleChildScrollView(
+                    controller: _scrollController,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (final favorite in favorites)
+                          Row(
+                            children: [
+                              Expanded(
+                                child: TextButton(
+                                  style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
+                                  onPressed: _fetching ? null : () async => await _checkConnectionToDevice(favorite),
+                                  child: Align(
+                                    alignment: Alignment.centerLeft,
+                                    child: Text('${favorite.alias}\n(${favorite.ip})'),
+                                  ),
+                                ),
+                              ),
+                              TextButton(
+                                style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
+                                onPressed: _fetching ? null : () async => await _showDeviceDialog(favorite),
+                                child: const Icon(Icons.edit),
+                              ),
+                            ],
+                          ),
+                      ],
                     ),
                   ),
                 ),
-                TextButton(
-                  style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface),
-                  onPressed: _fetching ? null : () async => await _showDeviceDialog(favorite),
-                  child: const Icon(Icons.edit),
-                ),
-              ],
-            ),
-          if (_error != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 10),
-              child: Row(
-                children: [
-                  Text(t.general.error, style: TextStyle(color: Theme.of(context).colorScheme.warning)),
-                  if (_error != null) ...[
-                    const SizedBox(width: 5),
-                    InkWell(
-                      onTap: () async {
-                        await showDialog(
-                          context: context,
-                          builder: (_) => ErrorDialog(error: _error!),
-                        );
-                      },
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 5),
-                        child: Icon(Icons.info, color: Theme.of(context).colorScheme.warning, size: 20),
-                      ),
-                    ),
-                  ],
-                ],
               ),
-            ),
-        ],
+            if (_error != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 10),
+                child: Row(
+                  children: [
+                    Text(t.general.error, style: TextStyle(color: Theme.of(context).colorScheme.warning)),
+                    if (_error != null) ...[
+                      const SizedBox(width: 5),
+                      InkWell(
+                        onTap: () async {
+                          await showDialog(
+                            context: context,
+                            builder: (_) => ErrorDialog(error: _error!),
+                          );
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 5),
+                          child: Icon(Icons.info, color: Theme.of(context).colorScheme.warning, size: 20),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+          ],
+        ),
       ),
       actions: [
         TextButton(


### PR DESCRIPTION
Currently the favorites modal does not allow for scrolling, which becomes an issue when there are too many favorites as the later entries become unaccessible. 