### PR TITLE
fix(linux): stop accumulating ScreenSaver inhibit locks during transfer

### DIFF
--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -77,7 +77,10 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
           unawaited(WakelockPlus.enable());
         } catch (_) {}
 
-        // Periodically call WakelockPlus.enable() to keep the screen awake
+        // Poll for completion and disable the wakelock once.
+        // We must NOT call WakelockPlus.enable() repeatedly here: on Linux (FreeDesktop D-Bus ScreenSaver)
+        // each enable() acquires a new inhibit cookie while disable() only releases one, so re-calling
+        // enable() every 30s leaks inhibit locks that keep the screen awake indefinitely (issue #3209).
         _wakelockPlusTimer = Timer.periodic(const Duration(seconds: 30), (timer) {
           final finished =
               ref.read(serverProvider)?.session?.files.values.map((e) => e.status).isFinishedOrSkipped ??
@@ -87,10 +90,6 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
             timer.cancel();
             try {
               unawaited(WakelockPlus.disable());
-            } catch (_) {}
-          } else {
-            try {
-              unawaited(WakelockPlus.enable());
             } catch (_) {}
           }
         });


### PR DESCRIPTION
On Linux, every call to WakelockPlus.enable() goes through the FreeDesktop D-Bus ScreenSaver interface, which issues a fresh inhibit cookie each time. The progress page calls enable() once on init (correct) but the 30s periodic timer was also calling enable() on every tick until the transfer finished, and disable() on dispose only releases a single cookie. The net effect is that a ~13-minute transfer leaks ~26 inhibit locks that keep the screen awake and block dpms/suspend indefinitely, even after the app exits — exactly what #3209 reports.

The repeated enable() call in the timer is redundant on all platforms: the initial enable() is already enough to hold the wakelock for the transfer duration, and it was actively harmful on Linux. This change keeps the timer (it still polls for completion and calls disable() once) but removes the inner enable() call.

I did not touch the init/dispose calls since those are the single enable/disable pair that needs to stay. Verified the logic against the reproduction in the issue (hyprland + hypridle) — the lock count now returns to 0 when the transfer ends.

Fixes #3209