### PR TITLE
fix(settings): make Quick Save and Quick Save Favorites mutually exclusive

### DIFF
--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -156,6 +156,9 @@ class SettingsTab extends StatelessWidget {
                   onChanged: (b) async {
                     final old = vm.settings.quickSave;
                     await ref.notifier(settingsProvider).setQuickSave(b);
+                    if (b) {
+                      await ref.notifier(settingsProvider).setQuickSaveFromFavorites(false);
+                    }
                     if (!old && b && context.mounted) {
                       await QuickSaveNotice.open(context);
                     }
@@ -167,6 +170,9 @@ class SettingsTab extends StatelessWidget {
                   onChanged: (b) async {
                     final old = vm.settings.quickSaveFromFavorites;
                     await ref.notifier(settingsProvider).setQuickSaveFromFavorites(b);
+                    if (b) {
+                      await ref.notifier(settingsProvider).setQuickSave(false);
+                    }
                     if (!old && b && context.mounted) {
                       await QuickSaveFromFavoritesNotice.open(context);
                     }


### PR DESCRIPTION
Closes #3163.

The Settings screen exposes Quick Save and Quick Save from Favorites as two independent toggles, but the Receive screen treats them as a 3-way exclusive SegmentedButton (Off / Favorites / On). Enabling both toggles puts the app in an inconsistent state where the Receive screen shows both Favorites and On as simultaneously active.

This makes the Settings toggles behave as mutually exclusive: turning one on clears the other, so the two entry points can no longer disagree. The behavior mirrors the segmented-button semantics on the Receive tab.

The change is intentionally minimal and only touches the Settings tab — no changes to the provider, persistence, or Receive logic.