### PR TITLE
ci: run the Rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,33 @@ jobs:
         working-directory: packages/localsend_isolates
         run: flutter test
 
+  rust:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Rust
+        run: rustup toolchain install stable --profile minimal --component clippy
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      # `cargo fmt --check` is deliberately left out: the tree is not
+      # rustfmt-clean today, and `frb_generated.rs` never will be.
+      #
+      # `packages/core` declares its modules unconditionally while their
+      # dependencies are optional, so it only builds with a feature set that
+      # pulls all of them in.
+      - name: Clippy (core)
+        working-directory: packages/core
+        run: cargo clippy --features full --all-targets
+      - name: Test (core)
+        working-directory: packages/core
+        run: cargo test --features full
+      - name: Test (signaling server)
+        run: cargo test --package server
+      - name: Check (plugin crate, CLI)
+        run: cargo check --package rust_lib_localsend_app --package localsend-cli
+
   packaging:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
No Rust test runs in CI. The only `cargo` invocations across the eleven
workflows are two `cargo build --release --package localsend-cli`. So roughly
140 tests — protocol v2, crypto, HTTP server and client, TLS pinning, web send,
discovery, multicast, signaling server — never run.

That is how `discovery::test_subnet_scan_finds_device_on_loopback` came to hang
forever without anyone noticing.

## What this changes

A `rust` job: `clippy` and `cargo test --features full` on `packages/core`,
`cargo test` on the signaling server, `cargo check` on the plugin crate and the
CLI, with `Swatinem/rust-cache`.

`packages/core` is built with `--features full` because it declares its modules
unconditionally while their dependencies are optional — a bare `cargo check`
fails by design, as `AGENTS.md` documents.


*Written with AI assistance