### PR TITLE
test: release exe

### DIFF
--- a/.github/workflows/test_exe.yml
+++ b/.github/workflows/test_exe.yml
@@ -1,0 +1,78 @@
+name: Build windows exe
+
+on:
+  workflow_dispatch:
+
+env:
+  FLUTTER_VERSION: "3.41.9"
+
+jobs:
+  build_windows_exe:
+    runs-on: windows-latest
+    environment: packaging
+
+    steps:
+      - name: Fix long file paths
+        run: git config --system core.longpaths true
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: "stable"
+
+      - name: Build MSIX helper
+        run: '& ''C:\Program Files (x86)\Windows Kits\10\App Certification Kit\makeappx.exe'' pack /o /d support\build\msix /nv /p app\windows\localsend_msix_helper.msix'
+
+      - name: Dependencies
+        working-directory: app
+        run: flutter pub get
+
+      - name: Compile for Windows
+        working-directory: app
+        run: flutter build windows
+
+      - name: Prepare Inno Setup payload
+        run: |
+          New-Item -ItemType Directory -Force -Path "${{ runner.temp }}\inno" | Out-Null
+          Copy-Item -Path "app\build\windows\x64\runner\Release\*" -Destination "${{ runner.temp }}\inno" -Recurse
+          Copy-Item -Path "app\assets\packaging\logo.ico" -Destination "${{ runner.temp }}\inno"
+          Copy-Item -Path "support\build\windows\x64\*" -Destination "${{ runner.temp }}\inno" -Recurse
+          New-Item -ItemType Directory -Force -Path "${{ runner.temp }}\inno-result" | Out-Null
+
+      - name: Compile installer (unsigned)
+        run: iscc /DSkipSignTool "/DPayloadDir=${{ runner.temp }}\inno" "/DResultDir=${{ runner.temp }}\inno-result" support\scripts\compile_windows_exe-inno.iss
+
+      - name: Upload unsigned installer
+        id: unsigned-installer
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-exe-unsigned
+          path: ${{ runner.temp }}\inno-result\localsend.exe
+          if-no-files-found: error
+
+      - name: Sign installer (SignPath)
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORG_ID }}
+          project-slug: localsend
+          signing-policy-slug: test-signing
+          artifact-configuration-slug: installer
+          github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed/installer
+
+      - name: Verify signature
+        continue-on-error: true
+        run: |
+          $signtool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin\10.*\x64\signtool.exe' | Select-Object -Last 1
+          & $signtool.FullName verify /pa /v signed\installer\localsend.exe
+
+      - name: Upload signed installer
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-exe-x86-64-result
+          path: signed/installer/localsend.exe


### PR DESCRIPTION
Add GitHub Actions workflow to build and release Windows .exe installer.  This runs during CI and uploads the artifact so that users can download a standalone installer without building locally.