### PR TITLE
i18n: complete missing Hindi translations for remainingTime

### DIFF
--- a/app/assets/i18n/_missing_translations_hi.json
+++ b/app/assets/i18n/_missing_translations_hi.json
@@ -7,8 +7,8 @@
     "remainingTime": {
       "seconds": "{n}:{ss}",
       "minutes": "{n}:{ss}",
-      "hours": "{h}h {m}m",
-      "days": "{d}d {h}h {m}m"
+      "hours": "{h}घं {m}मि",
+      "days": "{d}दि {h}घं {m}मि"
     }
   }
 }


### PR DESCRIPTION
### Summary
This PR completes the missing Hindi translations for the `progressPage.remainingTime` strings (`seconds`, `minutes`, `hours`, `days`) in `_missing_translations_hi.json`.

### Proposed Changes
- Updated `app/assets/i18n/_missing_translations_hi.json` with the localized Hindi time suffix abbreviations:
  - `hours`: `{h}घं {m}मि` (घं = घंटे, मि = मिनट)
  - `days`: `{d}दि {h}घं {m}मि` (दि = दिन)