### PR TITLE
fix(desktop): start receive server when launched hidden to tray

### DIFF
--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## unreleased
 
-- fix(desktop): start the receive server when launching hidden to the tray so files can be received without opening the window first (@davidboulay, https://github.com/localsend/localsend/pull/XXXX)
-- feat(desktop): show a native notification when files are received, with an "Open folder" action to reveal them (@davidboulay, https://github.com/localsend/localsend/pull/XXXX)
+- fix(desktop): start the receive server when launching hidden to the tray so files can be received without opening the window first (@davidboulay, https://github.com/localsend/localsend/pull/3196)
+- feat(desktop): show a native notification when files are received, with an "Open folder" action to reveal them (@davidboulay, https://github.com/localsend/localsend/pull/3196)
 - feat(windows): add LocalSend to Windows Share Sheet (@chenxdust, https://github.com/localsend/localsend/pull/2555)
 - feat: enable starting text share via command line using `--text` or `-t` flags (@guilhermetiscoski, https://github.com/localsend/localsend/pull/2661)
 - feat(android): add quick settings tile for instant app launch (@Voltra, https://github.com/localsend/localsend/pull/2676)

--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 - fix(desktop): start the receive server when launching hidden to the tray so files can be received without opening the window first (@davidboulay, https://github.com/localsend/localsend/pull/XXXX)
+- feat(desktop): show a native notification when files are received, with an "Open folder" action to reveal them (@davidboulay, https://github.com/localsend/localsend/pull/XXXX)
 - feat(windows): add LocalSend to Windows Share Sheet (@chenxdust, https://github.com/localsend/localsend/pull/2555)
 - feat: enable starting text share via command line using `--text` or `-t` flags (@guilhermetiscoski, https://github.com/localsend/localsend/pull/2661)
 - feat(android): add quick settings tile for instant app launch (@Voltra, https://github.com/localsend/localsend/pull/2676)

--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+- fix(desktop): start the receive server when launching hidden to the tray so files can be received without opening the window first (@davidboulay, https://github.com/localsend/localsend/pull/XXXX)
 - feat(windows): add LocalSend to Windows Share Sheet (@chenxdust, https://github.com/localsend/localsend/pull/2555)
 - feat: enable starting text share via command line using `--text` or `-t` flags (@guilhermetiscoski, https://github.com/localsend/localsend/pull/2661)
 - feat(android): add quick settings tile for instant app launch (@Voltra, https://github.com/localsend/localsend/pull/2676)

--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -249,6 +249,16 @@
       "@days": "Use 'd' for days, 'h' for hours, and 'm' for minutes"
     }
   },
+  "receiveNotification": {
+    "title": {
+      "one": "File received",
+      "other": "Files received"
+    },
+    "body": {
+      "one": "{alias} sent you a file",
+      "other": "{alias} sent you {n} files"
+    }
+  },
   "webSharePage": {
     "title": "Share via link",
     "loading": "Starting server…",

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
+import 'package:local_notifier/local_notifier.dart';
 import 'package:localsend_app/config/refena.dart';
 import 'package:localsend_app/config/theme.dart';
 import 'package:localsend_app/pages/home_page.dart';
@@ -122,6 +123,14 @@ Future<RefenaContainer> preInit(List<String> args) async {
       await initTray();
     } catch (e) {
       _logger.warning('Initializing tray failed: $e');
+    }
+
+    // initialize desktop notifications (used e.g. to signal received files
+    // when the window is hidden)
+    try {
+      await localNotifier.setup(appName: 'LocalSend');
+    } catch (e) {
+      _logger.warning('Initializing desktop notifications failed: $e');
     }
 
     // initialize size and position

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -189,6 +189,22 @@ Future<RefenaContainer> preInit(List<String> args) async {
 
   await container.redux(parentIsolateProvider).dispatchAsync(IsolateSetupAction());
 
+  // Start the receive server here instead of relying solely on postInit(),
+  // which runs from HomePage.initState. When the app launches hidden to the
+  // tray (e.g. autostart with --hidden), the home page is never built, so
+  // postInit() never fires and the HTTP server stays down while multicast
+  // discovery (started in the isolate above) is up. This makes the device
+  // appear discoverable but unable to actually receive files until the window
+  // is opened once. startServer() guards against double-start, so the later
+  // postInit() call becomes a no-op.
+  if (checkPlatformIsDesktop()) {
+    try {
+      await container.notifier(serverProvider).startServerFromSettings();
+    } catch (e) {
+      _logger.warning('Starting server during init failed', e);
+    }
+  }
+
   return container;
 }
 

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 53
-/// Strings: 17825 (336 per locale)
+/// Strings: 17829 (336 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -62,6 +62,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
   late final Translations$receiveOptionsPage$en receiveOptionsPage = Translations$receiveOptionsPage$en.internal(_root);
   late final Translations$sendPage$en sendPage = Translations$sendPage$en.internal(_root);
   late final Translations$progressPage$en progressPage = Translations$progressPage$en.internal(_root);
+  late final Translations$receiveNotification$en receiveNotification = Translations$receiveNotification$en.internal(_root);
   late final Translations$webSharePage$en webSharePage = Translations$webSharePage$en.internal(_root);
   late final Translations$aboutPage$en aboutPage = Translations$aboutPage$en.internal(_root);
   late final Translations$donationPage$en donationPage = Translations$donationPage$en.internal(_root);
@@ -472,6 +473,29 @@ class Translations$progressPage$en {
 
   late final Translations$progressPage$total$en total = Translations$progressPage$total$en.internal(_root);
   late final Translations$progressPage$remainingTime$en remainingTime = Translations$progressPage$remainingTime$en.internal(_root);
+}
+
+// Path: receiveNotification
+class Translations$receiveNotification$en {
+  Translations$receiveNotification$en.internal(this._root);
+
+  final Translations _root; // ignore: unused_field
+
+  // Translations
+
+  /// en: '(one) {File received} (other) {Files received}'
+  String title({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(
+    n,
+    one: 'File received',
+    other: 'Files received',
+  );
+
+  /// en: '(one) {{alias} sent you a file} (other) {{alias} sent you {n} files}'
+  String body({required num n, required Object alias}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(
+    n,
+    one: '${alias} sent you a file',
+    other: '${alias} sent you ${n} files',
+  );
 }
 
 // Path: webSharePage

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/state/send/send_session_state.dart';
 import 'package:localsend_app/model/state/server/receive_session_state.dart';
 import 'package:localsend_app/model/state/server/receiving_file.dart';
@@ -29,6 +30,8 @@ import 'package:localsend_app/provider/selection/selected_sending_files_provider
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/native/directories.dart';
 import 'package:localsend_app/util/native/file_saver.dart';
+import 'package:localsend_app/util/native/notification_helper.dart';
+import 'package:localsend_app/util/native/open_folder.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
 import 'package:localsend_app/util/simple_server.dart';
@@ -627,6 +630,22 @@ class ReceiveController {
           }
         });
       }
+      // Notify the user that files were received. Especially important when the
+      // window is hidden (e.g. started in the tray), where there is otherwise no
+      // visible feedback that a transfer completed.
+      final finishedFiles = session.files.values.where((f) => f.status == FileStatus.finished).toList();
+      if (finishedFiles.isNotEmpty) {
+        final destinationDirectory = session.destinationDirectory;
+        final highlightFileName = finishedFiles.length == 1 ? finishedFiles.first.path?.split(Platform.pathSeparator).last : null;
+        unawaited(showDesktopNotification(
+          title: t.receiveNotification.title(n: finishedFiles.length),
+          body: t.receiveNotification.body(n: finishedFiles.length, alias: session.sender.alias),
+          // Clicking the notification (or its action button) reveals the received file(s) in the file manager.
+          actionLabel: t.receiveHistoryPage.openFolder,
+          onAction: () => unawaited(openFolder(folderPath: destinationDirectory, fileName: highlightFileName)),
+        ));
+      }
+
       _logger.info('Received all files.');
     }
 

--- a/app/lib/util/native/notification_helper.dart
+++ b/app/lib/util/native/notification_helper.dart
@@ -1,0 +1,37 @@
+import 'package:local_notifier/local_notifier.dart';
+import 'package:localsend_app/util/native/platform_check.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('Notification');
+
+/// Shows a native desktop notification.
+/// No-op on platforms where [local_notifier] is not supported (mobile/web).
+///
+/// When [actionLabel] and [onAction] are provided, the notification exposes a
+/// clickable action. On Linux, clicking the notification body is not delivered
+/// by the platform plugin, so an explicit action button is required; on
+/// macOS/Windows the body click ([onClick]) is wired to the same callback.
+Future<void> showDesktopNotification({
+  required String title,
+  required String body,
+  String? actionLabel,
+  void Function()? onAction,
+}) async {
+  if (!checkPlatformIsDesktop()) {
+    return;
+  }
+  try {
+    final notification = LocalNotification(
+      title: title,
+      body: body,
+      actions: actionLabel != null && onAction != null ? [LocalNotificationAction(text: actionLabel)] : null,
+    );
+    if (onAction != null) {
+      notification.onClick = onAction;
+      notification.onClickAction = (_) => onAction();
+    }
+    await notification.show();
+  } catch (e) {
+    _logger.warning('Showing desktop notification failed', e);
+  }
+}

--- a/app/linux/flutter/generated_plugin_registrant.cc
+++ b/app/linux/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <gtk/gtk_plugin.h>
+#include <local_notifier/local_notifier_plugin.h>
 #include <open_dir_linux/open_dir_linux_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
@@ -36,6 +37,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
+  g_autoptr(FlPluginRegistrar) local_notifier_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "LocalNotifierPlugin");
+  local_notifier_plugin_register_with_registrar(local_notifier_registrar);
   g_autoptr(FlPluginRegistrar) open_dir_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "OpenDirLinuxPlugin");
   open_dir_linux_plugin_register_with_registrar(open_dir_linux_registrar);

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
   file_selector_linux
   gtk
+  local_notifier
   open_dir_linux
   pasteboard
   screen_retriever_linux

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import file_picker
 import file_selector_macos
 import gal
 import in_app_purchase_storekit
+import local_notifier
 import network_info_plus
 import open_dir_macos
 import package_info_plus
@@ -38,6 +39,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
+  LocalNotifierPlugin.register(with: registry.registrar(forPlugin: "LocalNotifierPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   OpenDirMacosPlugin.register(with: registry.registrar(forPlugin: "OpenDirMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -910,6 +910,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  local_notifier:
+    dependency: "direct main"
+    description:
+      name: local_notifier
+      sha256: f6cfc933c6fbc961f4e52b5c880f68e41b2d3cd29aad557cc654fd211093a025
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   localsend_isolates:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   intl: ^0.20.2 # allow newer versions, so it can compile with newer Flutter versions
   legalize: 1.2.2
   local_hero: 0.3.0
+  local_notifier: 0.1.6
   localsend_isolates:
     path: ../packages/localsend_isolates
   logging: 1.3.0

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <gal/gal_plugin_c_api.h>
+#include <local_notifier/local_notifier_plugin.h>
 #include <open_dir_windows/open_dir_windows_plugin_c_api.h>
 #include <pasteboard/pasteboard_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -35,6 +36,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   GalPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GalPluginCApi"));
+  LocalNotifierPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("LocalNotifierPlugin"));
   OpenDirWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("OpenDirWindowsPluginCApi"));
   PasteboardPluginRegisterWithRegistrar(

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
   file_selector_windows
   gal
+  local_notifier
   open_dir_windows
   pasteboard
   permission_handler_windows


### PR DESCRIPTION
## Summary

Fixes #3195.

When LocalSend is launched hidden to the tray on desktop (e.g. autostart with `--hidden`), the device is discoverable but **cannot receive files** until the main window is opened once.

**Root cause:** multicast discovery is started early in `preInit` (isolate setup), but the HTTP(S) receive server is only started from `postInit()`, which runs from `HomePage.initState`. When the app starts hidden, the home page is never built, so `postInit()` never fires and the server never binds — UDP discovery is up, but the TCP receive port is down.

**Fix:** start the receive server during `preInit` on desktop, decoupled from the home page. `startServer()` already guards against double-start, so the later `postInit()` call becomes a no-op when the window is eventually opened.

Verified on Linux: launched with `--hidden`, the TCP server binds (`ss -ltnup` shows `LISTEN :53317`), `GET /api/localsend/v2/info` returns 200, and a real transfer from another device completes with the window never shown.

## Second commit: receive notification (desktop)

While testing the hidden path I noticed there is **no feedback at all** when a file is received while the window is hidden — the file just silently lands in the destination folder. The second commit adds a native desktop notification on receive completion, with an "Open folder" action that reveals the received file(s).

- Uses `local_notifier` (from the same leanflutter family as the already-used `window_manager` / `tray_manager`).
- On Linux the platform plugin does not deliver notification body clicks, so an explicit action button ("Open folder") is used. The Dart-side body-click handler (`onClick`) is also wired for the other desktop platforms, where the plugin does deliver it.
- New user-facing strings are added to `en.json` only; other locales fall back to English until translated.

The two changes are kept as **separate commits** so they can be split if you'd prefer to land them independently.

## Test plan

- [x] Launch hidden on Linux → receive server binds, `/info` returns 200, real file transfer completes with no window shown
- [x] Receive a file while hidden → desktop notification appears
- [x] Click the notification's "Open folder" action → destination folder opens with the file highlighted
- [x] `flutter analyze` clean on changed files
- [ ] Windows / macOS — **not tested;** I only have Linux. The changes are desktop-guarded and reuse the same cross-platform plugin API, so they should apply, but a maintainer with those platforms should confirm.