### PR TITLE
fix(i18n): improve Traditional Chinese wording

### DIFF
--- a/app/assets/i18n/zh-TW.json
+++ b/app/assets/i18n/zh-TW.json
@@ -81,7 +81,7 @@
       "link": "透過連結分享"
     },
     "sendModeHelp": "說明",
-    "help": "請確保所需目標的處於相同的 Wi‑Fi 網路。",
+    "help": "請確認目標裝置也已連線至相同的 Wi‑Fi 網路。",
     "placeItems": "列出要分享的項目。"
   },
   "settingsTab": {
@@ -145,13 +145,13 @@
       "discoveryTimeout": "探索裝置逾時",
       "useSystemName": "使用系統名稱",
       "generateRandomAlias": "隨機產生別名",
-      "portWarning": "您可能無法被其他裝置偵測，因為您正在使用自訂通訊埠。(預設：{defaultPort})",
+      "portWarning": "您使用了自訂通訊埠，因此其他裝置可能無法偵測到您。（預設值：{defaultPort}）",
       "encryption": "加密",
-      "multicastGroup": "多點傳送",
-      "multicastGroupWarning": "您可能無法被其他裝置偵測，因為您正在使用自訂多點傳送位址。(預設：{defaultMulticast})"
+      "multicastGroup": "多點傳送位址",
+      "multicastGroupWarning": "您使用了自訂多點傳送位址，因此其他裝置可能無法偵測到您。（預設值：{defaultMulticast}）"
     },
     "other": {
-      "title": "其它",
+      "title": "其他",
       "support": "支持 LocalSend",
       "donate": "贊助",
       "privacyPolicy": "隱私權政策",
@@ -175,7 +175,7 @@
     },
     "noConnection": {
       "symptom": "兩部裝置無法探索彼此，也無法分享檔案。",
-      "solution": "雙方都存在問題？然後你需要確保兩部裝置處於相同的 Wi‑Fi 網路中並共用相同的組態 (通訊埠、多點傳送位址、加密選項)。Wi‑Fi 可能不允許參與者之間進行通訊。在這種狀況下，必須在路由器上停用「存取點 (AP) 隔離」選項。"
+      "solution": "兩部裝置都有這個問題嗎？若是，請確認兩部裝置已連線至相同的 Wi‑Fi 網路，且使用相同的設定（通訊埠、多點傳送位址、加密選項）。Wi‑Fi 網路可能因為啟用了「無線存取點（AP）隔離」而不允許裝置彼此通訊。請在路由器上停用此選項。"
     }
   },
   "networkInterfacesPage": {
@@ -443,9 +443,9 @@
     },
     "sendModeHelp": {
       "title": "傳送模式",
-      "single": "傳送檔案至單個接收者，選取項目將在檔案傳輸完成後被清除。",
-      "multiple": "傳送檔案至多重接收者，選取項目將不會被清除。",
-      "link": "未安裝 LocalSend 的接收者可以透過在瀏覽器開啟連結以下載選取的檔案."
+      "single": "傳送檔案給單一接收者；檔案傳輸完成後，系統會清除選取項目。",
+      "multiple": "傳送檔案給多位接收者；檔案傳輸完成後，系統不會清除選取項目。",
+      "link": "未安裝 LocalSend 的接收者可以在瀏覽器中開啟連結，以下載選取的檔案。"
     },
     "zoom": {
       "title": "網址"


### PR DESCRIPTION
## Summary

- fix an ungrammatical same-network hint
- clarify the multicast address label and normalize zh-TW punctuation
- rewrite the two-device troubleshooting guidance for clarity and consistent tone
- improve the send-mode explanations and fix a full-stop typo

This is a wording-only update; translation keys and placeholders are unchanged.

## Validation

- `jq empty app/assets/i18n/zh-TW.json`
- `git diff --check`
- compared scalar key paths before and after the change (no structural changes)