### PR TITLE
fix(app): repair the single-instance "show" handover so Send-To reaches the running instance

### DIFF
--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_mappable/dart_mappable.dart';
@@ -39,14 +38,13 @@ import 'package:localsend_app/util/native/tray_helper.dart';
 import 'package:localsend_app/util/notification_strings.dart';
 import 'package:localsend_app/util/ui/dynamic_colors.dart';
 import 'package:localsend_app/util/ui/snackbar.dart';
-import 'package:localsend_isolates/api_route_builder.dart';
-import 'package:localsend_isolates/constants.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/dto/file_dto.dart';
 import 'package:localsend_isolates/model/dto/multicast_dto.dart';
 import 'package:localsend_isolates/rust/api/logging.dart' as rust_logging;
 import 'package:localsend_isolates/rust/frb_generated.dart';
 import 'package:localsend_isolates/util/logger.dart';
+import 'package:localsend_isolates/util/show_instance.dart';
 import 'package:localsend_isolates/util/transfer_notification.dart';
 import 'package:logging/logging.dart';
 import 'package:refena_flutter/addons.dart';
@@ -93,35 +91,15 @@ Future<RefenaContainer> preInit(List<String> args) async {
     // Check if this app is already open and let it "show up".
     // If this is the case, then exit the current instance.
 
-    final client = HttpClient();
-    client.connectionTimeout = const Duration(milliseconds: 100);
-    client.badCertificateCallback = (cert, host, port) => true;
-
-    try {
-      final uri =
-          Uri.parse(
-            ApiRoute.show.targetRaw(
-              '127.0.0.1',
-              persistenceService.getPort(),
-              persistenceService.isHttps(),
-              peerProtocolVersion,
-            ),
-          ).replace(
-            queryParameters: {
-              'token': persistenceService.getShowToken(),
-            },
-          );
-
-      final request = await client.postUrl(uri);
-      request.headers.contentType = ContentType.json;
-      request.write(jsonEncode({'args': args}));
-      final response = await request.close().timeout(const Duration(milliseconds: 500));
-      if (response.statusCode == 200) {
-        exit(0); // Another instance does exist
-      }
-    } catch (_) {
-    } finally {
-      client.close(force: true);
+    final handedOver = await notifyRunningInstance(
+      securityContext: persistenceService.getSecurityContext(),
+      port: persistenceService.getPort(),
+      https: persistenceService.isHttps(),
+      showToken: persistenceService.getShowToken(),
+      args: args,
+    );
+    if (handedOver) {
+      exit(0); // Another instance does exist
     }
 
     // initialize tray AFTER i18n has been initialized

--- a/packages/localsend_isolates/lib/util/show_instance.dart
+++ b/packages/localsend_isolates/lib/util/show_instance.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:localsend_isolates/api_route_builder.dart';
+import 'package:localsend_isolates/model/stored_security_context.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('ShowInstance');
+
+/// Asks an app instance that is already running on this machine to show itself
+/// and to take over [args].
+///
+/// Returns `true` when a running instance accepted the handover, so the caller
+/// can exit instead of starting a second instance.
+///
+/// The server demands a client certificate whenever the web pages are not
+/// served, so this client must present the device's own certificate. Without
+/// it, the TLS handshake is rejected before the request is ever sent and the
+/// running instance is never reached.
+Future<bool> notifyRunningInstance({
+  required StoredSecurityContext securityContext,
+  required int port,
+  required bool https,
+  required String showToken,
+  required List<String> args,
+  Duration connectionTimeout = const Duration(milliseconds: 100),
+  Duration responseTimeout = const Duration(milliseconds: 500),
+}) async {
+  final client = HttpClient(context: https ? _clientContext(securityContext) : null);
+  client.connectionTimeout = connectionTimeout;
+
+  // The peer is this device itself; its certificate is self-signed by design.
+  client.badCertificateCallback = (cert, host, port) => true;
+
+  try {
+    // `show` is an internal endpoint that is only served on the v2 path, so the
+    // route must not be negotiated like a peer's protocol version.
+    final uri = Uri(
+      scheme: https ? 'https' : 'http',
+      host: '127.0.0.1',
+      port: port,
+      path: ApiRoute.show.v2,
+      queryParameters: {
+        'token': showToken,
+      },
+    );
+
+    final request = await client.postUrl(uri);
+    request.headers.contentType = ContentType.json;
+    request.write(jsonEncode({'args': args}));
+    final response = await request.close().timeout(responseTimeout);
+    final statusCode = response.statusCode;
+
+    // Read the (empty) body so the connection is not left half-read, but never
+    // wait longer than the response timeout for it: the status is already known
+    // and startup must not hang on whatever is holding the port.
+    try {
+      await response.drain<void>().timeout(responseTimeout);
+    } catch (_) {
+      // A body that never arrives does not change the answer above.
+    }
+
+    if (statusCode != 200) {
+      // Something answered on the port but refused the handover. That is never
+      // normal, and it is exactly what silently degrades into a second instance
+      // fighting over the port, so it must not be swallowed.
+      _logger.warning('The running instance refused to take over the arguments: HTTP $statusCode');
+      return false;
+    }
+    return true;
+  } on HandshakeException catch (e) {
+    // An instance is listening but the TLS handshake did not complete, e.g.
+    // because it did not accept this device's certificate. Also never normal.
+    _logger.warning('TLS handshake with the running instance failed: $e');
+    return false;
+  } catch (e) {
+    // Nothing is listening - the normal case on a regular app start.
+    _logger.fine('No running instance took over the arguments: $e');
+    return false;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+/// Presents the device's own certificate, which the server verifies.
+SecurityContext _clientContext(StoredSecurityContext securityContext) {
+  return SecurityContext(withTrustedRoots: false)
+    ..useCertificateChainBytes(utf8.encode(securityContext.certificate))
+    ..usePrivateKeyBytes(utf8.encode(securityContext.privateKey));
+}

--- a/packages/localsend_isolates/test/util/show_instance_test.dart
+++ b/packages/localsend_isolates/test/util/show_instance_test.dart
@@ -1,0 +1,185 @@
+// Regression test for https://github.com/localsend/localsend/issues/3165
+//
+// "Send to -> LocalSend" starts a second process with the file paths as
+// arguments. Only the internal `show` handover keeps that process from becoming
+// a duplicate instance that then collides on port 53317.
+//
+// Two things made the handover fail:
+//   * it was addressed with `peerProtocolVersion` ('1.0'), which builds the v1
+//     path, while the server only serves `show` on the v2 path, and
+//   * it presented no client certificate, while the server demands one whenever
+//     the web pages are not served (`mandatory_client_auth` in
+//     `packages/core/src/http/server/mod.rs`), so the TLS handshake was
+//     rejected before the request was sent.
+//
+// The stub server below stands in for the running instance: a real one cannot
+// be started in-process here, because the Rust TLS stack and the client's
+// BoringSSL deadlock inside `flutter_tester`.
+@Timeout(Duration(minutes: 1))
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart' show ExternalLibrary;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localsend_isolates/model/stored_security_context.dart';
+import 'package:localsend_isolates/rust/api/crypto.dart' hide SecurityContext;
+import 'package:localsend_isolates/rust/frb_generated.dart';
+import 'package:localsend_isolates/util/show_instance.dart';
+
+const _token = 'show-token-3165';
+
+/// Cargo writes the library under a different name per platform.
+File _findDylib() {
+  final base = '${Directory.current.path}/../../target/debug';
+  return [
+    File('$base/librust_lib_localsend_app.dylib'),
+    File('$base/librust_lib_localsend_app.so'),
+    File('$base/rust_lib_localsend_app.dll'),
+  ].firstWhere((f) => f.existsSync(), orElse: () => File('$base/librust_lib_localsend_app.dylib'));
+}
+
+/// What the stub server saw of a handover request.
+class _Received {
+  String? path;
+  String? token;
+  String? body;
+  X509Certificate? clientCertificate;
+}
+
+void main() {
+  late StoredSecurityContext identity;
+
+  setUpAll(() async {
+    final dylib = _findDylib();
+    if (!dylib.existsSync()) {
+      return;
+    }
+    await RustLib.init(externalLibrary: ExternalLibrary.open(dylib.path));
+    final generated = await generateSecurityContext();
+    identity = StoredSecurityContext(
+      privateKey: generated.privateKey,
+      publicKey: generated.publicKey,
+      certificate: generated.certificate,
+      certificateHash: generated.certificateHash,
+    );
+  });
+
+  /// Serves the `show` endpoint like a running instance would, over TLS with
+  /// client certificates requested, and answers with [statusCode].
+  Future<(HttpServer, _Received)> startStub({int statusCode = 200}) async {
+    final context = SecurityContext(withTrustedRoots: false)
+      ..useCertificateChainBytes(utf8.encode(identity.certificate))
+      ..usePrivateKeyBytes(utf8.encode(identity.privateKey))
+      // The client presents this same self-signed identity.
+      ..setTrustedCertificatesBytes(utf8.encode(identity.certificate));
+
+    final server = await HttpServer.bindSecure(
+      InternetAddress.loopbackIPv4,
+      0,
+      context,
+      requestClientCertificate: true,
+    );
+
+    final received = _Received();
+    server.listen((request) async {
+      received
+        ..path = request.uri.path
+        ..token = request.uri.queryParameters['token']
+        ..body = await utf8.decodeStream(request)
+        ..clientCertificate = request.certificate;
+
+      // Mirrors what the real server does: `show` exists on the v2 path only,
+      // it is guarded by the token, and it is unreachable without a client
+      // certificate (there the handshake itself is refused, which a Dart server
+      // cannot express, so an unauthorized answer stands in for it).
+      request.response.statusCode = switch (received) {
+        _Received(clientCertificate: null) => HttpStatus.unauthorized,
+        _Received(path: != '/api/localsend/v2/show') => HttpStatus.notFound,
+        _Received(token: != _token) => HttpStatus.forbidden,
+        _ => statusCode,
+      };
+      await request.response.close();
+    });
+
+    return (server, received);
+  }
+
+  test('hands the arguments to the running instance over TLS', () async {
+    if (!_findDylib().existsSync()) {
+      markTestSkipped('Rust dylib not built (cargo build -p rust_lib_localsend_app)');
+      return;
+    }
+    final (server, received) = await startStub();
+    addTearDown(() => server.close(force: true));
+
+    const args = [r'C:\Users\Test\holiday.png'];
+    final handedOver = await notifyRunningInstance(
+      securityContext: identity,
+      port: server.port,
+      https: true,
+      showToken: _token,
+      args: args,
+      connectionTimeout: const Duration(seconds: 10),
+      responseTimeout: const Duration(seconds: 10),
+    );
+
+    expect(handedOver, isTrue, reason: 'the running instance accepted the handover');
+
+    // Regression: '1.0' used to select the v1 path, which the server does not serve.
+    expect(received.path, '/api/localsend/v2/show');
+    expect(received.token, _token);
+    expect(jsonDecode(received.body!), {'args': args});
+
+    // Regression: without this the server rejects the handshake and the second
+    // instance starts anyway, fighting over the port.
+    expect(
+      received.clientCertificate,
+      isNotNull,
+      reason: 'the device certificate must be presented, the server requires one',
+    );
+  });
+
+  test('does not exit when the running instance rejects the request', () async {
+    if (!_findDylib().existsSync()) {
+      markTestSkipped('Rust dylib not built (cargo build -p rust_lib_localsend_app)');
+      return;
+    }
+    final (server, _) = await startStub();
+    addTearDown(() => server.close(force: true));
+
+    final handedOver = await notifyRunningInstance(
+      securityContext: identity,
+      port: server.port,
+      https: true,
+      showToken: 'wrong-token',
+      args: const [],
+      connectionTimeout: const Duration(seconds: 10),
+      responseTimeout: const Duration(seconds: 10),
+    );
+
+    expect(handedOver, isFalse);
+  });
+
+  test('reports no running instance when nothing listens', () async {
+    if (!_findDylib().existsSync()) {
+      markTestSkipped('Rust dylib not built (cargo build -p rust_lib_localsend_app)');
+      return;
+    }
+    // Bind and immediately release a port so that nothing answers on it.
+    final probe = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final closedPort = probe.port;
+    await probe.close();
+
+    final handedOver = await notifyRunningInstance(
+      securityContext: identity,
+      port: closedPort,
+      https: true,
+      showToken: _token,
+      args: const [],
+    );
+
+    expect(handedOver, isFalse);
+  });
+}


### PR DESCRIPTION
### What happens today on `main`

On desktop, `preInit` asks an already-running instance to show itself and take over the arguments, and exits if that succeeds. On `main` that request cannot succeed, so every "Send to → LocalSend" starts a second process, which then fails to bind port 53317 and appears as a duplicate window.

Reproduction, on a Windows build of `main`:

1. Start LocalSend and let it bind 53317.
2. In Explorer, right-click any file → **Send to → LocalSend**.
3. A second `localsend_app.exe` starts and stays alive with its own window, while the first process keeps the port.

Windows Explorer creates that second process by design: the Send-To entry is a plain shortcut to `Platform.resolvedExecutable` with no DDE (`app/lib/util/native/context_menu_helper.dart`), so there is no OS-level single-instance guard. The `show` handover is the only guard there is.

### Two root causes, on the same request

**1. The internal `show` endpoint was addressed on the v1 path.**

`preInit` built the URL with `ApiRoute.show.targetRaw(..., peerProtocolVersion)` (`app/lib/config/init.dart:103` on `main`). `peerProtocolVersion` is the constant `'1.0'` (`packages/localsend_isolates/lib/constants.dart:14`), and `targetRaw` maps `'1.0'` to the v1 path (`packages/localsend_isolates/lib/api_route_builder.dart:39`). The server registers exactly one show route:

```rust
// packages/core/src/http/server/mod.rs:540
(&Method::POST, "/api/localsend/v2/show") => internal::show(req, state).await,
```

There is no v1 route in the Rust server, so the handover got a 404, `statusCode != 200`, and the second instance kept starting. `show` is an internal endpoint used to talk to another copy of this same app on this same machine — it is not a peer's negotiated protocol version and should never have been version-negotiated.

**2. No client certificate was presented.**

TLS is on by default (`isHttps()` returns `true` by default, `app/lib/provider/persistence_provider.dart:494`), and the server makes client certificates mandatory whenever the web pages are not served:

```rust
// packages/core/src/http/server/mod.rs:322
let mandatory_client_auth = app_state.web.is_none() && !app_state.web_upload;
```

```rust
// packages/core/src/http/server/common/client_cert_verifier.rs:46
fn client_auth_mandatory(&self) -> bool { self.mandatory }
```

`preInit` used a bare `HttpClient()` (`app/lib/config/init.dart:96` on `main`). `badCertificateCallback` only overrides validation of the *server's* certificate and cannot satisfy a *client* certificate requirement, so the handshake was refused before the request was sent. Confirmed against the real Rust server:

```
no client cert       -> HttpException: TLSV1_ALERT_CERTIFICATE_REQUIRED (ssl/tls_record.cc:486) error 268436572
client cert, v2 path -> 200, and the server emits RsServerEvent.show_(args: [a.txt])
```

Either defect alone produces the duplicate window and the port collision.

### How it got here

Neither commit is wrong on its own reading, which is probably why this passed review:

- `b43b7950` ("fix: remove rhttp", 2026-07-14) replaced `createRhttpClient(<timeout>, persistenceService.getSecurityContext())` with a bare `HttpClient()`, dropping the client certificate. The Dart server at that point did not request client certificates (`HttpServer.bindSecure` without `requestClientCertificate`) and served both `show.v1` and `show.v2` (`app/lib/provider/network/server/controller/receive_controller.dart:115` and `:119`), so nothing broke.
- `1a6d5eae` ("feat(core): add internal show route", 2026-07-15) moved `show` into the Rust server, which serves v2 only and sets `mandatory_client_auth`. Both latent defects went live in that commit.

The token wiring is fine and untouched: `preInit` and the server read the same persisted value (`settings_provider.dart:48` and `server_provider.dart:174`).

### What this PR does

- Adds `packages/localsend_isolates/lib/util/show_instance.dart` with `notifyRunningInstance(...)`. It addresses `ApiRoute.show.v2` directly and gives the client the device's own certificate via `SecurityContext.useCertificateChainBytes` / `usePrivateKeyBytes` from the persisted `StoredSecurityContext`. It lives in `localsend_isolates` because that package owns `ApiRoute` and `StoredSecurityContext`, and because `app` depends only on `localsend_isolates`.
- `app/lib/config/init.dart` calls that helper and exits when it returns `true` (+10 / −32).
- Connect (100 ms) and response (500 ms) timeouts are unchanged; they are named parameters only so the test can widen them.
- The bare `catch (_)` is replaced by outcome-aware logging: a refusal (`statusCode != 200`) and a failed TLS handshake are logged as warnings, because both mean something answered on the port and then denied the handover — the exact shape of this bug. "Nothing is listening", which is the normal case on a cold start, stays at `fine` and prints nothing at the default log level.

Behavior note for reviewers: `preInit` exits only on HTTP 200. That is the same rule the current `main` uses, but it is stricter than 1.17.0, which exited whenever the rhttp call returned without throwing.

### Tests

`packages/localsend_isolates/test/util/show_instance_test.dart` — three cases: the handover succeeds and forwards the arguments; a rejected token does not exit; nothing listening does not exit. The stub server enforces the real server's contract, so reverting either defect alone fails the suite:

| Reverted | Stub answers | Test |
|---|---|---|
| v2 → v1 path | 404 | fails |
| client certificate removed | 401 | fails |
| both | 401 | fails |
| neither | 200 | passes |

Checks run locally with the pinned Flutter 3.41.9: `dart format --set-exit-if-changed lib test`, `flutter analyze` and `flutter test` all pass in both `app` and `packages/localsend_isolates`.

**One honest caveat.** These tests mint a throwaway identity through `generateSecurityContext()`, so `setUpAll` needs the Rust dylib and the tests self-skip without it. `ci.yml` runs `flutter test` on `ubuntu-latest` and does not run `cargo build`, so **they will skip on CI** — the same way the package's existing `cancel_session_repro_test.dart` already does. They do run locally once `cargo build -p rust_lib_localsend_app` has been done. I did not want to trade that skip for a static certificate and private key checked into the repo. Happy to follow whatever you prefer here.

### Evidence

`main` was built for Windows twice from the same tree — once with `init.dart` at upstream, once with the fix — and the real Explorer Send-To path was exercised against each, via the actual `SendTo\LocalSend.lnk` invoked through `ShellExecute` with the test file as its argument.

| Run | Result |
|---|---|
| unfixed `main` | **2** `localsend_app` processes, **2** visible windows, sustained for 15 s. First PID keeps 53317, second cannot bind |
| with the fix | **1** process, **1** window throughout. The second process exits. 53317 never contested |

The surviving instance came to the foreground on the Send page showing `Files: 1, Size: 27 B`, which is the 27-byte test file — so the arguments really reached the running instance. The fix is not just suppressing the second window.

### Scope

This PR fixes the duplicate-instance behavior as it exists on `main` today. It does not claim to explain the original report: #3165 was filed on 2026-07-03 against release **1.17.0** (tagged 2025-02-19), which predates both commits above and takes a different code path, and I could not reproduce the reported symptom on 1.17.0 on Windows 11. So I have left the issue open rather than auto-closing it — please close it if you consider this the same defect, and I am glad to keep digging on the 1.17.0 path if you would rather treat it separately.
