### PR TITLE
fix(desktop): start receive server when launched hidden

### DIFF
--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -57,6 +57,23 @@ import 'package:window_manager/window_manager.dart';
 
 final _logger = Logger('Init');
 
+@visibleForTesting
+Future<void> startReceiveServerDuringPreInit({
+  required bool isDesktop,
+  required Future<void> Function() startServer,
+  required void Function(Object error, StackTrace stackTrace) onError,
+}) async {
+  if (!isDesktop) {
+    return;
+  }
+
+  try {
+    await startServer();
+  } catch (error, stackTrace) {
+    onError(error, stackTrace);
+  }
+}
+
 /// Will be called before the MaterialApp started
 Future<RefenaContainer> preInit(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -196,6 +213,19 @@ Future<RefenaContainer> preInit(List<String> args) async {
   );
 
   await container.redux(parentIsolateProvider).dispatchAsync(IsolateSetupAction());
+
+  // The receive server must start before the widget tree is mounted. When a
+  // desktop app launches hidden, HomePage may not be built, so postInit() may
+  // never run until the window is opened manually.
+  await startReceiveServerDuringPreInit(
+    isDesktop: checkPlatformIsDesktop(),
+    startServer: () async {
+      await container.notifier(serverProvider).startServerFromSettings();
+    },
+    onError: (error, stackTrace) {
+      _logger.warning('Starting receive server during initialization failed', error, stackTrace);
+    },
+  );
 
   return container;
 }

--- a/app/test/unit/config/init_test.dart
+++ b/app/test/unit/config/init_test.dart
@@ -1,0 +1,58 @@
+import 'package:localsend_app/config/init.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('starts the receive server during desktop pre-initialization', () async {
+    var startCount = 0;
+    Object? reportedError;
+
+    await startReceiveServerDuringPreInit(
+      isDesktop: true,
+      startServer: () async {
+        startCount++;
+      },
+      onError: (error, stackTrace) {
+        reportedError = error;
+      },
+    );
+
+    expect(startCount, 1);
+    expect(reportedError, isNull);
+  });
+
+  test('does not start the receive server during mobile pre-initialization', () async {
+    var startCount = 0;
+
+    await startReceiveServerDuringPreInit(
+      isDesktop: false,
+      startServer: () async {
+        startCount++;
+      },
+      onError: (error, stackTrace) {
+        fail('Unexpected error: $error');
+      },
+    );
+
+    expect(startCount, 0);
+  });
+
+  test('reports desktop receive server failures without aborting initialization', () async {
+    final expectedError = StateError('failed to bind');
+    Object? reportedError;
+    StackTrace? reportedStackTrace;
+
+    await startReceiveServerDuringPreInit(
+      isDesktop: true,
+      startServer: () async {
+        throw expectedError;
+      },
+      onError: (error, stackTrace) {
+        reportedError = error;
+        reportedStackTrace = stackTrace;
+      },
+    );
+
+    expect(reportedError, same(expectedError));
+    expect(reportedStackTrace, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary

- start the desktop receive server during `preInit`, after the isolate setup and before the widget tree is mounted
- keep mobile startup unchanged and preserve the existing idempotent `postInit` startup call
- report early server startup failures without aborting application initialization
- add regression coverage for desktop, mobile, and startup-failure behavior

## Root cause

When LocalSend starts with `--hidden`, some desktop compositors do not build `HomePage` until the window is shown. The receive server currently starts from `postInit`, which is called by `HomePage.initState`, so multicast discovery can advertise the device while no TCP server is listening. Opening the window builds the page and starts the server, making receiving work for the rest of the session.

Starting the server during `preInit` decouples receiving from whether the UI is ever shown. `ServerService.startServer` already treats a second start as a no-op, so the existing `postInit` call remains safe.

Fixes #3055.
Relates to #3195 and #3196. This is a narrower alternative to #3196: it contains only the server-start fix and regression tests, without the additional desktop-notification feature or dependency.

## Validation

- `flutter test test/unit/config/init_test.dart`
- `flutter test test/unit` (65 tests passed)
- `flutter analyze lib/config/init.dart test/unit/config/init_test.dart`
