### PR TITLE
android: companion-device bluetooth association

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,14 @@
          FOREGROUND_SERVICE and POST_NOTIFICATIONS come from the flutter_foreground_task manifest. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
+    <!-- CompanionDeviceManager: permanent background execution exemption via BT association -->
+    <uses-permission android:name="android.permission.REQUEST_COMPANION_RUN_IN_BACKGROUND" />
+    <uses-permission android:name="android.permission.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND" />
+    <uses-permission android:name="android.permission.REQUEST_COMPANION_START_FOREGROUND_SERVICES_FROM_BACKGROUND" />
+    <uses-permission android:name="android.permission.REQUEST_OBSERVE_COMPANION_DEVICE_PRESENCE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
+
     <!-- Android TV -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
@@ -92,6 +100,16 @@
             android:foregroundServiceType="dataSync"
             android:exported="false" />
 
+        <!-- CompanionDeviceManager: wakes the app when the associated BT device appears -->
+        <service
+            android:name=".LocalSendCompanionService"
+            android:exported="true"
+            android:permission="android.permission.BIND_COMPANION_DEVICE_SERVICE"
+            tools:targetApi="31">
+            <intent-filter>
+                <action android:name="android.companion.CompanionDeviceService" />
+            </intent-filter>
+        </service>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/CompanionBridge.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/CompanionBridge.kt
@@ -1,0 +1,186 @@
+package org.localsend.localsend_ng
+
+import android.app.Activity
+import android.companion.AssociationInfo
+import android.companion.AssociationRequest
+import android.companion.BluetoothDeviceFilter
+import android.companion.CompanionDeviceManager
+import android.content.Context
+import android.content.IntentSender
+import android.os.Build
+import android.util.Log
+import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.Executor
+
+private const val TAG = "CompanionBridge"
+private const val REQUEST_CODE_ASSOCIATE = 100
+
+class CompanionBridge(private val activity: Activity) {
+
+    private var pendingResult: MethodChannel.Result? = null
+
+    fun associate(result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            result.error("UNSUPPORTED", "CompanionDeviceManager requires Android 8+", null)
+            return
+        }
+
+        val cdm = activity.getSystemService(Context.COMPANION_DEVICE_SERVICE) as? CompanionDeviceManager
+        if (cdm == null) {
+            result.error("UNAVAILABLE", "CompanionDeviceManager service not available", null)
+            return
+        }
+
+        val filter = BluetoothDeviceFilter.Builder().build()
+        val request = AssociationRequest.Builder()
+            .addDeviceFilter(filter)
+            .setSingleDevice(false)
+            .build()
+
+        pendingResult = result
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val executor: Executor = activity.mainExecutor
+            cdm.associate(request, executor, object : CompanionDeviceManager.Callback() {
+                override fun onAssociationPending(intentSender: IntentSender) {
+                    try {
+                        activity.startIntentSenderForResult(
+                            intentSender, REQUEST_CODE_ASSOCIATE,
+                            null, 0, 0, 0
+                        )
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to launch association intent", e)
+                        pendingResult?.error("LAUNCH_FAILED", e.message, null)
+                        pendingResult = null
+                    }
+                }
+
+                override fun onAssociationCreated(associationInfo: AssociationInfo) {
+                    Log.i(TAG, "Association created: id=${associationInfo.id}")
+                    pendingResult?.success(mapOf(
+                        "id" to associationInfo.id,
+                        "deviceName" to (associationInfo.displayName?.toString() ?: "Unknown")
+                    ))
+                    pendingResult = null
+                }
+
+                override fun onFailure(error: CharSequence?) {
+                    Log.w(TAG, "Association failed: $error")
+                    pendingResult?.error("ASSOCIATION_FAILED", error?.toString() ?: "Unknown error", null)
+                    pendingResult = null
+                }
+            })
+        } else {
+            @Suppress("DEPRECATION")
+            cdm.associate(request, object : CompanionDeviceManager.Callback() {
+                @Deprecated("Deprecated in API 33")
+                override fun onDeviceFound(chooserLauncher: IntentSender) {
+                    try {
+                        activity.startIntentSenderForResult(
+                            chooserLauncher, REQUEST_CODE_ASSOCIATE,
+                            null, 0, 0, 0
+                        )
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to launch association intent", e)
+                        pendingResult?.error("LAUNCH_FAILED", e.message, null)
+                        pendingResult = null
+                    }
+                }
+
+                override fun onFailure(error: CharSequence?) {
+                    Log.w(TAG, "Association failed: $error")
+                    pendingResult?.error("ASSOCIATION_FAILED", error?.toString() ?: "Unknown error", null)
+                    pendingResult = null
+                }
+            }, null)
+        }
+    }
+
+    fun getAssociations(): List<Map<String, Any?>> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return emptyList()
+
+        val cdm = activity.getSystemService(Context.COMPANION_DEVICE_SERVICE) as? CompanionDeviceManager
+            ?: return emptyList()
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            cdm.myAssociations.map { info ->
+                mapOf(
+                    "id" to info.id,
+                    "deviceName" to (info.displayName?.toString() ?: "Unknown"),
+                    "deviceAddress" to (info.deviceMacAddress?.toString() ?: "")
+                )
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            cdm.associations.mapIndexed { index, address ->
+                mapOf(
+                    "id" to index,
+                    "deviceName" to address,
+                    "deviceAddress" to address
+                )
+            }
+        }
+    }
+
+    fun disassociate(id: Int, result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            result.error("UNSUPPORTED", "Disassociate by ID requires Android 13+", null)
+            return
+        }
+
+        val cdm = activity.getSystemService(Context.COMPANION_DEVICE_SERVICE) as? CompanionDeviceManager
+        if (cdm == null) {
+            result.error("UNAVAILABLE", "CompanionDeviceManager service not available", null)
+            return
+        }
+
+        try {
+            cdm.disassociate(id)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("DISASSOCIATE_FAILED", e.message, null)
+        }
+    }
+
+    fun startObservingDevicePresence(result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            result.error("UNSUPPORTED", "Device presence observing requires Android 12+", null)
+            return
+        }
+
+        val cdm = activity.getSystemService(Context.COMPANION_DEVICE_SERVICE) as? CompanionDeviceManager
+        if (cdm == null) {
+            result.error("UNAVAILABLE", "CompanionDeviceManager service not available", null)
+            return
+        }
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                for (association in cdm.myAssociations) {
+                    cdm.startObservingDevicePresence(association.deviceMacAddress?.toString() ?: continue)
+                }
+            } else {
+                @Suppress("DEPRECATION")
+                for (address in cdm.associations) {
+                    cdm.startObservingDevicePresence(address)
+                }
+            }
+            result.success(null)
+        } catch (e: Exception) {
+            Log.w(TAG, "startObservingDevicePresence failed", e)
+            result.error("OBSERVE_FAILED", e.message, null)
+        }
+    }
+
+    fun onActivityResult(requestCode: Int, resultCode: Int): Boolean {
+        if (requestCode != REQUEST_CODE_ASSOCIATE) return false
+
+        if (resultCode == Activity.RESULT_OK) {
+            pendingResult?.success(mapOf("id" to -1, "deviceName" to "Associated"))
+        } else {
+            pendingResult?.error("CANCELED", "User canceled association", null)
+        }
+        pendingResult = null
+        return true
+    }
+}

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/LocalSendCompanionService.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/LocalSendCompanionService.kt
@@ -1,0 +1,55 @@
+package org.localsend.localsend_ng
+
+import android.companion.AssociationInfo
+import android.companion.CompanionDeviceService
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.S)
+class LocalSendCompanionService : CompanionDeviceService() {
+
+    // API 33+ delivers the full AssociationInfo; API 31/32 only the MAC address,
+    // so both overloads are implemented. Overriding the AssociationInfo variant
+    // means the platform's default fan-out to the String one never fires on 33+.
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    override fun onDeviceAppeared(associationInfo: AssociationInfo) {
+        Log.i(TAG, "Companion device appeared (associationId=${associationInfo.id})")
+        startMainActivityInBackground()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    override fun onDeviceDisappeared(associationInfo: AssociationInfo) {
+        Log.i(TAG, "Companion device disappeared (associationId=${associationInfo.id})")
+    }
+
+    @Deprecated("Only called on API 31/32; API 33+ uses the AssociationInfo overload.")
+    override fun onDeviceAppeared(address: String) {
+        Log.i(TAG, "Companion device appeared ($address)")
+        startMainActivityInBackground()
+    }
+
+    @Deprecated("Only called on API 31/32; API 33+ uses the AssociationInfo overload.")
+    override fun onDeviceDisappeared(address: String) {
+        Log.i(TAG, "Companion device disappeared ($address)")
+    }
+
+    private fun startMainActivityInBackground() {
+        try {
+            val launchIntent = MainActivity.createDefaultIntent(this).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
+                        Intent.FLAG_ACTIVITY_NO_ANIMATION
+                putExtra(EXTRA_BACKGROUND_START, true)
+            }
+            startActivity(launchIntent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not start activity from companion service", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "LocalSendCompanion"
+    }
+}

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -23,6 +23,7 @@ private const val REQUEST_CODE_PICK_FILE = 3
 
 class MainActivity : FlutterActivity() {
     private var pendingResult: MethodChannel.Result? = null
+    private lateinit var companionBridge: CompanionBridge
 
     // Overriding the static methods we need from the Java class, as described
     // in the documentation of `FlutterActivity.NewEngineIntentBuilder`
@@ -34,6 +35,11 @@ class MainActivity : FlutterActivity() {
         fun createDefaultIntent(launchContext: Context): Intent {
             return withNewEngine().build(launchContext)
         }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        companionBridge = CompanionBridge(this)
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -83,6 +89,17 @@ class MainActivity : FlutterActivity() {
                 "getDownloadsDirectory" -> {
                     result.success(getDownloadsDirectory())
                 }
+
+                "companion_associate" -> companionBridge.associate(result)
+
+                "companion_getAssociations" -> result.success(companionBridge.getAssociations())
+
+                "companion_disassociate" -> {
+                    val id = call.argument<Int>("id") ?: 0
+                    companionBridge.disassociate(id, result)
+                }
+
+                "companion_startObserving" -> companionBridge.startObservingDevicePresence(result)
 
                 else -> result.notImplemented()
             }
@@ -255,6 +272,7 @@ class MainActivity : FlutterActivity() {
     @Override
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
+        if (companionBridge.onActivityResult(requestCode, resultCode)) return
         if (resultCode == Activity.RESULT_CANCELED) {
             pendingResult?.error("CANCELED", "Canceled", null)
             pendingResult = null

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -29,6 +29,7 @@ import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/util/i18n.dart';
 import 'package:localsend_app/util/native/autostart_helper.dart';
 import 'package:localsend_app/util/native/cache_helper.dart';
+import 'package:localsend_app/util/native/channel/companion_device_channel.dart';
 import 'package:localsend_app/util/native/context_menu_helper.dart';
 import 'package:localsend_app/util/native/cross_file_converters.dart';
 import 'package:localsend_app/util/native/device_info_helper.dart';
@@ -206,6 +207,11 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
     _logger.warning('Starting discovery listener failed', e);
   }
 
+  if (checkPlatform([TargetPlatform.android])) {
+    // Re-arm device-presence observing for already-associated companion devices.
+    // No-op when the user has never paired one.
+    await companionStartObserving();
+  }
   // ignore: dead_code
   if (webRTCEnabled) {
     ref.redux(signalingProvider).dispatch(SetupSignalingConnection());

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -16,6 +16,7 @@ import 'package:localsend_app/provider/version_provider.dart';
 import 'package:localsend_app/util/alias_generator.dart';
 import 'package:localsend_app/util/device_type_ext.dart';
 import 'package:localsend_app/util/i18n.dart';
+import 'package:localsend_app/util/native/channel/companion_device_channel.dart';
 import 'package:localsend_app/util/native/macos_channel.dart';
 import 'package:localsend_app/util/native/pick_directory_path.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
@@ -515,6 +516,7 @@ class SettingsTab extends StatelessWidget {
                     ),
                   ),
                 ),
+                if (checkPlatform([TargetPlatform.android]) && vm.advanced) const _CompanionDeviceEntry(),
               ],
             ),
             _SettingsSection(
@@ -770,5 +772,105 @@ extension on ColorMode {
       ColorMode.yaru => 'Yaru',
       ColorMode.custom => t.settingsTab.general.colorOptions.custom,
     };
+  }
+}
+
+class _CompanionDeviceEntry extends StatefulWidget {
+  const _CompanionDeviceEntry();
+
+  @override
+  State<_CompanionDeviceEntry> createState() => _CompanionDeviceEntryState();
+}
+
+class _CompanionDeviceEntryState extends State<_CompanionDeviceEntry> {
+  List<CompanionAssociation> _associations = [];
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAssociations(); // ignore: discarded_futures
+  }
+
+  Future<void> _loadAssociations() async {
+    final list = await companionGetAssociations();
+    if (mounted) setState(() => _associations = list);
+  }
+
+  Future<void> _associate() async {
+    setState(() => _loading = true);
+    final result = await companionAssociate();
+    if (result != null) {
+      await companionStartObserving();
+      await _loadAssociations();
+    }
+    if (mounted) setState(() => _loading = false);
+  }
+
+  Future<void> _disassociate(int id) async {
+    await companionDisassociate(id);
+    await _loadAssociations();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 15),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(child: Text('Bluetooth Companion')),
+              const SizedBox(width: 10),
+              SizedBox(
+                width: 150,
+                child: TextButton(
+                  style: TextButton.styleFrom(
+                    backgroundColor: Theme.of(context).inputDecorationTheme.fillColor,
+                    shape: RoundedRectangleBorder(borderRadius: Theme.of(context).inputDecorationTheme.borderRadius),
+                    foregroundColor: Theme.of(context).colorScheme.onSurface,
+                  ),
+                  onPressed: _loading ? null : _associate,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 5),
+                    child: _loading
+                        ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                        : Text('Pair Device', style: Theme.of(context).textTheme.titleMedium, textAlign: TextAlign.center),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (_associations.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            ...List.generate(_associations.length, (i) {
+              final a = _associations[i];
+              return Padding(
+                padding: const EdgeInsets.only(left: 8, bottom: 4),
+                child: Row(
+                  children: [
+                    const Icon(Icons.bluetooth_connected, size: 16),
+                    const SizedBox(width: 8),
+                    Expanded(child: Text(a.deviceName, style: Theme.of(context).textTheme.bodySmall)),
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline, size: 18),
+                      onPressed: () => _disassociate(a.id),
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ],
+          const SizedBox(height: 4),
+          Text(
+            'Grants permanent background execution for receiving files.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/app/lib/util/native/channel/companion_device_channel.dart
+++ b/app/lib/util/native/channel/companion_device_channel.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
+
+const _methodChannel = MethodChannel('org.localsend.localsend_ng/localsend');
+final _logger = Logger('CompanionDevice');
+
+class CompanionAssociation {
+  final int id;
+  final String deviceName;
+  final String deviceAddress;
+
+  CompanionAssociation({required this.id, required this.deviceName, required this.deviceAddress});
+}
+
+Future<CompanionAssociation?> companionAssociate() async {
+  if (defaultTargetPlatform != TargetPlatform.android) return null;
+  try {
+    final result = await _methodChannel.invokeMethod<Map>('companion_associate');
+    if (result == null) return null;
+    return CompanionAssociation(
+      id: result['id'] as int? ?? -1,
+      deviceName: result['deviceName'] as String? ?? 'Unknown',
+      deviceAddress: '',
+    );
+  } on PlatformException catch (e) {
+    _logger.warning('companion_associate failed: ${e.message}');
+    return null;
+  }
+}
+
+Future<List<CompanionAssociation>> companionGetAssociations() async {
+  if (defaultTargetPlatform != TargetPlatform.android) return [];
+  try {
+    final result = await _methodChannel.invokeMethod<List>('companion_getAssociations');
+    if (result == null) return [];
+    return result.map((item) {
+      final map = item as Map;
+      return CompanionAssociation(
+        id: map['id'] as int? ?? -1,
+        deviceName: map['deviceName'] as String? ?? 'Unknown',
+        deviceAddress: map['deviceAddress'] as String? ?? '',
+      );
+    }).toList();
+  } on PlatformException catch (e) {
+    _logger.warning('companion_getAssociations failed: ${e.message}');
+    return [];
+  }
+}
+
+Future<bool> companionDisassociate(int id) async {
+  if (defaultTargetPlatform != TargetPlatform.android) return false;
+  try {
+    await _methodChannel.invokeMethod('companion_disassociate', {'id': id});
+    return true;
+  } on PlatformException catch (e) {
+    _logger.warning('companion_disassociate failed: ${e.message}');
+    return false;
+  }
+}
+
+Future<bool> companionStartObserving() async {
+  if (defaultTargetPlatform != TargetPlatform.android) return false;
+  try {
+    await _methodChannel.invokeMethod('companion_startObserving');
+    return true;
+  } on PlatformException catch (e) {
+    _logger.warning('companion_startObserving failed: ${e.message}');
+    return false;
+  }
+}


### PR DESCRIPTION
Use CompanionDeviceManager to observe associated Bluetooth devices and wake the app when a paired device is nearby.  Adds CompanionBridge, LocalSendCompanionService, companion permissions, and a settings UI entry for pairing.\n\nThis eliminates the need for constant BLE scanning — the OS handles proximity detection and starts the app only when a trusted device is present.