### PR TITLE
ci(winget): add LocalSend CLI publish

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,15 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal9/winget-releaser@main
+      - name: Publish LocalSend
+        uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: LocalSend.LocalSend
+          installers-regex: 'LocalSend-(?!CLI-).*\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}
+      - name: Publish LocalSend CLI
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: LocalSend.LocalSend.CLI
+          installers-regex: 'LocalSend-CLI-.*\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Update Winget Releaser workflow to also publish the new CLI version introduced in https://github.com/localsend/localsend/releases/tag/v1.18.0 (#11).

Initial PR for `LocalSend.LocalSend.CLI`:
- https://github.com/microsoft/winget-pkgs/pull/415597

---

P.S., can you take a look at the latest CI failure? https://github.com/localsend/localsend/actions/runs/31436708398/job/93612331896
<img width="1048" height="495" alt="image" src="https://github.com/user-attachments/assets/aad31306-04dc-4c19-975c-7ac53f6e5054" />
