### PR TITLE
fix: recover favorite devices after sleep

### DIFF
--- a/app/lib/provider/http_provider.dart
+++ b/app/lib/provider/http_provider.dart
@@ -12,12 +12,19 @@ class HttpClientCollection {
   /// and is learned from the response. Never use this to transfer files:
   /// it cannot tell the discovered device apart from anyone else answering
   /// on that address.
-  final RsHttpClient discovery;
+  ///
+  /// A fresh client is created for every probe so a device that went to sleep
+  /// cannot leave a dead keep-alive connection in the discovery client pool.
+  RsHttpClient get discovery => createClient(
+    privateKey: _privateKey,
+    cert: _certificate,
+    version: LsHttpClientVersion.v2,
+    expectedFingerprint: null,
+  );
 
   HttpClientCollection({
     required String privateKey,
     required String certificate,
-    required this.discovery,
   }) : _privateKey = privateKey,
        _certificate = certificate;
 
@@ -43,11 +50,5 @@ final httpProvider = ViewProvider((ref) {
   return HttpClientCollection(
     privateKey: securityContext.privateKey,
     certificate: securityContext.certificate,
-    discovery: createClient(
-      privateKey: securityContext.privateKey,
-      cert: securityContext.certificate,
-      version: LsHttpClientVersion.v2,
-      expectedFingerprint: null,
-    ),
   );
 });

--- a/app/lib/provider/network/nearby_devices_provider.dart
+++ b/app/lib/provider/network/nearby_devices_provider.dart
@@ -5,6 +5,7 @@ import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/model/state/nearby_devices_state.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
 import 'package:localsend_app/provider/logging/discovery_logs_provider.dart';
+import 'package:localsend_app/util/favorites.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/device.dart';
 import 'package:refena_flutter/refena_flutter.dart';
@@ -87,9 +88,10 @@ class RegisterDeviceAction extends AsyncReduxAction<NearbyDevicesService, Nearby
     assert(device.ip?.isNotEmpty ?? false, 'IP must not be empty');
 
     final favoriteDevice = notifier._favoriteService.state.firstWhereOrNull((e) => e.fingerprint == device.fingerprint);
-    if (favoriteDevice != null && !favoriteDevice.customAlias) {
-      // Update existing favorite with new alias
-      await external(notifier._favoriteService).dispatchAsync(UpdateFavoriteAction(favoriteDevice.copyWith(alias: device.alias)));
+    if (favoriteDevice != null) {
+      await external(notifier._favoriteService).dispatchAsync(
+        UpdateFavoriteAction(updateFavoriteFromDevice(favoriteDevice, device)),
+      );
     } else {
       await Future.microtask(() {});
     }

--- a/app/lib/util/favorites.dart
+++ b/app/lib/util/favorites.dart
@@ -13,3 +13,15 @@ extension FavoriteDevicesExt on Iterable<FavoriteDevice> {
     return any((e) => e.fingerprint == device.fingerprint);
   }
 }
+
+/// Refreshes the address stored for a favorite after the device was confirmed
+/// on the network. User-defined aliases are kept unchanged.
+FavoriteDevice updateFavoriteFromDevice(FavoriteDevice favorite, Device device) {
+  assert(device.ip?.isNotEmpty ?? false, 'IP must not be empty');
+
+  return favorite.copyWith(
+    ip: device.ip!,
+    port: device.port,
+    alias: favorite.customAlias ? favorite.alias : device.alias,
+  );
+}

--- a/app/lib/widget/dialogs/favorite_dialog.dart
+++ b/app/lib/widget/dialogs/favorite_dialog.dart
@@ -5,9 +5,12 @@ import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/provider/device_info_provider.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
 import 'package:localsend_app/provider/http_provider.dart';
+import 'package:localsend_app/provider/network/nearby_devices_provider.dart';
+import 'package:localsend_app/provider/network/scan_facade.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/widget/dialogs/error_dialog.dart';
 import 'package:localsend_app/widget/dialogs/favorite_edit_dialog.dart';
+import 'package:localsend_isolates/model/device.dart';
 import 'package:localsend_isolates/rust/api/model.dart';
 import 'package:localsend_isolates/util/rust.dart';
 import 'package:refena_flutter/refena_flutter.dart';
@@ -34,6 +37,21 @@ class _FavoritesDialogState extends State<FavoritesDialog> with Refena {
     final https = ref.read(settingsProvider).https;
 
     try {
+      final device = await _discoverFavorite(favorite, https);
+
+      if (mounted) {
+        context.pop(device);
+      }
+    } catch (e) {
+      setState(() {
+        _fetching = false;
+        _error = e.toString();
+      });
+    }
+  }
+
+  Future<Device> _discoverFavorite(FavoriteDevice favorite, bool https) async {
+    try {
       final payload = ref.read(deviceFullInfoProvider).toRegisterDto();
       final response = await ref
           .read(httpProvider)
@@ -45,17 +63,48 @@ class _FavoritesDialogState extends State<FavoritesDialog> with Refena {
             payload: payload,
           );
 
-      final device = response.body.toDevice(favorite.ip, favorite.port, https);
-
-      if (mounted) {
-        context.pop(device);
-      }
+      return response.body.toDevice(favorite.ip, favorite.port, https);
     } catch (e) {
-      setState(() {
-        _fetching = false;
-        _error = e.toString();
-      });
+      // A device may have received a new address while it was asleep. It may
+      // already have been rediscovered by multicast, so use that address
+      // before starting a full refresh.
+      final knownDevice = _deviceWithNewAddress(favorite);
+      if (knownDevice != null) {
+        return knownDevice;
+      }
+
+      // The favorite address is only a hint. If it is stale, refresh discovery
+      // so the subnet scan can find the device at its current address.
+      try {
+        await ref.global.dispatchAsync(StartSmartScan(forceLegacy: true));
+      } catch (_) {
+        // Preserve the original connection error when the recovery scan also
+        // cannot run, e.g. because the discovery isolate is unavailable.
+      }
+
+      final refreshedDevice = await _waitForDeviceWithNewAddress(favorite);
+      if (refreshedDevice != null) {
+        return refreshedDevice;
+      }
+
+      rethrow;
     }
+  }
+
+  Device? _deviceWithNewAddress(FavoriteDevice favorite) {
+    final device = ref.read(nearbyDevicesProvider).devices[favorite.fingerprint];
+    return device?.ip != null && device!.ip != favorite.ip ? device : null;
+  }
+
+  Future<Device?> _waitForDeviceWithNewAddress(FavoriteDevice favorite) async {
+    for (var attempt = 0; attempt < 20; attempt++) {
+      final device = _deviceWithNewAddress(favorite);
+      if (device != null) {
+        return device;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    return null;
   }
 
   Future<void> _showDeviceDialog([FavoriteDevice? favorite]) async {

--- a/app/test/unit/util/favorites_test.dart
+++ b/app/test/unit/util/favorites_test.dart
@@ -1,0 +1,53 @@
+import 'package:localsend_app/model/persistence/favorite_device.dart';
+import 'package:localsend_app/util/favorites.dart';
+import 'package:localsend_isolates/model/device.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('refreshes a favorite address and generated alias', () {
+    final favorite = _favorite(customAlias: false);
+
+    final updated = updateFavoriteFromDevice(favorite, _device());
+
+    expect(updated.ip, '192.168.1.42');
+    expect(updated.port, 53318);
+    expect(updated.alias, 'Phone');
+  });
+
+  test('keeps a custom favorite alias while refreshing its address', () {
+    final favorite = _favorite(customAlias: true, alias: 'My phone');
+
+    final updated = updateFavoriteFromDevice(favorite, _device());
+
+    expect(updated.ip, '192.168.1.42');
+    expect(updated.port, 53318);
+    expect(updated.alias, 'My phone');
+  });
+}
+
+FavoriteDevice _favorite({required bool customAlias, String alias = 'Old phone'}) {
+  return FavoriteDevice(
+    id: 'favorite-id',
+    fingerprint: 'phone-fingerprint',
+    ip: '192.168.1.10',
+    port: 53317,
+    alias: alias,
+    customAlias: customAlias,
+  );
+}
+
+Device _device() {
+  return const Device(
+    signalingId: null,
+    ip: '192.168.1.42',
+    version: '2.2',
+    port: 53318,
+    https: true,
+    fingerprint: 'phone-fingerprint',
+    alias: 'Phone',
+    deviceModel: 'Samsung S23+',
+    deviceType: DeviceType.mobile,
+    download: false,
+    channels: [],
+  );
+}


### PR DESCRIPTION
Fixes #3254

## Issue checklist

- [x] I have read [#528 - READ THIS BEFORE POSTING AN ISSUE](https://github.com/localsend/localsend/issues/528).
- [x] Issues not fitting are closed.
- [x] I searched the open and closed issues for duplicates.
- [x] The #3254 report states that the latest release was used.

## Problem addressed

A device that had already worked becomes unreachable after the receiving device sleeps. The sender remains on the same Wi-Fi network, but selecting the saved device from **Send -> Favourites** can use stale connection state and fail with:

`[RhttpTimeoutException] Request timed out`

This is different from a first-time connection failure: the affected device was previously reachable, and the failure appears after a sleep/reconnect interval.

## Related issues reviewed

- [#527 - Cannot discover other devices](https://github.com/localsend/localsend/issues/527): broad discovery/network troubleshooting guidance, not this specific favorite-after-sleep flow.
- [#414 - Nearby devices are not seen](https://github.com/localsend/localsend/issues/414): general directional discovery failure, not a previously working favorite becoming stale.
- [#2121 - RhttpTimeoutException: Request timed out](https://github.com/localsend/localsend/issues/2121): timeout while initially adding a device to Favorites; this PR targets an existing favorite after the peer sleeps.
- [#2438 - Add ping discovery for Favorite devices](https://github.com/localsend/localsend/issues/2438): related favorite reachability/discovery request, but focused on multiple VLANs and static addresses.
- [#1043 - Favorite devices do not require IP Address](https://github.com/localsend/localsend/issues/1043): broader proposal to identify favorites by device ID instead of IP; this PR keeps the current model and refreshes the saved address when the device is rediscovered.
- [#3044 - HTTP Operations Lack Timeout Mechanism](https://github.com/localsend/localsend/issues/3044): broad timeout/cancellation proposal; this PR is limited to recovering a favorite-device probe after a timeout.

None of the reviewed reports describe the same sequence of a previously working favorite becoming unreachable after the receiving device sleeps.

## What changed

- Refreshes a favorite's IP and port when the matching device is rediscovered.
- Preserves a user-defined favorite alias while refreshing generated device data.
- Uses a fresh HTTP client for discovery probes so a dead keep-alive connection is not reused after the peer sleeps.
- If a saved favorite probe times out, starts a full discovery scan and retries with the newly discovered address.
- Adds regression tests for favorite address refresh and custom-alias preservation.

## Manual validation

The sleep/wake scenario was manually exercised with the Android and Windows builds:

- Phone: OnePlus 11R 5G (IN), OxygenOS 16 / Android 16.
- Laptop: ThinkPad P14s G6 Intel, Windows 11 25H2.

- The laptop remained running with LocalSend active and was not rebooted.
- The phone was allowed to sleep and later resumed on the same network.
- The saved favorite remained reachable after the wait, and a small test transfer completed successfully.
- The Windows log shows discovery/updates from 8:48 PM through 11:06 PM, including an address change from `172.16.34.117` back to `192.168.137.15`.
- The Android view shows the device still marked as a Favorite and discovered via HTTPS at 11:06 PM.

### Test evidence

The Android screenshots show the favorite before the sleep/wait period and after more than two hours. The Windows screenshot shows the full discovery/update history.

<table>
  <tr>
    <td align="center">
      <img src="https://raw.githubusercontent.com/Chethan616/localsend/b15ecbf4afe39f1af732910d30578e50ea95bef6/pr-evidence/favorite-refresh-windows.png" width="380" alt="Windows favorite refresh log">
    </td>
    <td align="center">
      <img src="https://raw.githubusercontent.com/Chethan616/localsend/b15ecbf4afe39f1af732910d30578e50ea95bef6/pr-evidence/favorite-refresh-android-before.png" height="320" alt="Android favorite before sleep">
    </td>
    <td align="center">
      <img src="https://raw.githubusercontent.com/Chethan616/localsend/b15ecbf4afe39f1af732910d30578e50ea95bef6/pr-evidence/favorite-refresh-android.png" height="320" alt="Android favorite after sleep">
    </td>
  </tr>
  <tr>
    <td align="center">Windows history</td>
    <td align="center">Before wait - 8:53 PM</td>
    <td align="center">After wait - 11:06 PM</td>
  </tr>
</table>

## Automated and build validation

- `flutter analyze` passed.
- `flutter test` passed.
- An Android debug APK was built, installed, and launched on Android 16; the app startup UI was verified.
- A Windows debug bundle was packaged with its plugin DLLs/assets and launched successfully.