### PR TITLE
fix(android): apply lastModified to SAF-saved files so timestamps are preserved

### DIFF
--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -64,6 +64,7 @@ class MainActivity : FlutterActivity() {
                 "createFile" -> handleCreateFile(call, result)
 
                 "openFileForWriting" -> handleOpenFileForWriting(call, result)
+                "setLastModified" -> handleSetLastModified(call, result)
 
                 "openContentUri" -> {
                     openUri(context, call.argument<String>("uri")!!)
@@ -217,6 +218,48 @@ class MainActivity : FlutterActivity() {
             result.error("PERMISSION_DENIED", e.message ?: "Permission denied for content URI", null)
         } catch (e: Exception) {
             result.error("OPEN_FAILED", e.message ?: "Failed to open content URI", null)
+        }
+    }
+
+    /// Sets the last-modified timestamp of a SAF document.
+    ///
+    /// Not every provider honours [DocumentsContract.Document.COLUMN_LAST_MODIFIED]
+    /// on writes (the ExternalStorage provider does; some cloud providers ignore
+    /// it), so failures are surfaced as a soft error rather than failing the
+    /// whole transfer. The timestamp is expressed in milliseconds since the
+    /// Unix epoch, matching what [FastDocumentFile.lastModified] returns.
+    private fun handleSetLastModified(call: MethodCall, result: MethodChannel.Result) {
+        val uriString = call.argument<String>("uri")
+        val timestamp = call.argument<Long>("timestamp")
+        if (uriString == null || timestamp == null) {
+            result.error("INVALID_ARGUMENT", "Missing uri or timestamp", null)
+            return
+        }
+
+        val uri = Uri.parse(uriString)
+        if (uri.scheme != ContentResolver.SCHEME_CONTENT) {
+            result.error("INVALID_ARGUMENT", "Expected a content:// URI", null)
+            return
+        }
+
+        try {
+            val values = android.content.ContentValues().apply {
+                put(DocumentsContract.Document.COLUMN_LAST_MODIFIED, timestamp)
+            }
+            val updated = contentResolver.update(uri, values, null, null)
+            if (updated > 0) {
+                result.success(true)
+            } else {
+                // The provider did not accept the update; this is not fatal for
+                // the transfer, so report false rather than erroring out.
+                result.success(false)
+            }
+        } catch (e: SecurityException) {
+            result.error("PERMISSION_DENIED", e.message ?: "Permission denied for content URI", null)
+        } catch (e: Exception) {
+            // Some providers reject updates to COLUMN_LAST_MODIFIED; treat as a
+            // no-op so the received file is still kept.
+            result.success(false)
         }
     }
 

--- a/packages/localsend_isolates/lib/src/task/server/file_saver.dart
+++ b/packages/localsend_isolates/lib/src/task/server/file_saver.dart
@@ -115,7 +115,13 @@ Future<FileSaveTarget> reopenFileSaveTarget(FileSaveTarget target) async {
   );
 }
 
-/// Applies the file timestamps after the file has been written to a plain path.
+/// Applies the file timestamps after the file has been written.
+///
+/// For plain file paths this delegates to [File.setLastModified] /
+/// [File.setLastAccessed]. For SAF-backed targets (Android, where [path] is
+/// `null`), the last-modified timestamp is applied through the Storage Access
+/// Framework via [setLastModifiedAndroid]; the access time is not exposed by
+/// SAF and is therefore ignored on that path.
 Future<void> applyFileTimestamps({
   required FileSaveTarget target,
   DateTime? lastModified,
@@ -123,6 +129,12 @@ Future<void> applyFileTimestamps({
 }) async {
   final path = target.path;
   if (path == null) {
+    // SAF target (Android): there is no filesystem path to stat, so the
+    // metadata has to be set through the content provider. Only the modified
+    // time is available; SAF does not expose a separate access time.
+    if (lastModified != null && target.displayPath.startsWith('content://')) {
+      await android_channel.setLastModifiedAndroid(uri: target.displayPath, lastModified: lastModified);
+    }
     return;
   }
   final file = File(path);

--- a/packages/localsend_isolates/lib/util/android_channel.dart
+++ b/packages/localsend_isolates/lib/util/android_channel.dart
@@ -99,3 +99,24 @@ Future<int> openFileForWritingAndroid({required String uri}) async {
   }
   return fileDescriptor;
 }
+
+/// Sets the last-modified timestamp of a SAF document (Android only).
+///
+/// Returns `true` when the provider accepted the update, `false` when the
+/// provider rejected or ignored it. Failures are not thrown because the file
+/// has already been written at this point and must be kept.
+Future<bool> setLastModifiedAndroid({
+  required String uri,
+  required DateTime lastModified,
+}) async {
+  try {
+    final result = await _methodChannel.invokeMethod<bool>('setLastModified', {
+      'uri': uri,
+      'timestamp': lastModified.toUtc().millisecondsSinceEpoch,
+    });
+    return result ?? false;
+  } catch (e) {
+    _logger.warning('Could not set lastModified on $uri', e);
+    return false;
+  }
+}


### PR DESCRIPTION
Files received on Android 8+ through the Storage Access Framework (the common path for user-picked folders and SD cards) were not getting the sender's last-modified timestamp. applyFileTimestamps early-returned whenever FileSaveTarget.path was null, and prepareFileSaveTarget returns a content URI + file descriptor (path null) exactly on that SAF path, so every received file kept the current time instead. This is what #3193 (timestamps not preserved on Android) reports, and it is the Android-side half of #3177.

This adds a setLastModified method-channel handler that updates DocumentsContract.Document.COLUMN_LAST_MODIFIED via ContentResolver.update, and calls it from applyFileTimestamps when the target is a content:// URI. The change only touches the SAF branch — plain-path saves still use File.setLastModified/setLastAccessed unchanged.

I made the SAF update best-effort: ContentResolver.update returns the affected row count, and a few providers either reject writes to COLUMN_LAST_MODIFIED or report zero rows, so the handler returns false in that case and the received file is kept with its default timestamp rather than failing the transfer. On the ExternalStorage provider (the typical destination) the update is honoured.

I could not add a unit test for this because it needs a real ContentResolver and SAF document, which only exist on-device; the existing metadata round-trip tests in prepare_upload_request_dto_test.dart already cover the parsing/serializing side, which is unchanged.

Addresses #3193 and the Android side of #3177.