### PR TITLE
i18n: Updates to missing Ukrainian and Russian translations 

### DIFF
--- a/app/assets/i18n/_missing_translations_ru.json
+++ b/app/assets/i18n/_missing_translations_ru.json
@@ -4,26 +4,26 @@
     "After editing this file, you can run 'dart run slang apply --locale=ru' to quickly apply the newly added translations."
   ],
   "deviceDetailsPage": {
-    "title": "Device Details",
+    "title": "Сведения об устройстве",
     "favorite": "Favorite",
-    "verify": "Verify",
+    "verify": "Проверить",
     "info": {
-      "name": "Name",
-      "address": "Address",
-      "version": "Version",
-      "protocol": "Protocol v{version}"
+      "name": "Имя устройства",
+      "address": "Адрес",
+      "version": "Версия",
+      "protocol": "Протокол v{version}"
     },
     "logs": {
-      "title": "Logs",
-      "empty": "No logs available.",
-      "discovered": "Discovered via {protocol} ({host})",
-      "updated": "Updated via {protocol} ({host})"
+      "title": "Журналы",
+      "empty": "Нет доступных журналов.",
+      "discovered": "Обнаружено с помощью {protocol} ({host})",
+      "updated": "Обновлено с помощью {protocol} ({host})"
     }
   },
   "verifyPage": {
-    "title": "Verify",
-    "icons": "Icons",
+    "title": "Проверить",
+    "icons": "Значки",
     "raw": "Raw",
-    "question": "Does it look the same on the other device?"
+    "question": "Выглядит ли это так же на другом устройстве?"
   }
 }

--- a/app/assets/i18n/_missing_translations_ru.json
+++ b/app/assets/i18n/_missing_translations_ru.json
@@ -5,7 +5,7 @@
   ],
   "deviceDetailsPage": {
     "title": "Сведения об устройстве",
-    "favorite": "Favorite",
+    "favorite": "В избранное",
     "verify": "Проверить",
     "info": {
       "name": "Имя устройства",
@@ -16,14 +16,14 @@
     "logs": {
       "title": "Журналы",
       "empty": "Нет доступных журналов.",
-      "discovered": "Обнаружено с помощью {protocol} ({host})",
-      "updated": "Обновлено с помощью {protocol} ({host})"
+      "discovered": "Обнаружено через {protocol} ({host})",
+      "updated": "Обновлено через {protocol} ({host})"
     }
   },
   "verifyPage": {
-    "title": "Проверить",
+    "title": "Проверка",
     "icons": "Значки",
-    "raw": "Raw",
+    "raw": "Код",
     "question": "Выглядит ли это так же на другом устройстве?"
   }
 }

--- a/app/assets/i18n/_missing_translations_uk.json
+++ b/app/assets/i18n/_missing_translations_uk.json
@@ -4,26 +4,26 @@
     "After editing this file, you can run 'dart run slang apply --locale=uk' to quickly apply the newly added translations."
   ],
   "deviceDetailsPage": {
-    "title": "Device Details",
+    "title": "Відомості про пристрій",
     "favorite": "Favorite",
-    "verify": "Verify",
+    "verify": "Перевірити",
     "info": {
-      "name": "Name",
-      "address": "Address",
-      "version": "Version",
-      "protocol": "Protocol v{version}"
+      "name": "Ім'я пристрою",
+      "address": "Адреса",
+      "version": "Версія",
+      "protocol": "Протокол v{version}"
     },
     "logs": {
-      "title": "Logs",
-      "empty": "No logs available.",
-      "discovered": "Discovered via {protocol} ({host})",
-      "updated": "Updated via {protocol} ({host})"
+      "title": "Журнали",
+      "empty": "Немає доступних журналів.",
+      "discovered": "Виявлено за допомогою {protocol} ({host})",
+      "updated": "Оновлено за допомогою {protocol} ({host})"
     }
   },
   "verifyPage": {
-    "title": "Verify",
-    "icons": "Icons",
+    "title": "Перевірити",
+    "icons": "Піктограми",
     "raw": "Raw",
-    "question": "Does it look the same on the other device?"
+    "question": "Чи виглядає це так само на іншому пристрої?"
   }
 }

--- a/app/assets/i18n/_missing_translations_uk.json
+++ b/app/assets/i18n/_missing_translations_uk.json
@@ -5,7 +5,7 @@
   ],
   "deviceDetailsPage": {
     "title": "Відомості про пристрій",
-    "favorite": "Favorite",
+    "favorite": "До улюблених",
     "verify": "Перевірити",
     "info": {
       "name": "Ім'я пристрою",
@@ -16,14 +16,14 @@
     "logs": {
       "title": "Журнали",
       "empty": "Немає доступних журналів.",
-      "discovered": "Виявлено за допомогою {protocol} ({host})",
-      "updated": "Оновлено за допомогою {protocol} ({host})"
+      "discovered": "Виявлено через {protocol} ({host})",
+      "updated": "Оновлено через {protocol} ({host})"
     }
   },
   "verifyPage": {
-    "title": "Перевірити",
+    "title": "Перевірка",
     "icons": "Піктограми",
-    "raw": "Raw",
+    "raw": "Код",
     "question": "Чи виглядає це так само на іншому пристрої?"
   }
 }


### PR DESCRIPTION
Could you please clarify what Favorite means in this context? Is it simply a list of the user's favorite devices? That's the only interpretation that comes to mind for something that would appear on the Device Details page.

I'm even less sure what Raw is supposed to mean on the Verify page.

It would be really helpful if you could provide screenshots of these two pages.

For example, Verify can be translated into Ukrainian in several different ways depending on the context. As a verb, it would normally be "Перевірити", and as a noun, "Перевірка". However, as I understand it, this page is about confirming that the information shown on two devices matches, so they can be securely paired and the correct device can be identified. In that context, the most natural Ukrainian term would be "Звірити" (verb) or "Звірка" (noun/title). Both Ukrainian and Russian have quite a few nuances like this 😄