### PR TITLE
fix(webrtc): await status_tx.send before returning on selection-publish failure

### DIFF
--- a/packages/core/src/webrtc/webrtc.rs
+++ b/packages/core/src/webrtc/webrtc.rs
@@ -492,7 +492,7 @@ pub async fn send_offer(
                 .is_err()
             {
                 let error = "Could not publish selection";
-                let _ = status_tx.send(RTCStatus::Error(error.to_owned()));
+                let _ = status_tx.send(RTCStatus::Error(error.to_owned())).await;
                 return Err(anyhow::anyhow!(error));
             }
 


### PR DESCRIPTION
In `send_offer`, the error path that runs when publishing the selected file set fails drops the `mpsc::Sender::send` future instead of awaiting it, so the `RTCStatus::Error("Could not publish selection")` message is never actually delivered to the status channel — the caller never learns that the selection could not be published. Every other `status_tx.send` call in the file is awaited (or uses `try_send`), so this one stands out.

Adding the missing `.await` makes the error notification fire as intended, matching the pattern used by the rest of the function. Verified with `cargo clippy --features full` (the `clippy::let_underscore_future` warning this site produced is gone) and `cargo test --features full` (44 tests pass).

I am not aware of a tracking issue for this; I found it while running clippy on the core crate.