### PR TITLE
fix: reject malformed tokens and oversized SDP from peers

### DIFF
--- a/packages/core/src/crypto/token.rs
+++ b/packages/core/src/crypto/token.rs
@@ -156,8 +156,13 @@ pub fn verify_token_timestamp(public_key: &dyn VerifyingTokenKey, token: &str) -
             )
         };
 
+        // `checked_sub` rejects timestamps from the future instead of
+        // underflowing on a salt the peer chose.
         let now_seconds = util::time::unix_timestamp_u64()?;
-        if now_seconds - salt > 60 * 60 {
+        let age = now_seconds
+            .checked_sub(salt)
+            .ok_or_else(|| anyhow::anyhow!("Fingerprint timestamp is in the future"))?;
+        if age > 60 * 60 {
             // Fingerprint is older than 1h, reject
             return Err(anyhow::anyhow!("Fingerprint timestamp expired"));
         }
@@ -183,8 +188,23 @@ pub fn verify_token_with_result(
     token: &str,
     verify_salt: impl Fn(&[u8]) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
-    let parts: Vec<&str> = token.split('.').collect();
-    let [hash_method, hash_base64, salt_base64, sign_method, signature_base64] = parts[0..5] else {
+    // Taken one by one instead of slicing a collected `Vec`: indexing a
+    // shorter one panics, and the token comes from the peer.
+    let mut parts = token.split('.');
+    let (
+        Some(hash_method),
+        Some(hash_base64),
+        Some(salt_base64),
+        Some(sign_method),
+        Some(signature_base64),
+    ) = (
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+    )
+    else {
         return Err(anyhow::anyhow!("Invalid structure"));
     };
 
@@ -254,6 +274,29 @@ mod tests {
         let fingerprint = generate_token_timestamp(&key).unwrap();
         let verified = verify_token_timestamp(&*key.to_verifying_key(), &fingerprint);
         assert!(verified);
+    }
+
+    /// A peer-supplied token with fewer than 5 dot-separated parts must be
+    /// rejected, not panic: the token is read straight off the WebRTC data
+    /// channel.
+    #[test]
+    fn test_malformed_token_is_rejected() {
+        let key = generate_key();
+        let verifying = key.to_verifying_key();
+        for token in ["", "a", "sha256.a", "sha256.a.b.ed25519"] {
+            assert!(!verify_token_nonce(&*verifying, token, b"nonce"));
+            assert!(!verify_token_timestamp(&*verifying, token));
+        }
+    }
+
+    /// A salt in the future must be rejected rather than underflow the age
+    /// computation.
+    #[test]
+    fn test_future_token_timestamp_is_rejected() {
+        let key = generate_key();
+        let future = (util::time::unix_timestamp_u64().unwrap() + 3600).to_le_bytes();
+        let token = generate_token_nonce(&key, &future).unwrap();
+        assert!(!verify_token_timestamp(&*key.to_verifying_key(), &token));
     }
 
     #[test]

--- a/packages/core/src/webrtc/webrtc.rs
+++ b/packages/core/src/webrtc/webrtc.rs
@@ -1259,14 +1259,34 @@ fn encode_sdp(s: &str) -> String {
     base64::encode(&compressed)
 }
 
+/// The largest SDP that is accepted from a peer, once decompressed.
+///
+/// A session description, ICE candidates included, is a few kilobytes; this
+/// leaves room for an unusually large one while keeping the decompressed size
+/// bounded.
+const MAX_SDP_SIZE: usize = 1024 * 1024;
+
 fn decode_sdp(s: &str) -> Result<String> {
     let decoded_data =
         base64::decode(s).map_err(|e| anyhow::anyhow!("Base64 decode of SDP failed: {e}"))?;
-    let mut d = ZlibDecoder::new(&*decoded_data);
-    let mut result = String::new();
-    d.read_to_string(&mut result)
+
+    // Bounded because the peer chose what to compress: zlib expands by up to
+    // ~1000x, so a payload of a few hundred kilobytes would otherwise be
+    // enough to exhaust this device's memory. The SDP is decoded before
+    // anything about the peer has been verified.
+    let mut decompressed = Vec::new();
+    ZlibDecoder::new(&*decoded_data)
+        .take(MAX_SDP_SIZE as u64 + 1)
+        .read_to_end(&mut decompressed)
         .map_err(|e| anyhow::anyhow!("Failed to decompress SDP: {e}"))?;
-    Ok(result)
+
+    if decompressed.len() > MAX_SDP_SIZE {
+        return Err(anyhow::anyhow!(
+            "SDP exceeds the limit of {MAX_SDP_SIZE} bytes"
+        ));
+    }
+
+    String::from_utf8(decompressed).map_err(|e| anyhow::anyhow!("SDP is not valid UTF-8: {e}"))
 }
 
 async fn send_delimiter(data_channel: &Arc<RTCDataChannel>) -> Result<()> {
@@ -1372,6 +1392,28 @@ fn to_receive_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An SDP a peer sends is zlib-compressed, and it is decoded before
+    /// anything about that peer has been verified. One that expands beyond the
+    /// limit must be refused instead of allocated, however small the payload
+    /// carrying it is.
+    #[test]
+    fn test_oversized_sdp_is_rejected() {
+        assert!(decode_sdp(&encode_sdp(&"a".repeat(MAX_SDP_SIZE + 1))).is_err());
+        assert_eq!(
+            decode_sdp(&encode_sdp(&"a".repeat(MAX_SDP_SIZE)))
+                .unwrap()
+                .len(),
+            MAX_SDP_SIZE
+        );
+    }
+
+    /// A normal SDP still round-trips.
+    #[test]
+    fn test_sdp_round_trip() {
+        let sdp = "v=0\r\no=- 4611731400430051336 2 IN IP4 127.0.0.1\r\ns=-\r\n".repeat(50);
+        assert_eq!(decode_sdp(&encode_sdp(&sdp)).unwrap(), sdp);
+    }
 
     #[tokio::test]
     async fn test_process_in_chunks() {


### PR DESCRIPTION
Two peer-supplied values are read straight off the WebRTC data channel, before
anything about the peer has been verified.

**`decode_sdp` decompresses without a bound.** 678 KiB of zlib expand to
512 MiB — a ratio of 773 to 1 — and the resident set follows.

**`verify_token_with_result` indexes `parts[0..5]`** on a `Vec` collected from
`split('.')`, which panics for any token with fewer than five segments:

```
panicked at packages/core/src/crypto/token.rs:187:87:
range end index 5 out of range for slice of length 1
```

`verify_token_timestamp` also subtracts a peer-chosen timestamp without
`checked_sub`.

## Scope

`webRTCEnabled` is `false` in the app, so this path does not run today. This is
hardening before it is switched on, not an urgent fix — and the panic aborts the
task, not the process, since no profile sets `panic = "abort"`.

## What this changes

The SDP is capped at 1 MiB once decompressed, far above any real session
description. The token segments are taken one by one instead of slicing a
collected `Vec`. The timestamp uses `checked_sub`.

AI assisted