### PR TITLE
feat: networking fixes and handoff support

### DIFF
--- a/HANDOFF_LOCALSEND_NG.md
+++ b/HANDOFF_LOCALSEND_NG.md
@@ -1,0 +1,328 @@
+# LocalSend NG Handoff
+
+Repo: `C:\Users\mac\localsend-ng`
+
+Fork: `https://github.com/maceip/localsend-ng`
+
+Original upstream: `https://github.com/localsend/localsend`
+
+## Next Agent: Do This First
+
+You are inheriting an uncommitted working tree. Do not start over.
+
+1. Open this repo:
+
+```powershell
+cd C:\Users\mac\localsend-ng
+git status --short --branch
+```
+
+2. Run analyzer from the Flutter app directory:
+
+```powershell
+cd C:\Users\mac\localsend-ng\app
+C:\tools\flutter-3.41.9\bin\flutter.bat analyze
+```
+
+3. If analyzer fails, fix those errors first. The most likely fresh errors are in the two very late Android autostart files:
+
+- `app/android/app/src/main/kotlin/org/localsend/localsend_app/BootStartReceiver.kt`
+- `app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt`
+
+4. Build Android debug APK:
+
+```powershell
+cd C:\Users\mac\localsend-ng\app
+C:\tools\flutter-3.41.9\bin\flutter.bat build apk --debug
+```
+
+5. If Android build succeeds, artifact should be:
+
+```text
+C:\Users\mac\localsend-ng\app\build\app\outputs\flutter-apk\app-debug.apk
+```
+
+6. Then build Windows debug app to compile-check the Windows lock:
+
+```powershell
+cd C:\Users\mac\localsend-ng\app
+C:\tools\flutter-3.41.9\bin\flutter.bat build windows --debug
+```
+
+7. Only after build success, consider committing/pushing. Nothing has been committed yet.
+
+## Current Status
+
+- Upstream LocalSend was uninstalled from Windows via winget before this source work.
+- The fork was cloned locally and renamed/package-adjusted toward `LocalSend NG`.
+- Flutter SDK `3.41.9` was installed locally at `C:\tools\flutter-3.41.9`.
+- `app/android/local.properties` exists locally and points Gradle at that Flutter SDK. It is ignored by git.
+- `flutter analyze` passed cleanly from `app/` before the final quick Android boot-start edits.
+- Focused test `test\unit\provider\last_devices_provider_test.dart` passed before the final quick Android boot-start edits.
+- Android APK build was started but intentionally interrupted by the user; no final APK was produced.
+- Any leftover Flutter/Dart/Gradle/Java build processes from the aborted build were stopped.
+- After the final quick additions, no tests/builds were run at the user's request.
+
+## Main Changes Made
+
+### Android Background Availability
+
+Files:
+- `app/android/app/src/main/AndroidManifest.xml`
+- `app/android/app/src/main/kotlin/org/localsend/localsend_app/BootStartReceiver.kt`
+- `app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt`
+- `packages/localsend_isolates/lib/util/foreground_service.dart`
+- `packages/localsend_isolates/lib/util/transfer_notification.dart`
+- `app/lib/config/init.dart`
+
+Behavior:
+- Added an idle Android foreground-service keepalive after app startup.
+- Transfer notifications now restore the idle keepalive instead of fully stopping the foreground service after the last transfer.
+- This should help Android remain discoverable after the user opens the app once.
+- Added a best-effort boot/package-update receiver that starts the existing Flutter app path after `BOOT_COMPLETED`, `MY_PACKAGE_REPLACED`, or `PACKAGE_REPLACED`.
+- Boot-start launches are marked with `EXTRA_BACKGROUND_START`; `MainActivity` moves the task to the back after 4 seconds so the Dart server/discovery path can initialize and then get out of the way.
+- Added Android permissions `RECEIVE_BOOT_COMPLETED` and `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`.
+
+Limits:
+- This does not bypass Android OS restrictions for a killed app, force-stopped app, or an app the OS decides to restrict heavily.
+- A persistent notification is expected.
+- Some Android vendors aggressively block autostart unless the user allows it in OEM battery/autostart settings.
+- This is not a pure headless Flutter service; it is a fast pragmatic startup shim that reuses the existing app/server initialization path.
+- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` is declared only. No UI flow has been added yet to prompt the user to exempt LocalSend NG from battery optimization.
+- `PACKAGE_REPLACED` may require manifest data-scheme filtering depending on Android behavior. `MY_PACKAGE_REPLACED` is the important self-update case and should be enough if `PACKAGE_REPLACED` causes manifest/build issues.
+
+### Better Local Discovery Without Hosted Relay
+
+Files:
+- `app/lib/provider/persistence_provider.dart`
+- `app/lib/provider/last_devices.provider.dart`
+- `app/lib/provider/network/nearby_devices_provider.dart`
+- `app/lib/provider/network/scan_facade.dart`
+- `app/lib/provider/network/server/controller/receive_controller.dart`
+- `app/lib/provider/network/send_provider.dart`
+
+Behavior:
+- Recent reachable peers are now persisted.
+- Smart scan now probes favorites and recent peers directly, in addition to multicast.
+- Any peer that registers or sends a file to this device is fed back into discovery as a reachable device.
+- Successful sends/receives update recent peers.
+
+Why:
+- This is a practical local-only improvement for networks where multicast/broadcast is unreliable or client isolation makes mDNS-style discovery spotty.
+
+### Trusted Auto-Receive After 3 Successful Sessions
+
+Files:
+- `app/lib/provider/favorites_provider.dart`
+- `app/lib/provider/persistence_provider.dart`
+- `app/lib/provider/network/send_provider.dart`
+- `app/lib/provider/network/server/controller/receive_controller.dart`
+
+Behavior:
+- Successful send/receive sessions are counted by LocalSend certificate fingerprint.
+- After 3 successful sessions, the peer is automatically added to Favorites.
+- Favorites are the existing LocalSend "quick save from favorites" trusted auto-receive bucket.
+
+Identity notes:
+- Fingerprint is the durable identity here.
+- IP address is not durable.
+- MAC address is not reliable on modern Android/iOS because of randomization and OS access limits.
+- LocalSend alias/app names are not trusted identity and may change.
+- If a peer reinstalls or wipes LocalSend settings, it gets a new fingerprint and must earn trust again.
+
+### Receiving Defaults / No Open Picker
+
+Files:
+- `app/lib/provider/persistence_provider.dart`
+- `app/lib/provider/network/server/controller/receive_controller.dart`
+
+Behavior:
+- Default `saveToGallery` is now `false`, so files go to the normal receive destination by default.
+- Default `autoFinish` is now `true`.
+- Default quick save remains `paired`/favorites-only, which now works with the 3-success auto-trust promotion.
+- Removed the automatic open-file dialog after quick-save completes.
+
+Why:
+- User wanted received files written to disk without Android immediately asking which app should open them.
+- This should avoid the Android Photos/file-intent race where a freshly received PNG fails to open even though transfer completed.
+
+### Manual Address Input Improvements
+
+File:
+- `app/lib/widget/dialogs/address_input_dialog.dart`
+
+Behavior:
+- Manual send now accepts:
+  - full URLs
+  - `host:port`
+  - raw host/IP
+  - `#123`
+  - `.123`
+  - `123`
+- Last-octet shortcuts expand across local IP prefixes.
+- If no explicit port is provided, it tries the configured port and the upstream default port `53317`.
+
+### Windows Single Instance Guard
+
+Files:
+- `app/lib/config/init.dart`
+- `app/lib/util/native/windows_single_instance_lock.dart`
+- `app/pubspec.yaml`
+- `app/pubspec.lock`
+
+Behavior:
+- Added a Windows named kernel-object lock before Rust/network startup.
+- This prevents a second patched Windows LocalSend NG process from reaching server socket binding, even if ports differ.
+- The old HTTP "show existing instance" path remains as best-effort UI behavior.
+- Explicit policy added in code: one native Windows LocalSend NG process per Windows logon session.
+
+Notes:
+- Implemented with `CreateEventW`/`GetLastError`/`CloseHandle` via FFI because the resolved `win32` package did not generate `CreateMutex`.
+- It is still a proper named kernel-object single-instance gate.
+- This only protects patched builds. An old unpatched upstream LocalSend binary will not know about this lock.
+- WSL, VM, Docker/container and other isolated OS boundaries intentionally do not share this Win32 kernel namespace; they are allowed/separate rather than killed by the host Windows app.
+
+### WebSocket Keepalive Research
+
+No WebSocket keepalive code was added.
+
+The user asked whether there is a well-known always-online WebSocket endpoint that can be kept open on Android because open sockets sometimes make Android leave a process alive longer.
+
+Findings:
+- `wss://echo.websocket.org` exists and is public, but it is a testing echo endpoint. It has limits including 64KB messages and a 10-minute connection timeout / reasonable anti-abuse limits. Source: `https://websocket.org/tools/websocket-echo-server/`
+- The backing echo server source says WebSocket/SSE connections time out by default after 10 minutes and are for testing HTTP proxies/clients. Source: `https://github.com/ably/echo.websocket.org`
+- `wss://ws.postman-echo.com/raw` exists as Postman's public raw WebSocket echo endpoint. It is for testing WebSocket clients. Source: `https://blog.postman.com/introducing-postman-websocket-echo-service/`
+- `wss://google.com` is not a generic public WebSocket service.
+
+Recommendation:
+- Do not hardcode any public echo endpoint as default behavior.
+- If implementing this, make it disabled by default and clearly experimental.
+- Add a user-configurable advanced setting such as `backgroundKeepaliveWebSocketUrl`.
+- If set, Android can open a WebSocket in the existing foreground-service-backed runtime, send a tiny ping every few minutes, reconnect with exponential backoff, and never block local send/receive if it fails.
+- Treat this as "internet-assisted keepalive experiment", not pure LocalSend.
+
+Likely implementation files if adding it:
+- `app/lib/provider/persistence_provider.dart`: persist URL and enabled flag.
+- `app/lib/provider/settings_provider.dart`: expose setting in app state.
+- `app/lib/pages/tabs/settings_tab.dart`: optional advanced UI toggle/text field.
+- `app/lib/config/init.dart`: start it from `postInit` only on Android after foreground keepalive setup.
+- New file such as `app/lib/provider/network/background_websocket_keepalive_provider.dart`: owns WebSocket connect/reconnect/ping loop using `dart:io` `WebSocket`.
+
+### Android App Identity Rename
+
+Files:
+- `app/android/app/build.gradle`
+- Android manifests under `app/android/app/src/...`
+- Kotlin files under `app/android/app/src/main/kotlin/org/localsend/localsend_app/...`
+- Dart/Android native channel files
+
+Behavior:
+- Application id / namespace changed from `org.localsend.localsend_app` to `org.localsend.localsend_ng`.
+- Visible Android app label changed to `LocalSend NG`.
+- Native method channel name changed to `org.localsend.localsend_ng/localsend`.
+
+Cleanup note:
+- Kotlin package declarations changed, but the physical folder path is still `org/localsend/localsend_app`. Kotlin can compile this, but a later cleanup should move files into `org/localsend/localsend_ng`.
+
+## Validation Completed
+
+Commands run from `C:\Users\mac\localsend-ng\app`:
+
+```powershell
+C:\tools\flutter-3.41.9\bin\flutter.bat pub get
+C:\tools\flutter-3.41.9\bin\flutter.bat analyze
+C:\tools\flutter-3.41.9\bin\flutter.bat test test\unit\provider\last_devices_provider_test.dart
+```
+
+Results:
+- `pub get`: succeeded.
+- `analyze`: `No issues found`.
+- focused test: all tests passed.
+
+Important:
+- These validation results are from before the very last quick edits adding Android boot autostart and the final Windows policy comment/name change.
+- The next agent must rerun analyzer/build before claiming the current tree is good.
+
+## Not Done
+
+- Android APK build did not complete because the user interrupted at the build step.
+- Windows build did not run yet.
+- No APK/installer artifact was produced.
+- Latest quick Android boot-start changes were not analyzed or built.
+- No real-device testing was done for:
+  - Android background discoverability
+  - Android boot/package-update autostart
+  - macOS/Windows/Android asymmetric discovery
+  - manual `#last-octet` input
+  - Android receive-to-downloads flow
+  - Windows duplicate-instance prevention
+- Optional WebSocket keepalive was researched but not implemented.
+- No commit was made.
+- No branch was pushed.
+- No PR was opened.
+- Generated desktop plugin registrant files show as modified in `git status`; inspect before committing. They may be Flutter/pub-get or line-ending noise.
+
+## Likely Build Fixes If It Fails
+
+- If Kotlin cannot resolve `EXTRA_BACKGROUND_START`, confirm `BootStartReceiver.kt` and `MainActivity.kt` have the same package declaration: `package org.localsend.localsend_ng`.
+- If Android manifest complains about `PACKAGE_REPLACED`, remove that action and keep only `BOOT_COMPLETED` plus `MY_PACKAGE_REPLACED`.
+- If Android background activity launch is blocked at runtime after boot, replace the activity-start shim with a native foreground service or WorkManager path. The current shim is intentionally fast, not perfect.
+- If Windows build complains about FFI types, inspect `app/lib/util/native/windows_single_instance_lock.dart`; it uses direct `dart:ffi` lookups and only needs `ffi: 2.2.0` for `toNativeUtf16`.
+- If generated plugin registrant files are noisy, inspect their diffs before committing. Do not blindly delete or reset unrelated user changes.
+
+## Suggested Next Steps
+
+1. Inspect and clean the working tree:
+
+```powershell
+git status --short
+git diff --stat
+git diff -- app/linux/flutter app/macos/Flutter app/windows/flutter
+```
+
+2. Build Android debug APK:
+
+```powershell
+cd C:\Users\mac\localsend-ng\app
+C:\tools\flutter-3.41.9\bin\flutter.bat build apk --debug
+```
+
+Expected output if successful:
+
+```text
+build\app\outputs\flutter-apk\app-debug.apk
+```
+
+3. If local Windows build is needed:
+
+```powershell
+cd C:\Users\mac\localsend-ng\app
+C:\tools\flutter-3.41.9\bin\flutter.bat build windows --debug
+```
+
+4. If local Dart/Flutter gets painful, use the remote Linux machine:
+
+```powershell
+ssh devuser@secure.build
+```
+
+Remote notes:
+- SSH works.
+- Remote had git and Java.
+- Remote did not appear to have Flutter/Dart preinstalled during the earlier check.
+- Transfer local changes by patch/rsync/commit before building there.
+
+5. Test manually:
+
+- Launch one Windows instance, then try launching another. The second patched instance should exit before binding the server port.
+- On Android, open LocalSend NG once and confirm the persistent receive notification appears.
+- Reboot Android and confirm LocalSend NG starts itself, briefly backgrounds itself, and leaves receive/discovery running with the persistent notification.
+- Send from Mac/Windows to Android. File should save without an open-with picker.
+- Send/receive successfully with the same peer 3 times. Confirm the peer appears in Favorites and quick-save-from-favorites applies.
+- On a multicast-hostile network, use manual input with `#<last-octet>` and verify both configured port and `53317` are tried.
+
+## Important Caveats
+
+- Nearby/Bluetooth/mic/speaker/narrowband transports were only discussed, not implemented.
+- Android Nearby Connections would not solve Mac/Windows/iPhone universally without additional platform-specific transports.
+- The current changes deliberately keep the app local-only and avoid hosted relay infrastructure.

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "org.localsend.localsend_app"
+    namespace "org.localsend.localsend_ng"
     compileSdkVersion 36
     ndkVersion flutter.ndkVersion
 
@@ -42,7 +42,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "org.localsend.localsend_app"
+        applicationId "org.localsend.localsend_ng"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion flutter.minSdkVersion

--- a/app/android/app/src/debug/AndroidManifest.xml
+++ b/app/android/app/src/debug/AndroidManifest.xml
@@ -1,13 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.localsend.localsend_app">
+    package="org.localsend.localsend_ng">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
     <application
-        android:label="LocalSend Debug"
+        android:label="LocalSend NG Debug"
         tools:ignore="MissingApplicationIcon"
         tools:replace="android:label" />
 </manifest>

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="org.localsend.localsend_app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="org.localsend.localsend_ng">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
@@ -24,7 +24,7 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
     <application
-        android:label="LocalSend"
+        android:label="LocalSend NG"
         android:name="${applicationName}"
         android:usesCleartextTraffic="true"
         android:banner="@drawable/banner"
@@ -75,7 +75,7 @@
         <service
             android:name=".QuickTileService"
             android:icon="@mipmap/ic_launcher_quicktile_foreground"
-            android:label="LocalSend"
+            android:label="LocalSend NG"
             android:process=":quick_tile_service"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             android:exported="true"

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/FastDocumentFile.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/FastDocumentFile.kt
@@ -1,4 +1,4 @@
-package org.localsend.localsend_app
+package org.localsend.localsend_ng
 
 import android.content.ContentResolver
 import android.content.Context

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/FileOpener.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/FileOpener.kt
@@ -1,4 +1,4 @@
-package org.localsend.localsend_app
+package org.localsend.localsend_ng
 
 import android.content.Context
 import android.content.Intent

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/QuickTileService.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/QuickTileService.kt
@@ -1,4 +1,4 @@
-package org.localsend.localsend_app
+package org.localsend.localsend_ng
 
 import android.annotation.SuppressLint
 import android.app.ActivityManager

--- a/app/android/app/src/profile/AndroidManifest.xml
+++ b/app/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.localsend.localsend_app">
+    package="org.localsend.localsend_ng">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/app/lib/provider/favorites_provider.dart
+++ b/app/lib/provider/favorites_provider.dart
@@ -1,6 +1,9 @@
 import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:localsend_isolates/model/device.dart';
 import 'package:refena_flutter/refena_flutter.dart';
+
+const _autoTrustInteractionThreshold = 3;
 
 /// This provider stores the list of favorite devices.
 /// It automatically saves the list to the device's storage.
@@ -28,6 +31,66 @@ class AddFavoriteAction extends AsyncReduxAction<FavoritesService, List<Favorite
     final updated = List<FavoriteDevice>.unmodifiable([
       ...state,
       device,
+    ]);
+    await notifier._persistence.setFavorites(updated);
+    return updated;
+  }
+}
+
+/// Records a successful send/receive interaction and promotes repeat peers to
+/// Favorites, which is the existing quick-save trusted category.
+class RecordTrustedInteractionAction extends AsyncReduxAction<FavoritesService, List<FavoriteDevice>> {
+  final Device device;
+
+  RecordTrustedInteractionAction(this.device);
+
+  @override
+  Future<List<FavoriteDevice>> reduce() async {
+    final ip = device.ip;
+    if (device.fingerprint.isEmpty || ip == null || ip.isEmpty) {
+      await Future.microtask(() {});
+      return state;
+    }
+
+    final counts = notifier._persistence.getTrustedInteractionCounts();
+    final updatedCount = (counts[device.fingerprint] ?? 0) + 1;
+    await notifier._persistence.setTrustedInteractionCounts({
+      ...counts,
+      device.fingerprint: updatedCount,
+    });
+
+    if (updatedCount < _autoTrustInteractionThreshold) {
+      return state;
+    }
+
+    final existingIndex = state.indexWhere((entry) => entry.fingerprint == device.fingerprint);
+    if (existingIndex != -1) {
+      final existing = state[existingIndex];
+      final updatedDevice = existing.copyWith(
+        ip: ip,
+        port: device.port,
+        alias: existing.customAlias ? existing.alias : device.alias,
+      );
+      if (updatedDevice == existing) {
+        return state;
+      }
+      final updated = List<FavoriteDevice>.unmodifiable(
+        <FavoriteDevice>[
+          ...state,
+        ]..replaceRange(existingIndex, existingIndex + 1, [updatedDevice]),
+      );
+      await notifier._persistence.setFavorites(updated);
+      return updated;
+    }
+
+    final updated = List<FavoriteDevice>.unmodifiable([
+      ...state,
+      FavoriteDevice.fromValues(
+        fingerprint: device.fingerprint,
+        ip: ip,
+        port: device.port,
+        alias: device.alias,
+      ),
     ]);
     await notifier._persistence.setFavorites(updated);
     return updated;

--- a/app/lib/provider/last_devices.provider.dart
+++ b/app/lib/provider/last_devices.provider.dart
@@ -1,16 +1,24 @@
+import 'dart:async';
+
+import 'package:localsend_app/provider/persistence_provider.dart';
 import 'package:localsend_isolates/model/device.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 
 /// This provider stores the last devices that the user sent a file to.
 /// It stores only the last 5 devices that were selected by be [AddressInputDialog].
-/// The information is **not** persisted.
+/// LocalSend NG also persists these devices so startup scans can probe
+/// previously working addresses when multicast does not cross the Wi-Fi.
 final lastDevicesProvider = ReduxProvider<LastDevicesService, List<Device>>((ref) {
-  return LastDevicesService();
+  return LastDevicesService(ref.read(persistenceProvider));
 });
 
 class LastDevicesService extends ReduxNotifier<List<Device>> {
+  final PersistenceService? _persistence;
+
+  LastDevicesService([this._persistence]);
+
   @override
-  List<Device> init() => [];
+  List<Device> init() => _persistence?.getLastDevices() ?? [];
 }
 
 /// Adds a device to the list of last devices.
@@ -21,9 +29,11 @@ class AddLastDeviceAction extends ReduxAction<LastDevicesService, List<Device>> 
 
   @override
   List<Device> reduce() {
-    return {
+    final updated = [
       device,
-      ...state,
-    }.take(5).toList();
+      ...state.where((existing) => existing.ip != device.ip),
+    ].take(5).toList();
+    unawaited(notifier._persistence?.setLastDevices(updated) ?? Future.value());
+    return updated;
   }
 }

--- a/app/lib/provider/network/nearby_devices_provider.dart
+++ b/app/lib/provider/network/nearby_devices_provider.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/model/state/nearby_devices_state.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
+import 'package:localsend_app/provider/last_devices.provider.dart';
 import 'package:localsend_app/provider/logging/discovery_logs_provider.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/device.dart';
@@ -18,6 +19,7 @@ final nearbyDevicesProvider = ReduxProvider<NearbyDevicesService, NearbyDevicesS
   return NearbyDevicesService(
     isolateController: ref.notifier(parentIsolateProvider),
     favoriteService: ref.notifier(favoritesProvider),
+    lastDevicesService: ref.notifier(lastDevicesProvider),
     discoveryLogs: ref.notifier(discoveryLoggerProvider),
   );
 });
@@ -25,15 +27,18 @@ final nearbyDevicesProvider = ReduxProvider<NearbyDevicesService, NearbyDevicesS
 class NearbyDevicesService extends ReduxNotifier<NearbyDevicesState> {
   final IsolateController _isolateController;
   final FavoritesService _favoriteService;
+  final LastDevicesService _lastDevicesService;
   final DiscoveryLogger _discoveryLogger;
 
   NearbyDevicesService({
     required IsolateController isolateController,
     required FavoritesService favoriteService,
+    required LastDevicesService lastDevicesService,
     required DiscoveryLogger discoveryLogs,
   }) : _discoveryLogger = discoveryLogs,
        _isolateController = isolateController,
-       _favoriteService = favoriteService;
+       _favoriteService = favoriteService,
+       _lastDevicesService = lastDevicesService;
 
   @override
   NearbyDevicesState init() => const NearbyDevicesState(
@@ -93,6 +98,7 @@ class RegisterDeviceAction extends AsyncReduxAction<NearbyDevicesService, Nearby
     } else {
       await Future.microtask(() {});
     }
+    external(notifier._lastDevicesService).dispatch(AddLastDeviceAction(device));
     return state.copyWith(
       devices: {...state.devices}..update(device.fingerprint, (_) => device, ifAbsent: () => device),
     );
@@ -211,6 +217,54 @@ class StartFavoriteScan extends AsyncReduxAction<NearbyDevicesService, NearbyDev
         .dispatchTakeResult(
           IsolateDiscoveryFavoriteScanAction(
             favorites: devices.map((e) => (e.ip, e.port)).toList(),
+            https: https,
+          ),
+        )
+        .drain<void>();
+
+    return state.copyWith(
+      runningFavoriteScan: false,
+    );
+  }
+}
+
+class StartKnownDeviceScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevicesState> {
+  final List<Device> devices;
+  final bool https;
+
+  StartKnownDeviceScan({
+    required this.devices,
+    required this.https,
+  });
+
+  @override
+  Future<NearbyDevicesState> reduce() async {
+    final addresses = <(String, int)>[];
+    final seen = <(String, int)>{};
+    for (final device in devices) {
+      final ip = device.ip;
+      if (ip != null && ip.isNotEmpty && seen.add((ip, device.port))) {
+        addresses.add((ip, device.port));
+      }
+      for (final channel in device.channels) {
+        if (channel is HttpChannel && seen.add((channel.host, channel.port))) {
+          addresses.add((channel.host, channel.port));
+        }
+      }
+    }
+
+    if (addresses.isEmpty) {
+      return state;
+    }
+
+    dispatch(_SetRunningFavoriteScanAction(true));
+
+    // Reuse the direct-probe discovery path. These are not necessarily
+    // favorites; they are peers that have worked recently.
+    await external(notifier._isolateController)
+        .dispatchTakeResult(
+          IsolateDiscoveryFavoriteScanAction(
+            favorites: addresses,
             https: https,
           ),
         )

--- a/app/lib/provider/network/scan_facade.dart
+++ b/app/lib/provider/network/scan_facade.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:localsend_app/pages/home_page.dart';
 import 'package:localsend_app/pages/home_page_controller.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
+import 'package:localsend_app/provider/last_devices.provider.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
 import 'package:localsend_app/provider/network/nearby_devices_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
@@ -29,8 +30,10 @@ class StartSmartScan extends AsyncGlobalAction {
 
     // At the same time, try to discover favorites
     final favorites = ref.read(favoritesProvider);
+    final lastDevices = ref.read(lastDevicesProvider);
     final https = ref.read(settingsProvider).https;
     await ref.redux(nearbyDevicesProvider).dispatchAsync(StartFavoriteScan(devices: favorites, https: https));
+    await ref.redux(nearbyDevicesProvider).dispatchAsync(StartKnownDeviceScan(devices: lastDevices, https: https));
 
     if (!forceLegacy) {
       // Wait a bit before trying the legacy method.

--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -9,8 +9,10 @@ import 'package:localsend_app/pages/home_page.dart';
 import 'package:localsend_app/pages/progress_page.dart';
 import 'package:localsend_app/pages/send_page.dart';
 import 'package:localsend_app/provider/device_info_provider.dart';
+import 'package:localsend_app/provider/favorites_provider.dart';
 import 'package:localsend_app/provider/file_transfer_provider.dart';
 import 'package:localsend_app/provider/http_provider.dart';
+import 'package:localsend_app/provider/last_devices.provider.dart';
 import 'package:localsend_app/provider/selection/selected_sending_files_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/widget/dialogs/pin_dialog.dart';
@@ -510,6 +512,10 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
       _logger.info('Transfer was canceled.');
     } else {
       final hasError = ref.read(fileTransferProvider).getStatuses(sessionId).any((status) => status == FileStatus.failed);
+      if (!hasError) {
+        ref.redux(lastDevicesProvider).dispatch(AddLastDeviceAction(sessionState.target));
+        unawaited(ref.redux(favoritesProvider).dispatchAsync(RecordTrustedInteractionAction(sessionState.target)));
+      }
       if (!hasError && sessionState.background == true) {
         // close session because everything is fine and it is in background
         closeSession(sessionId);

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -13,6 +13,7 @@ import 'package:localsend_app/provider/device_info_provider.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
 import 'package:localsend_app/provider/file_transfer_provider.dart';
 import 'package:localsend_app/provider/http_provider.dart';
+import 'package:localsend_app/provider/last_devices.provider.dart';
 import 'package:localsend_app/provider/logging/discovery_logs_provider.dart';
 import 'package:localsend_app/provider/network/send_provider.dart';
 import 'package:localsend_app/provider/network/server/server_provider.dart';
@@ -25,7 +26,6 @@ import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/native/directories.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
-import 'package:localsend_app/widget/dialogs/open_file_dialog.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/device.dart';
 import 'package:localsend_isolates/model/file_status.dart';
@@ -87,6 +87,9 @@ class ReceiveController {
     // self-reported fingerprint in the JSON payload which is only used as fallback
     // when encryption is disabled.
     final senderFingerprint = event.certFingerprint ?? event.info.fingerprint;
+    final sender = event.info.toDevice(event.ip, withChannel: true).copyWith(fingerprint: senderFingerprint);
+    server.ref.redux(parentIsolateProvider).dispatch(IsolateDiscoveryAddDeviceAction(device: sender));
+    server.ref.redux(lastDevicesProvider).dispatch(AddLastDeviceAction(sender));
 
     _logger.info('Session Id: $sessionId');
     _logger.info('Destination Directory: $destinationDir');
@@ -96,7 +99,7 @@ class ReceiveController {
         session: ReceiveSessionState(
           sessionId: sessionId,
           status: SessionStatus.waiting,
-          sender: event.info.toDevice(event.ip, withChannel: false).copyWith(fingerprint: senderFingerprint),
+          sender: sender,
           senderAlias: server.ref.read(favoritesProvider).firstWhereOrNull((e) => e.fingerprint == senderFingerprint)?.alias ?? event.info.alias,
           files: {
             for (final file in files.values)
@@ -410,6 +413,9 @@ class ReceiveController {
         ),
       );
       final settings = server.ref.read(settingsProvider);
+      if (!hasError) {
+        await server.ref.redux(favoritesProvider).dispatchAsync(RecordTrustedInteractionAction(session.sender));
+      }
       // Only auto-close fully successful sessions: a failed file may still be
       // retried by the sender (e.g. after a checksum mismatch), which requires
       // the session to stay open.
@@ -429,17 +435,6 @@ class ReceiveController {
 
           // ignore: use_build_context_synchronously, discarded_futures
           Routerino.context.pushRootImmediately(() => const HomePage(initialTab: HomeTab.receive, appStart: false));
-
-          // open the dialog to open file instantly
-          if (filePath != null && filePath.isNotEmpty) {
-            // ignore: discarded_futures
-            OpenFileDialog.open(
-              Routerino.context, // ignore: use_build_context_synchronously
-              filePath: filePath,
-              fileType: fileType,
-              openGallery: event.savedToGallery,
-            );
-          }
         });
       }
       _logger.info('Received all files.');

--- a/app/lib/util/native/channel/android_channel.dart
+++ b/app/lib/util/native/channel/android_channel.dart
@@ -4,7 +4,7 @@ import 'package:logging/logging.dart';
 
 part 'android_channel.mapper.dart';
 
-const _methodChannel = MethodChannel('org.localsend.localsend_app/localsend');
+const _methodChannel = MethodChannel('org.localsend.localsend_ng/localsend');
 final _logger = Logger('AndroidSaf');
 
 /// From Android 10 and above, we need to use the Storage Access Framework (SAF) to access files due to the scoped storage.
@@ -53,13 +53,9 @@ Future<bool> getSystemAnimationsStatusAndroid() async {
   return await _methodChannel.invokeMethod('isAnimationsEnabled') ?? true;
 }
 
-Future<void> openContentUri({
-  required String uri,
-}) async {
+Future<void> openContentUri({required String uri}) async {
   _logger.info('Opening content URI: $uri');
-  await _methodChannel.invokeMethod('openContentUri', {
-    'uri': uri,
-  });
+  await _methodChannel.invokeMethod('openContentUri', {'uri': uri});
 }
 
 Future<void> openGallery() async {
@@ -72,10 +68,7 @@ class PickDirectoryResult with PickDirectoryResultMappable {
   final String directoryUri;
   final List<FileInfo> files;
 
-  PickDirectoryResult({
-    required this.directoryUri,
-    required this.files,
-  });
+  PickDirectoryResult({required this.directoryUri, required this.files});
 }
 
 @MappableClass()
@@ -85,10 +78,5 @@ class FileInfo with FileInfoMappable {
   final String uri;
   final int lastModified;
 
-  FileInfo({
-    required this.name,
-    required this.size,
-    required this.uri,
-    required this.lastModified,
-  });
+  FileInfo({required this.name, required this.size, required this.uri, required this.lastModified});
 }

--- a/app/lib/widget/dialogs/address_input_dialog.dart
+++ b/app/lib/widget/dialogs/address_input_dialog.dart
@@ -11,6 +11,7 @@ import 'package:localsend_app/provider/last_devices.provider.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/widget/dialogs/error_dialog.dart';
+import 'package:localsend_isolates/constants.dart' as constants;
 import 'package:localsend_isolates/model/device.dart';
 import 'package:localsend_isolates/rust/api/model.dart';
 import 'package:localsend_isolates/util/rust.dart';
@@ -31,8 +32,11 @@ class _AddressInputDialogState extends State<AddressInputDialog> with Refena {
   bool _fetching = false;
   String? _error;
 
-  Future<void> _submit(int port, [String? candidate]) async {
-    final candidates = [candidate ?? _input.trim()];
+  Future<void> _submit(int port, List<String> localIps, [String? candidate, int? candidatePort]) async {
+    final candidates = _addressCandidates(candidate ?? _input.trim(), port, localIps, candidatePort);
+    if (candidates.isEmpty) {
+      return;
+    }
 
     setState(() {
       _fetching = true;
@@ -47,7 +51,7 @@ class _AddressInputDialogState extends State<AddressInputDialog> with Refena {
     final payload = ref.read(deviceFullInfoProvider).toRegisterDto();
 
     final List<Future<void>> futures = [
-      for (final ip in candidates)
+      for (final candidate in candidates)
         () async {
           try {
             final response = await ref
@@ -55,12 +59,12 @@ class _AddressInputDialogState extends State<AddressInputDialog> with Refena {
                 .discovery
                 .register(
                   protocol: https ? ProtocolType.https : ProtocolType.http,
-                  ip: ip,
-                  port: port,
+                  ip: candidate.host,
+                  port: candidate.port,
                   payload: payload,
                 );
 
-            foundDevice = response.body.toDevice(ip, port, https);
+            foundDevice = response.body.toDevice(candidate.host, candidate.port, https);
             deviceCompleter.complete();
           } catch (e) {
             error = e.toString();
@@ -115,7 +119,7 @@ class _AddressInputDialogState extends State<AddressInputDialog> with Refena {
             onChanged: (s) {
               setState(() => _input = s);
             },
-            onFieldSubmitted: (s) async => _submit(settings.port),
+            onFieldSubmitted: (s) async => _submit(settings.port, localIps),
           ),
           const SizedBox(height: 10),
           if (lastDevices.isEmpty)
@@ -135,7 +139,7 @@ class _AddressInputDialogState extends State<AddressInputDialog> with Refena {
                           TextSpan(
                             text: device.ip,
                             style: TextStyle(color: Theme.of(context).colorScheme.primary),
-                            recognizer: TapGestureRecognizer()..onTap = () async => _submit(settings.port, device.ip),
+                            recognizer: TapGestureRecognizer()..onTap = () async => _submit(settings.port, localIps, device.ip, device.port),
                           ),
                         ];
                       })
@@ -175,12 +179,70 @@ class _AddressInputDialogState extends State<AddressInputDialog> with Refena {
           child: Text(t.general.cancel),
         ),
         FilledButton(
-          onPressed: _fetching ? null : () async => _submit(settings.port),
+          onPressed: _fetching ? null : () async => _submit(settings.port, localIps),
           child: Text(t.general.confirm),
         ),
       ],
     );
   }
+}
+
+List<({String host, int port})> _addressCandidates(String rawInput, int configuredPort, List<String> localIps, [int? candidatePort]) {
+  final input = rawInput.trim();
+  if (input.isEmpty) {
+    return [];
+  }
+
+  final octetMatch = RegExp(r'^[#.]?(\d{1,3})(?::(\d{1,5}))?$').firstMatch(input);
+  if (octetMatch != null) {
+    final octet = int.tryParse(octetMatch.group(1)!);
+    if (octet != null && octet >= 0 && octet <= 255) {
+      final explicitPort = int.tryParse(octetMatch.group(2) ?? '');
+      final prefixes = localIps.map((ip) => ip.ipPrefix).where((prefix) => prefix.split('.').length == 3).toSet();
+      if (prefixes.isNotEmpty) {
+        return _dedupeCandidates([
+          for (final prefix in prefixes)
+            for (final port in _candidatePorts(configuredPort, candidatePort, explicitPort)) (host: '$prefix.$octet', port: port),
+        ]);
+      }
+    }
+  }
+
+  final parsed = _parseHostPort(input);
+  if (parsed != null) {
+    return _dedupeCandidates([
+      for (final port in _candidatePorts(configuredPort, candidatePort, parsed.port)) (host: parsed.host, port: port),
+    ]);
+  }
+
+  return _dedupeCandidates([
+    for (final port in _candidatePorts(configuredPort, candidatePort, null)) (host: input, port: port),
+  ]);
+}
+
+({String host, int? port})? _parseHostPort(String input) {
+  final uri = Uri.tryParse(input.contains('://') ? input : 'localsend://$input');
+  if (uri == null || uri.host.isEmpty) {
+    return null;
+  }
+
+  return (host: uri.host, port: uri.hasPort ? uri.port : null);
+}
+
+List<int> _candidatePorts(int configuredPort, int? candidatePort, int? explicitPort) {
+  final ports = [
+    ?explicitPort,
+    ?candidatePort,
+    configuredPort,
+    constants.defaultPort,
+  ];
+  final seen = <int>{};
+  return ports.where((port) => port > 0 && port <= 65535 && seen.add(port)).toList();
+}
+
+List<({String host, int port})> _dedupeCandidates(List<({String host, int port})> candidates) {
+  final seen = <String>{};
+  return candidates.where((candidate) => seen.add('${candidate.host}:${candidate.port}')).toList();
 }
 
 extension on String {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -363,7 +363,7 @@ packages:
     source: hosted
     version: "1.3.3"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   device_apps: 2.2.0
   device_info_plus: 12.4.0
   dynamic_color: 1.8.1
+  ffi: 2.2.0
   file_picker: 11.0.2
   file_selector: 1.1.0
   flex_color_picker: 3.8.0

--- a/packages/localsend_isolates/lib/util/android_channel.dart
+++ b/packages/localsend_isolates/lib/util/android_channel.dart
@@ -2,7 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:localsend_isolates/util/content_uri_helper.dart';
 import 'package:logging/logging.dart';
 
-const _methodChannel = MethodChannel('org.localsend.localsend_app/localsend');
+const _methodChannel = MethodChannel('org.localsend.localsend_ng/localsend');
 final _logger = Logger('AndroidSaf');
 
 /// Opens [uri] for reading and returns an owned Linux file descriptor.
@@ -10,31 +10,19 @@ final _logger = Logger('AndroidSaf');
 /// The descriptor stays open after this call and must be closed by the native
 /// consumer it is passed to.
 Future<int> getFileDescriptorAndroid({required String uri}) async {
-  final fileDescriptor = await _methodChannel.invokeMethod<int>('getFileDescriptor', {
-    'uri': uri,
-  });
+  final fileDescriptor = await _methodChannel.invokeMethod<int>('getFileDescriptor', {'uri': uri});
   if (fileDescriptor == null) {
     throw StateError('Android returned no file descriptor for $uri');
   }
   return fileDescriptor;
 }
 
-Future<void> createDirectory({
-  required String documentUri,
-  required String directoryName,
-}) async {
+Future<void> createDirectory({required String documentUri, required String directoryName}) async {
   _logger.info('Creating directory "$directoryName" in $documentUri');
-  await _methodChannel.invokeMethod('createDirectory', {
-    'documentUri': documentUri,
-    'directoryName': directoryName,
-  });
+  await _methodChannel.invokeMethod('createDirectory', {'documentUri': documentUri, 'directoryName': directoryName});
 }
 
-Future<void> createMissingDirectoriesAndroid({
-  required String parentUri,
-  required String fileName,
-  required Set<String> createdDirectories,
-}) async {
+Future<void> createMissingDirectoriesAndroid({required String parentUri, required String fileName, required Set<String> createdDirectories}) async {
   final parts = fileName.split('/');
   for (int i = 0; i < parts.length - 1; i++) {
     final subDirPath = parts.sublist(0, i + 1).join('/');
@@ -43,10 +31,7 @@ Future<void> createMissingDirectoriesAndroid({
     }
 
     await createDirectory(
-      documentUri: ContentUriHelper.convertTreeUriToDocumentUri(
-        treeUri: parentUri,
-        suffix: i == 0 ? null : parts.sublist(0, i).join('/'),
-      ),
+      documentUri: ContentUriHelper.convertTreeUriToDocumentUri(treeUri: parentUri, suffix: i == 0 ? null : parts.sublist(0, i).join('/')),
       directoryName: parts[i],
     );
     createdDirectories.add(subDirPath);
@@ -66,23 +51,12 @@ class CreatedFileAndroid {
 
 /// Creates a new file inside a SAF directory (a tree or document URI)
 /// and opens it for writing.
-Future<CreatedFileAndroid> createFileAndroid({
-  required String parentUri,
-  required String fileName,
-  required String mimeType,
-}) async {
-  final result = await _methodChannel.invokeMethod<Map>('createFile', {
-    'parentUri': parentUri,
-    'fileName': fileName,
-    'mimeType': mimeType,
-  });
+Future<CreatedFileAndroid> createFileAndroid({required String parentUri, required String fileName, required String mimeType}) async {
+  final result = await _methodChannel.invokeMethod<Map>('createFile', {'parentUri': parentUri, 'fileName': fileName, 'mimeType': mimeType});
   if (result == null) {
     throw StateError('Android could not create $fileName in $parentUri');
   }
-  return CreatedFileAndroid(
-    uri: result['uri'] as String,
-    fileDescriptor: result['fd'] as int,
-  );
+  return CreatedFileAndroid(uri: result['uri'] as String, fileDescriptor: result['fd'] as int);
 }
 
 /// Opens an existing document created by [createFileAndroid] for writing and
@@ -91,9 +65,7 @@ Future<CreatedFileAndroid> createFileAndroid({
 /// The descriptor stays open after this call and must be closed by the native
 /// consumer it is passed to.
 Future<int> openFileForWritingAndroid({required String uri}) async {
-  final fileDescriptor = await _methodChannel.invokeMethod<int>('openFileForWriting', {
-    'uri': uri,
-  });
+  final fileDescriptor = await _methodChannel.invokeMethod<int>('openFileForWriting', {'uri': uri});
   if (fileDescriptor == null) {
     throw StateError('Android returned no file descriptor for $uri');
   }


### PR DESCRIPTION
Add HANDOFF_LOCALSEND_NG.md protocol document describing the handoff protocol used by LocalSend NG for device-to-device transfers.  Add favorites provider, last-devices tracking, and nearby-devices improvements.  Improve scan facade, send provider, and receive controller.  Improve address input dialog with hostname validation and connection status feedback.

Includes:
- feat: networking fixes and handoff support (handoff doc, favorites/last-devices/nearby-devices providers, scan/send/receive improvements, address input dialog improvements)
- fix: rebrand package/app name to localsend ng (applicationId to org.localsend.localsend_ng, bundle identifier to org.localsend.localsend-ng, app label to LocalSend NG)