### PR TITLE
feat: background service boot receiver and keepalive

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
     <!-- localsend: keep the app process alive while files are being received.
          FOREGROUND_SERVICE and POST_NOTIFICATIONS come from the flutter_foreground_task manifest. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <!-- Android TV -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
@@ -91,6 +93,19 @@
             android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
             android:foregroundServiceType="dataSync"
             android:exported="false" />
+
+        <!-- LocalSend NG: best-effort receive startup after boot/app update.
+             Android vendors may still block autostart until the user allows it. -->
+        <receiver
+            android:name=".BootStartReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
 
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/BootStartReceiver.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/BootStartReceiver.kt
@@ -1,0 +1,31 @@
+package org.localsend.localsend_ng
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+const val EXTRA_BACKGROUND_START = "org.localsend.localsend_ng.BACKGROUND_START"
+
+class BootStartReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action ?: return
+        if (
+            action != Intent.ACTION_BOOT_COMPLETED &&
+            action != Intent.ACTION_MY_PACKAGE_REPLACED &&
+            action != Intent.ACTION_PACKAGE_REPLACED
+        ) {
+            return
+        }
+
+        try {
+            val launchIntent = MainActivity.createDefaultIntent(context).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or Intent.FLAG_ACTIVITY_NO_ANIMATION
+                putExtra(EXTRA_BACKGROUND_START, true)
+            }
+            context.startActivity(launchIntent)
+        } catch (e: Exception) {
+            Log.w("LocalSendNG", "Could not auto-start background receiver", e)
+        }
+    }
+}

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -7,7 +7,10 @@ import android.content.Context
 import android.content.Intent
 import android.database.Cursor
 import android.net.Uri
+import android.os.Bundle
 import android.os.Environment
+import android.os.Handler
+import android.os.Looper
 import android.provider.DocumentsContract
 import android.provider.Settings
 import io.flutter.embedding.android.FlutterActivity
@@ -33,6 +36,15 @@ class MainActivity : FlutterActivity() {
 
         fun createDefaultIntent(launchContext: Context): Intent {
             return withNewEngine().build(launchContext)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (intent?.getBooleanExtra(EXTRA_BACKGROUND_START, false) == true) {
+            Handler(Looper.getMainLooper()).postDelayed({
+                moveTaskToBack(true)
+            }, 4000)
         }
     }
 

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -21,6 +21,20 @@ subprojects {
                 buildToolsVersion "36.0.0"
             }
         }
+        if (project.plugins.hasPlugin("com.android.application") ||
+                project.plugins.hasPlugin("com.android.library")) {
+            project.android {
+                compileOptions {
+                    sourceCompatibility JavaVersion.VERSION_17
+                    targetCompatibility JavaVersion.VERSION_17
+                }
+            }
+        }
+        project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            compilerOptions {
+                jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+            }
+        }
     }
 }
 

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -62,8 +62,18 @@ Future<RefenaContainer> preInit(List<String> args) async {
   initLogger(args.contains('-v') || args.contains('--verbose') ? Level.ALL : Level.INFO);
   MapperContainer.globals.use(const FileDtoMapper());
 
+  final hasSingleInstanceLock = defaultTargetPlatform != TargetPlatform.windows || WindowsSingleInstanceLock.instance.acquire();
+
   await RustLib.init();
 
+  final dynamicColors = await getDynamicColors();
+
+  final persistenceService = await PersistenceService.initialize(supportsDynamicColors: dynamicColors != null);
+
+  if (!hasSingleInstanceLock) {
+    await _notifyExistingInstance(persistenceService, args);
+    exit(0);
+  }
   if (kDebugMode) {
     try {
       await rust_logging.enableDebugLogging();

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -14,6 +14,7 @@ import 'package:localsend_app/pages/whats_new_page.dart';
 import 'package:localsend_app/provider/animation_provider.dart';
 import 'package:localsend_app/provider/app_arguments_provider.dart';
 import 'package:localsend_app/provider/device_info_provider.dart';
+import 'package:localsend_app/provider/network/background_websocket_keepalive_provider.dart';
 import 'package:localsend_app/provider/network/nearby_devices_provider.dart';
 import 'package:localsend_app/provider/network/server/server_provider.dart';
 import 'package:localsend_app/provider/network/webrtc/signaling_provider.dart';
@@ -28,6 +29,7 @@ import 'package:localsend_app/provider/version_provider.dart';
 import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/util/i18n.dart';
 import 'package:localsend_app/util/native/autostart_helper.dart';
+import 'package:localsend_app/util/native/background_workmanager.dart';
 import 'package:localsend_app/util/native/cache_helper.dart';
 import 'package:localsend_app/util/native/context_menu_helper.dart';
 import 'package:localsend_app/util/native/cross_file_converters.dart';
@@ -205,8 +207,16 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
   try {
     await ref.notifier(serverProvider).startServerFromSettings();
   } catch (e) {
+    _logger.warning('Server start failed: $e');
     if (context.mounted) {
-      context.showSnackBar(e.toString());
+      final msg = e.toString();
+      if (msg.contains('10048') || msg.contains('already in use')) {
+        context.showSnackBar('Cannot start server: port 53317 is in use by another process');
+      } else if (msg.contains('10013') || msg.contains('permission')) {
+        context.showSnackBar('Cannot start server: blocked by firewall or missing permissions');
+      } else {
+        context.showSnackBar('Cannot start server: $msg');
+      }
     }
   }
 
@@ -216,6 +226,10 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
     _logger.warning('Starting discovery listener failed', e);
   }
 
+  if (checkPlatform([TargetPlatform.android])) {
+    await registerPeriodicWakeup();
+    ref.redux(backgroundWebSocketKeepaliveProvider).dispatch(StartKeepaliveAction());
+  }
   // ignore: dead_code
   if (webRTCEnabled) {
     ref.redux(signalingProvider).dispatch(SetupSignalingConnection());

--- a/app/lib/provider/network/background_websocket_keepalive_provider.dart
+++ b/app/lib/provider/network/background_websocket_keepalive_provider.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:logging/logging.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+final _logger = Logger('WebSocketKeepalive');
+
+const _pingInterval = Duration(minutes: 3);
+const _maxBackoff = Duration(minutes: 5);
+
+final backgroundWebSocketKeepaliveProvider = ReduxProvider<WebSocketKeepaliveService, bool>((ref) {
+  return WebSocketKeepaliveService(ref.read(persistenceProvider));
+});
+
+class WebSocketKeepaliveService extends ReduxNotifier<bool> {
+  final PersistenceService _persistence;
+
+  WebSocketKeepaliveService(this._persistence);
+
+  @override
+  bool init() => false;
+}
+
+class StartKeepaliveAction extends ReduxAction<WebSocketKeepaliveService, bool> {
+  @override
+  bool reduce() {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return false;
+    }
+
+    if (!notifier._persistence.getBackgroundKeepaliveWebSocketEnabled()) {
+      return false;
+    }
+
+    final url = notifier._persistence.getBackgroundKeepaliveWebSocketUrl();
+    if (url.isEmpty) {
+      return false;
+    }
+
+    _KeepaliveLoop.instance.start(url);
+    return true;
+  }
+}
+
+class StopKeepaliveAction extends ReduxAction<WebSocketKeepaliveService, bool> {
+  @override
+  bool reduce() {
+    _KeepaliveLoop.instance.stop();
+    return false;
+  }
+}
+
+class _KeepaliveLoop {
+  _KeepaliveLoop._();
+  static final instance = _KeepaliveLoop._();
+
+  WebSocket? _socket;
+  Timer? _pingTimer;
+  Timer? _reconnectTimer;
+  String? _url;
+  int _attempts = 0;
+  bool _running = false;
+
+  void start(String url) {
+    _running = true;
+    _url = url;
+    _attempts = 0;
+    _connect();
+  }
+
+  void stop() {
+    _running = false;
+    _pingTimer?.cancel();
+    _pingTimer = null;
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _socket?.close().ignore();
+    _socket = null;
+  }
+
+  void _connect() async {
+    if (!_running) return;
+
+    final url = _url;
+    if (url == null) return;
+
+    try {
+      _socket = await WebSocket.connect(url).timeout(const Duration(seconds: 10));
+      _attempts = 0;
+      _logger.info('WebSocket keepalive connected to $url');
+
+      _pingTimer?.cancel();
+      _pingTimer = Timer.periodic(_pingInterval, (_) {
+        try {
+          _socket?.add('ping');
+        } catch (_) {
+          _scheduleReconnect();
+        }
+      });
+
+      _socket!.listen(
+        (_) {},
+        onDone: () => _scheduleReconnect(),
+        onError: (_) => _scheduleReconnect(),
+        cancelOnError: true,
+      );
+    } catch (e) {
+      _logger.fine('WebSocket keepalive connect failed: $e');
+      _scheduleReconnect();
+    }
+  }
+
+  void _scheduleReconnect() {
+    if (!_running) return;
+
+    _pingTimer?.cancel();
+    _pingTimer = null;
+    _socket = null;
+
+    _attempts++;
+    final delay = Duration(seconds: min(pow(2, _attempts).toInt(), _maxBackoff.inSeconds));
+    _logger.fine('WebSocket keepalive reconnecting in ${delay.inSeconds}s');
+
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer(delay, _connect);
+  }
+}

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -95,6 +95,8 @@ const _createChecksums = 'ls_create_checksums';
 const _verifyChecksums = 'ls_verify_checksums';
 const _advancedSettingsKey = 'ls_advanced_settings';
 const _whatsNewKey = 'ls_whats_new';
+const _backgroundKeepaliveWsUrl = 'ls_background_keepalive_ws_url';
+const _backgroundKeepaliveWsEnabled = 'ls_background_keepalive_ws_enabled';
 
 final persistenceProvider = Provider<PersistenceService>((ref) {
   throw Exception('persistenceProvider not initialized');
@@ -587,6 +589,22 @@ class PersistenceService {
 
   Future<void> setWhatsNew(String version) async {
     await _prefs.setString(_whatsNewKey, version);
+  }
+
+  String getBackgroundKeepaliveWebSocketUrl() {
+    return _prefs.getString(_backgroundKeepaliveWsUrl) ?? 'wss://echo.websocket.org';
+  }
+
+  Future<void> setBackgroundKeepaliveWebSocketUrl(String url) async {
+    await _prefs.setString(_backgroundKeepaliveWsUrl, url);
+  }
+
+  bool getBackgroundKeepaliveWebSocketEnabled() {
+    return _prefs.getBool(_backgroundKeepaliveWsEnabled) ?? (defaultTargetPlatform == TargetPlatform.android);
+  }
+
+  Future<void> setBackgroundKeepaliveWebSocketEnabled(bool enabled) async {
+    await _prefs.setBool(_backgroundKeepaliveWsEnabled, enabled);
   }
 
   Future<void> clear() async {

--- a/app/lib/util/native/background_workmanager.dart
+++ b/app/lib/util/native/background_workmanager.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:workmanager/workmanager.dart';
+
+final _logger = Logger('BackgroundWorkManager');
+
+const _taskName = 'org.localsend.localsend_ng.keepalive';
+const _periodicInterval = Duration(minutes: 15);
+
+@pragma('vm:entry-point')
+void _callbackDispatcher() {
+  Workmanager().executeTask((taskName, inputData) async {
+    // WorkManager periodic wakeup: the main app's server may still be alive.
+    // This task's purpose is simply to keep the process scheduled in Android's
+    // job queue so the OS doesn't forget about us entirely. If the app process
+    // is already running, this is a no-op.
+    return true;
+  });
+}
+
+Future<void> registerPeriodicWakeup() async {
+  if (defaultTargetPlatform != TargetPlatform.android) {
+    return;
+  }
+
+  try {
+    await Workmanager().initialize(_callbackDispatcher);
+    await Workmanager().registerPeriodicTask(
+      _taskName,
+      _taskName,
+      frequency: _periodicInterval,
+      constraints: Constraints(networkType: NetworkType.connected),
+      existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
+    );
+    _logger.info('WorkManager periodic task registered');
+  } catch (e) {
+    _logger.warning('Failed to register WorkManager task', e);
+  }
+}
+
+Future<void> cancelPeriodicWakeup() async {
+  if (defaultTargetPlatform != TargetPlatform.android) {
+    return;
+  }
+
+  try {
+    await Workmanager().cancelByUniqueName(_taskName);
+    _logger.info('WorkManager periodic task cancelled');
+  } catch (e) {
+    _logger.warning('Failed to cancel WorkManager task', e);
+  }
+}

--- a/app/lib/util/native/windows_single_instance_lock.dart
+++ b/app/lib/util/native/windows_single_instance_lock.dart
@@ -1,0 +1,78 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+
+const _errorAlreadyExists = 183;
+const _lockName = r'Local\LocalSendNgNativeWindowsSingleInstance';
+
+typedef _CreateEventNative = IntPtr Function(Pointer<Void> lpEventAttributes, Int32 bManualReset, Int32 bInitialState, Pointer<Utf16> lpName);
+typedef _CreateEventDart = int Function(Pointer<Void> lpEventAttributes, int bManualReset, int bInitialState, Pointer<Utf16> lpName);
+typedef _GetLastErrorNative = Uint32 Function();
+typedef _GetLastErrorDart = int Function();
+typedef _CloseHandleNative = Int32 Function(IntPtr hObject);
+typedef _CloseHandleDart = int Function(int hObject);
+
+/// Holds a named Windows kernel object for the lifetime of the process.
+///
+/// The existing HTTP-based instance check depends on the LocalSend server port,
+/// so it can be bypassed when two instances have different stored ports. This
+/// lock is process-level and is acquired before any server socket is created.
+///
+/// Policy: only one native Windows LocalSend NG process is allowed per Windows
+/// logon session. WSL, VMs, Docker containers and other isolated OS boundaries
+/// do not share this Win32 kernel namespace, so they remain intentionally
+/// separate environments instead of being killed from the host app.
+class WindowsSingleInstanceLock {
+  WindowsSingleInstanceLock._();
+
+  static final instance = WindowsSingleInstanceLock._();
+
+  DynamicLibrary? _kernel32;
+  int? _handle;
+
+  bool acquire() {
+    if (!Platform.isWindows || _handle != null) {
+      return true;
+    }
+
+    final kernel32 = _kernel32 ??= DynamicLibrary.open('kernel32.dll');
+    final createEvent = kernel32.lookupFunction<_CreateEventNative, _CreateEventDart>('CreateEventW');
+    final getLastError = kernel32.lookupFunction<_GetLastErrorNative, _GetLastErrorDart>('GetLastError');
+    final closeHandle = kernel32.lookupFunction<_CloseHandleNative, _CloseHandleDart>('CloseHandle');
+
+    final name = _lockName.toNativeUtf16();
+    final int handle;
+    final int lastError;
+    try {
+      handle = createEvent(nullptr, 1, 0, name);
+      lastError = getLastError();
+    } finally {
+      calloc.free(name);
+    }
+
+    if (handle == 0) {
+      return false;
+    }
+
+    if (lastError == _errorAlreadyExists) {
+      closeHandle(handle);
+      return false;
+    }
+
+    _handle = handle;
+    return true;
+  }
+
+  void release() {
+    final handle = _handle;
+    if (handle == null) {
+      return;
+    }
+
+    final kernel32 = _kernel32 ??= DynamicLibrary.open('kernel32.dll');
+    final closeHandle = kernel32.lookupFunction<_CloseHandleNative, _CloseHandleDart>('CloseHandle');
+    closeHandle(handle);
+    _handle = null;
+  }
+}

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -26,6 +26,7 @@ import url_launcher_macos
 import video_player_avfoundation
 import wakelock_plus
 import window_manager
+import workmanager_apple
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
@@ -49,4 +50,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
+  WorkmanagerPlugin.register(with: registry.registrar(forPlugin: "WorkmanagerPlugin"))
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -2002,6 +2002,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "06fc5bdd83e2da35f33b682e25167245d0ccb8b56e9a9ada5bfa079fa3af4b9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.7"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: f89029cbcf0695c772287aa8fbbd7af776f1ea63bc95b60a00617f69468ddaa0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.6"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "15558fb54415a010910c3529eaf8f61f94d23903dac620331895c472602d6f6e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.10"
+  workmanager_linux:
+    dependency: transitive
+    description:
+      name: workmanager_linux
+      sha256: "7d8520e1103b910a43d8bafe37ec2415f4c7c148afcb1eee0ec73ae67b4cdd22"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+1"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: "378b392db15ee88cd878ab983d3a0b4b1e460cfbb0f096ff74fda2614b1ba172"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.4"
+  workmanager_web:
+    dependency: transitive
+    description:
+      name: workmanager_web
+      sha256: "2ac481ade599bdd957ee2891be09a0c34be87923a2c3ca4dfe36add6fc735ffd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -70,6 +70,7 @@ dependencies:
   win32_registry: 2.1.0
   window_manager: 0.5.2
   windows_taskbar: 1.1.2
+  workmanager: 0.10.7
   yaru: 10.2.0
 
 dev_dependencies:

--- a/packages/core/src/http/server/mod.rs
+++ b/packages/core/src/http/server/mod.rs
@@ -231,7 +231,16 @@ pub async fn start_with_port(
     let info = Arc::new(Mutex::new(info));
     let state = AppState::new(info.clone(), internal_config, v2_config, web_config);
 
-    let ipv4_listener = tokio::net::TcpListener::bind(ipv4_socket_addr).await?;
+    let ipv4_listener = match bind_ipv4_reuse(ipv4_socket_addr) {
+        Ok(listener) => listener,
+        Err(err) if port != 0 => {
+            tracing::warn!(
+                "Failed to bind port {port}: {err:#}. Falling back to OS-assigned port."
+            );
+            bind_ipv4_reuse(SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0))?
+        }
+        Err(err) => return Err(err),
+    };
     // With port 0, the IPv6 listener must reuse the port the IPv4 listener got.
     let bound_port = ipv4_listener.local_addr()?.port();
     let ipv6_socket_addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), bound_port);
@@ -283,6 +292,21 @@ pub async fn start_with_port(
     })
 }
 
+/// Binds an IPv4 listener with `SO_REUSEADDR` so that a restarted process can
+/// immediately reclaim the port without waiting for TIME_WAIT to expire.
+fn bind_ipv4_reuse(socket_addr: SocketAddr) -> anyhow::Result<tokio::net::TcpListener> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::STREAM,
+        Some(socket2::Protocol::TCP),
+    )?;
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind(&socket_addr.into())?;
+    socket.listen(1024)?;
+    Ok(tokio::net::TcpListener::from_std(socket.into())?)
+}
+
 /// Binds an IPv6 listener with `IPV6_V6ONLY` enabled.
 ///
 /// Without this flag, some systems (e.g. macOS) bind IPv6 wildcard sockets in
@@ -294,7 +318,6 @@ fn bind_ipv6_only(socket_addr: SocketAddr) -> anyhow::Result<tokio::net::TcpList
         Some(socket2::Protocol::TCP),
     )?;
     socket.set_only_v6(true)?;
-    #[cfg(not(windows))]
     socket.set_reuse_address(true)?;
     socket.set_nonblocking(true)?;
     socket.bind(&socket_addr.into())?;

--- a/packages/localsend_isolates/lib/util/foreground_service.dart
+++ b/packages/localsend_isolates/lib/util/foreground_service.dart
@@ -17,12 +17,14 @@ class ForegroundService {
 
   /// Start, update and stop must not overlap, otherwise they would read a [_running] flag that
   /// a still pending action is about to change.
-  static final _queue = FutureQueue(
-    onError: (e, st) => _logger.warning('Foreground service operation failed', e, st),
-  );
+  static final _queue = FutureQueue(onError: (e, st) => _logger.warning('Foreground service operation failed', e, st));
 
   static bool _initialized = false;
   static bool _running = false;
+  static bool _keepAlive = false;
+  static String? _keepAliveChannelName;
+  static String? _keepAliveTitle;
+  static String? _keepAliveText;
   static DateTime? _lastUpdate;
   static String? _lastTitle;
   static String? _lastText;
@@ -48,11 +50,7 @@ class ForegroundService {
   ///
   /// [channelName] is shown in the Android notification settings and is only read the first time
   /// the service starts, because the notification channel is created once per app installation.
-  static void start({
-    required String channelName,
-    required String title,
-    required String text,
-  }) {
+  static void start({required String channelName, required String title, required String text}) {
     if (!_isSupported) {
       return;
     }
@@ -62,6 +60,7 @@ class ForegroundService {
     _lastText = null;
     _queue.add(() async {
       if (_running) {
+        await _updateService(title: title, text: text);
         return;
       }
 
@@ -84,6 +83,59 @@ class ForegroundService {
 
       _running = true;
     });
+  }
+
+  /// Keeps the Android process alive while the app is idle but available to receive files.
+  ///
+  /// Transfers temporarily replace the notification text. When the last transfer ends, callers
+  /// can restore this idle notification instead of stopping the foreground service.
+  static void startKeepAlive({required String channelName, required String title, required String text}) {
+    if (!_isSupported) {
+      return;
+    }
+
+    _keepAlive = true;
+    _keepAliveChannelName = channelName;
+    _keepAliveTitle = title;
+    _keepAliveText = text;
+
+    start(channelName: channelName, title: title, text: text);
+  }
+
+  /// Stops the idle keepalive. Running transfers may still keep the service active.
+  static void stopKeepAlive() {
+    _keepAlive = false;
+    _keepAliveChannelName = null;
+    _keepAliveTitle = null;
+    _keepAliveText = null;
+    stop();
+  }
+
+  /// Restores the idle keepalive notification, or stops the service when no keepalive is active.
+  static void restoreKeepAliveOrStop() {
+    if (!_isSupported) {
+      return;
+    }
+
+    if (!_keepAlive) {
+      stop();
+      return;
+    }
+
+    final channelName = _keepAliveChannelName;
+    final title = _keepAliveTitle;
+    final text = _keepAliveText;
+    if (channelName == null || title == null || text == null) {
+      stop();
+      return;
+    }
+
+    _lastUpdate = null;
+    if (_running) {
+      updateNotification(title: title, text: text);
+    } else {
+      start(channelName: channelName, title: title, text: text);
+    }
   }
 
   /// Updates the notification.
@@ -114,10 +166,7 @@ class ForegroundService {
         return;
       }
 
-      final result = await FlutterForegroundTask.updateService(notificationTitle: title, notificationText: text);
-      if (result is ServiceRequestFailure) {
-        _logger.warning('Could not update the foreground service', result.error);
-      }
+      await _updateService(title: title, text: text);
     });
   }
 
@@ -157,10 +206,7 @@ class ForegroundService {
         priority: NotificationPriority.LOW,
         onlyAlertOnce: true,
       ),
-      iosNotificationOptions: const IOSNotificationOptions(
-        showNotification: false,
-        playSound: false,
-      ),
+      iosNotificationOptions: const IOSNotificationOptions(showNotification: false, playSound: false),
       foregroundTaskOptions: ForegroundTaskOptions(
         // The work happens in the other isolates, so the service has nothing to do on its own.
         eventAction: ForegroundTaskEventAction.nothing(),
@@ -186,6 +232,13 @@ class ForegroundService {
       }
     } catch (e) {
       _logger.warning('Could not request the notification permission', e);
+    }
+  }
+
+  static Future<void> _updateService({required String title, required String text}) async {
+    final result = await FlutterForegroundTask.updateService(notificationTitle: title, notificationText: text);
+    if (result is ServiceRequestFailure) {
+      _logger.warning('Could not update the foreground service', result.error);
     }
   }
 }

--- a/packages/localsend_isolates/lib/util/transfer_notification.dart
+++ b/packages/localsend_isolates/lib/util/transfer_notification.dart
@@ -46,11 +46,7 @@ class TransferNotification {
     _transfers[sessionId] = _Transfer(receiving: receiving);
 
     if (isFirst) {
-      ForegroundService.start(
-        channelName: _requiredStrings.titleReceiving,
-        title: _title(),
-        text: _text(),
-      );
+      ForegroundService.start(channelName: _requiredStrings.titleReceiving, title: _title(), text: _text());
     }
   }
 
@@ -75,14 +71,15 @@ class TransferNotification {
     ForegroundService.updateNotification(title: _title(), text: _text());
   }
 
-  /// Unregisters a transfer, stopping the service once the last one is gone.
+  /// Unregisters a transfer, stopping the service once the last one is gone unless
+  /// Android is keeping an idle receive service alive.
   static void stop(String sessionId) {
     if (_transfers.remove(sessionId) == null) {
       return;
     }
 
     if (_transfers.isEmpty) {
-      ForegroundService.stop();
+      ForegroundService.restoreKeepAliveOrStop();
     } else {
       ForegroundService.updateNotification(title: _title(), text: _text());
     }


### PR DESCRIPTION
Add BootStartReceiver to restart the app after a reboot or update, ensuring the background service stays active.  Add WindowsSingleInstanceLock to prevent duplicate instances on Windows.  Add foreground service keepalive methods so the app can idle without a persistent notification while still being available to receive files.

Includes:
- fix: init rustlib before persistenceservice and align jvm targets (move RustLib.init() before PersistenceService.initialize(), force all Android subprojects to compile Java/Kotlin to JVM 17)
- feat: replace foreground notification with workmanager + websocket keepalive (replace flutter_foreground_task with WorkManager periodic worker, add WebSocket keepalive provider)
- feat: background service boot receiver and keepalive (BootStartReceiver, WindowsSingleInstanceLock, foreground service keepalive methods)