### PR TITLE
fix: keep answering register and finishing scans when events pile up

### DIFF
--- a/packages/core/src/discovery/mod.rs
+++ b/packages/core/src/discovery/mod.rs
@@ -180,7 +180,19 @@ impl DiscoveryState {
         let (event, merged) = self.store.upsert(device, SystemTime::now());
         let is_new = matches!(event, DiscoveryEvent::Discovered { .. });
         if let Some(event_tx) = &self.event_tx {
-            let _ = event_tx.send(event).await;
+            // Never wait for the application here. A subnet scan confirms up to
+            // 255 devices in a burst, far more than the channel holds, and
+            // every confirmation runs inside the scan's own concurrency limit:
+            // blocking on a full channel would stall the scan for good and
+            // leave its `ScanGuard` held, so the interface could never be
+            // scanned again.
+            //
+            // Dropping an event only costs a refresh. The device is in the
+            // store before the event is emitted, so it is still returned by
+            // the scan and by `devices()`.
+            if let Err(err) = event_tx.try_send(event) {
+                tracing::debug!("Dropped a discovery event: {err}");
+            }
         }
         (is_new, merged)
     }

--- a/packages/core/src/http/server/v2.rs
+++ b/packages/core/src/http/server/v2.rs
@@ -158,13 +158,21 @@ pub(crate) async fn register(
 
     if let Some(v2) = &state.v2 {
         if fingerprint_valid {
-            let _ = v2
-                .event_tx
-                .send(ServerEventV2::Register {
-                    ip: client_info.ip,
-                    info: payload,
-                })
-                .await;
+            // Not awaited: registrations arrive in bursts (every device on the
+            // network answers an announcement, and a peer scanning its subnet
+            // registers with everyone), so the channel fills up easily. Waiting
+            // would block this request handler — and every later one — until
+            // the application catches up, which is what makes the device stop
+            // answering `register` altogether.
+            //
+            // The event carries no responder, and peers repeat their
+            // announcement, so a dropped registration is recoverable.
+            if let Err(err) = v2.event_tx.try_send(ServerEventV2::Register {
+                ip: client_info.ip,
+                info: payload,
+            }) {
+                tracing::debug!("Dropped a register event: {err}");
+            }
         } else {
             tracing::warn!(
                 "Ignoring register from {}: claimed fingerprint does not match the client certificate",

--- a/packages/core/tests/event_backpressure.rs
+++ b/packages/core/tests/event_backpressure.rs
@@ -1,0 +1,175 @@
+#![cfg(feature = "discovery")]
+
+//! Emitting an informational event must never block the work that produced it.
+//!
+//! Registrations and discoveries arrive in bursts — a subnet scan confirms up
+//! to 255 devices, and every device on the network answers an announcement —
+//! while the event channels hold a handful of items. Waiting for the
+//! application to catch up would stall an HTTP request handler, or a scan, for
+//! as long as the application is busy.
+
+use localsend::crypto::cert::generate_self_signed;
+use localsend::discovery::{self, DeviceIdentity, DiscoveryConfig, DiscoveryEvent};
+use localsend::http::client::LsHttpClientV2;
+use localsend::http::dto_v2::RegisterDtoV2;
+use localsend::http::server::v2::ServerEventV2;
+use localsend::http::server::{start_with_port, ServerConfigV2};
+use localsend::http::state::ClientInfo;
+use localsend::model::discovery::{DeviceType, ProtocolType, PROTOCOL_VERSION_V2};
+use localsend::multicast::MulticastDevice;
+use std::net::Ipv4Addr;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+
+/// The capacity the isolate layer uses for both event channels.
+const CHANNEL_CAPACITY: usize = 16;
+
+fn free_port() -> u16 {
+    static PORT_COUNTER: AtomicU16 = AtomicU16::new(43551);
+
+    loop {
+        let port = PORT_COUNTER.fetch_add(1, Ordering::SeqCst);
+        if std::net::TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return port;
+        }
+    }
+}
+
+fn register_dto(port: u16) -> RegisterDtoV2 {
+    RegisterDtoV2 {
+        alias: "Probe".to_string(),
+        version: PROTOCOL_VERSION_V2.to_string(),
+        device_model: None,
+        device_type: None,
+        fingerprint: "probe-fingerprint".to_string(),
+        port,
+        protocol: ProtocolType::Http,
+        download: false,
+    }
+}
+
+/// Starts a v2 server whose event receiver is kept alive but never read, i.e.
+/// an application that is busy.
+async fn start_server_with_stalled_events(
+    port: u16,
+) -> (oneshot::Sender<()>, mpsc::Receiver<ServerEventV2>) {
+    let (event_tx, event_rx) = mpsc::channel::<ServerEventV2>(CHANNEL_CAPACITY);
+    let (stop_tx, stop_rx) = oneshot::channel();
+
+    start_with_port(
+        port,
+        None, // plain HTTP
+        ClientInfo {
+            alias: "Target".to_string(),
+            version: PROTOCOL_VERSION_V2.to_string(),
+            device_model: None,
+            device_type: Some(DeviceType::Headless),
+            token: "target-fingerprint".to_string(),
+        },
+        None,
+        Some(ServerConfigV2 {
+            pin: None,
+            verify_checksums: true,
+            event_tx,
+        }),
+        None,
+        stop_rx,
+    )
+    .await
+    .expect("Failed to start server");
+
+    for _ in 0..100 {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    (stop_tx, event_rx)
+}
+
+/// More registrations than the event channel holds must all be answered, even
+/// though the application reads none of them.
+#[tokio::test(flavor = "multi_thread")]
+async fn register_keeps_answering_when_events_are_not_consumed() {
+    let port = free_port();
+    let (_stop_tx, _event_rx) = start_server_with_stalled_events(port).await;
+
+    let cert = generate_self_signed().expect("Failed to generate an identity");
+    let client = LsHttpClientV2::try_new(
+        &cert.private_key_pem,
+        &cert.certificate_pem,
+        None,
+        Some(Duration::from_secs(2)),
+    )
+    .expect("client");
+
+    let requests = CHANNEL_CAPACITY * 4;
+    for i in 0..requests {
+        client
+            .register(ProtocolType::Http, "127.0.0.1", port, register_dto(port))
+            .await
+            .unwrap_or_else(|err| {
+                panic!("register #{i} was not answered ({requests} sent, channel holds {CHANNEL_CAPACITY}): {err}")
+            });
+    }
+}
+
+/// A scan that confirms more devices than the event channel holds must still
+/// finish and return them, even though the application reads no event.
+#[tokio::test(flavor = "multi_thread")]
+async fn subnet_scan_finishes_when_events_are_not_consumed() {
+    // Every 127.0.0.x address reaches this server, so the scan confirms the
+    // whole subnet at once.
+    let port = free_port();
+    let (_stop_tx, _server_event_rx) = start_server_with_stalled_events(port).await;
+
+    let cert = generate_self_signed().expect("Failed to generate an identity");
+    let (event_tx, _events) = mpsc::channel::<DiscoveryEvent>(CHANNEL_CAPACITY);
+    let (_discovery_stop_tx, discovery_stop_rx) = oneshot::channel();
+
+    let handle = discovery::start(
+        DiscoveryConfig {
+            group: Ipv4Addr::new(224, 0, 0, 171),
+            group_v6: None,
+            port: free_port(),
+            interface_filter: Default::default(),
+            device: MulticastDevice {
+                alias: "Scanner".to_string(),
+                version: PROTOCOL_VERSION_V2.to_string(),
+                device_model: None,
+                device_type: Some(DeviceType::Headless),
+                fingerprint: cert.fingerprint.clone(),
+                port,
+                protocol: ProtocolType::Http,
+                download: false,
+            },
+            identity: DeviceIdentity {
+                cert_pem: cert.certificate_pem,
+                private_key_pem: cert.private_key_pem,
+            },
+            timeout: discovery::DEFAULT_DISCOVERY_TIMEOUT,
+            event_tx: Some(event_tx),
+        },
+        discovery_stop_rx,
+    )
+    .await;
+
+    let found = tokio::time::timeout(
+        Duration::from_secs(30),
+        handle.scan_subnet(Ipv4Addr::new(127, 0, 0, 99), port, ProtocolType::Http),
+    )
+    .await
+    .expect("the scan blocked on the full event channel")
+    .expect("Subnet scan failed");
+
+    assert!(
+        found.len() > CHANNEL_CAPACITY,
+        "the scan must return every confirmed device, got {} for a channel of {CHANNEL_CAPACITY}",
+        found.len()
+    );
+}


### PR DESCRIPTION
`discovery::found` and the v2 `register` handler publish their event with
`send().await` on a channel bounded to 16 — the capacity the isolate layer uses.
When the application does not consume fast enough, the HTTP request handler and
the subnet scan wait for it, indefinitely.

Measured on a server whose events are not being read:

| | before | after |
|---|---|---|
| addresses answering `register` | 16 of 256, in 2.66 s | 256 of 256, in 205 ms |
| `scan_subnet` over a populated `/24` | never returns | 255 devices in 26 ms |

The scan holds its `ScanGuard` while blocked, so the interface can never be
scanned again either.

This is not theoretical: the repository's own
`discovery::test_subnet_scan_finds_device_on_loopback` does not terminate on
`main` — I stopped it after 400 s. On this branch it runs in 2.87 s. It went
unnoticed because no workflow runs the Rust tests.

## What this changes

Both events become `try_send`, with a trace when one is dropped. They are
informational: they carry no responder, the device is already in the store
before the event is emitted, and peers repeat their announcement, so a dropped
event costs a refresh rather than data.

## What this deliberately does not change

Events that carry a responder — `PrepareUpload`, `FileUpload` — keep their
`send().await`. Dropping one would break a session.


*Written with AI assistance