### PR TITLE
fix: make Quick Save and Quick Save From Favorites mutually exclusive

### DIFF
--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -165,16 +165,32 @@ class SettingsService extends PureNotifier<SettingsState> {
 
   Future<void> setQuickSave(bool quickSave) async {
     await _persistence.setQuickSave(quickSave);
-    state = state.copyWith(
-      quickSave: quickSave,
-    );
+    if (quickSave) {
+      await _persistence.setQuickSaveFromFavorites(false);
+      state = state.copyWith(
+        quickSave: true,
+        quickSaveFromFavorites: false,
+      );
+    } else {
+      state = state.copyWith(
+        quickSave: false,
+      );
+    }
   }
 
   Future<void> setQuickSaveFromFavorites(bool quickSaveFromFavorites) async {
     await _persistence.setQuickSaveFromFavorites(quickSaveFromFavorites);
-    state = state.copyWith(
-      quickSaveFromFavorites: quickSaveFromFavorites,
-    );
+    if (quickSaveFromFavorites) {
+      await _persistence.setQuickSave(false);
+      state = state.copyWith(
+        quickSave: false,
+        quickSaveFromFavorites: true,
+      );
+    } else {
+      state = state.copyWith(
+        quickSaveFromFavorites: false,
+      );
+    }
   }
 
   Future<void> setReceivePin(String? receivePin) async {


### PR DESCRIPTION
### Summary
This PR resolves Issue #3163 by ensuring that "Quick Save" and "Quick Save From Favorites" are mutually exclusive.

### Proposed Changes
- Modified `app/lib/provider/settings_provider.dart`:
  - In `setQuickSave(true)`, automatically set `quickSaveFromFavorites` to `false` and persist it.
  - In `setQuickSaveFromFavorites(true)`, automatically set `quickSave` to `false` and persist it.

This prevents both options from being enabled at the same time in the settings menu.