### PR TITLE
Fix folder path bugs on Android:

### DIFF
--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/FileOpener.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/FileOpener.kt
@@ -13,7 +13,16 @@ fun openUri(context: Context, uriStr: String) {
 
     println("Inferred type: $type")
 
-    intent.setDataAndType(uri, type)
+    // Handle folder directory separately
+    if (type == DocumentsContract.Document.MIME_TYPE_DIR) {
+        val treeId = DocumentsContract.getTreeDocumentId(uri)
+        val browseUri = DocumentsContract.buildDocumentUriUsingTree(uri, treeId)
+
+        intent.setDataAndType(browseUri, type)
+    } else {
+        intent.setDataAndType(uri, type)
+    }
+
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
     context.startActivity(intent)
 }

--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -16,6 +16,7 @@ import 'package:localsend_app/provider/progress_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/file_size_helper.dart';
 import 'package:localsend_app/util/file_speed_helper.dart';
+import 'package:localsend_app/util/native/content_uri_helper.dart';
 import 'package:localsend_app/util/native/open_file.dart';
 import 'package:localsend_app/util/native/open_folder.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
@@ -273,7 +274,9 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
                                     style: const TextStyle(color: Colors.grey),
                                   ),
                                   TextSpan(
-                                    text: receiveSession.destinationDirectory,
+                                    text: ContentUriHelper.isTreeURI(receiveSession.destinationDirectory)
+                                        ? (ContentUriHelper.getDisplayPathFromTreeUri(receiveSession.destinationDirectory))
+                                        : (receiveSession.destinationDirectory),
                                     style: TextStyle(
                                       color: checkPlatform([TargetPlatform.iOS]) ? Colors.grey : Theme.of(context).colorScheme.primary,
                                     ),

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -18,6 +18,8 @@ import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/provider/version_provider.dart';
 import 'package:localsend_app/util/alias_generator.dart';
 import 'package:localsend_app/util/device_type_ext.dart';
+import 'package:localsend_app/util/file_path_helper.dart';
+import 'package:localsend_app/util/native/content_uri_helper.dart';
 import 'package:localsend_app/util/native/macos_channel.dart';
 import 'package:localsend_app/util/native/pick_directory_path.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
@@ -224,7 +226,12 @@ class SettingsTab extends StatelessWidget {
                             },
                             child: Padding(
                               padding: const EdgeInsets.symmetric(vertical: 5),
-                              child: Text(vm.settings.destination ?? t.settingsTab.receive.downloads, style: Theme.of(context).textTheme.titleMedium),
+                              child: Text(
+                                ContentUriHelper.isTreeURI(vm.settings.destination)
+                                    ? ContentUriHelper.getDisplayPathFromTreeUri(vm.settings.destination!)!
+                                    : vm.settings.destination ?? t.settingsTab.receive.downloads,
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
                             ),
                           ),
                         ),

--- a/app/lib/util/native/content_uri_helper.dart
+++ b/app/lib/util/native/content_uri_helper.dart
@@ -3,6 +3,15 @@ import 'package:flutter/services.dart';
 import 'package:uri_content/uri_content.dart';
 
 class ContentUriHelper {
+  /// Checks uri in this format:
+  /// content://com.android.externalstorage.documents/tree/primary%3ADocuments
+  static bool isTreeURI(String? uri) {
+    if (uri == null || uri.startsWith('content') == false) return false;
+
+    final index = uri.indexOf('/tree/');
+    return (index != -1);
+  }
+  
   /// Converts
   /// content://com.android.externalstorage.documents/tree/primary%3ADocuments
   /// to primary:Documents
@@ -13,6 +22,15 @@ class ContentUriHelper {
     }
 
     return Uri.decodeComponent(uri.substring(index + 6));
+  }
+
+  /// Converts
+  /// content://com.android.externalstorage.documents/tree/primary%3ADocuments%2Fsubfolder
+  /// to Documents/subfolder
+  static String? getDisplayPathFromTreeUri(String uri) {
+    String? path = getPathFromTreeUri(uri);
+    // Remove `primary:` prefix
+    return path?.substring(8);
   }
 
   /// Converts


### PR DESCRIPTION
1. Previously, the 'Open Folder' button in history page opened the Downloads folder, even if the user changed the save location. I've fixed this by handling folder directories separately in the 'openUri' function in 'FileOpener.kt'

2. Previously, Folder paths on Android were displayed in Content URI format such as: 'content://com.android.externalstorage.documents/tree/primary%3ADocuments%2Fsubfolder'
I've fixed this issue by adding 2 helper functions in 'content_uri_helper.dart'.
Now they display a simple, user-friendly path like: Documents/subfolder

This contribution fixes issue [#2965](https://github.com/localsend/localsend/issues/2965), which's closed even though it has not been solved.