### PR TITLE
feat: discover devices over a Tailscale tailnet

### DIFF
--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -147,6 +147,8 @@
       "generateRandomAlias": "Generate random alias",
       "portWarning": "You might not be detected by other devices because you are using a custom port. (default: {defaultPort})",
       "encryption": "Encryption",
+      "tailnetDiscovery": "Discover Tailscale devices",
+      "@tailnetDiscovery": "Setting to also find devices that are reachable over a Tailscale tailnet, but not on the same local network. Tailscale is a VPN product; keep the product name untranslated.",
       "multicastGroup": "Multicast address",
       "multicastGroupWarning": "You might not be detected by other devices because you are using a custom multicast address. (default: {defaultMulticast})"
     },

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -167,6 +167,7 @@ Future<RefenaContainer> preInit(List<String> args) async {
             protocol: settings.https ? ProtocolType.https : ProtocolType.http,
             multicastGroup: settings.multicastGroup,
             discoveryTimeout: settings.discoveryTimeout,
+            tailnet: settings.tailnetDiscovery,
             serverRunning: true,
             download: false,
           ),

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 58
-/// Strings: 21022 (362 per locale)
+/// Strings: 21023 (362 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -1205,6 +1205,11 @@ class Translations$settingsTab$network$en {
   /// en: 'Encryption'
   String get encryption => 'Encryption';
 
+  /// Setting to also find devices that are reachable over a Tailscale tailnet, but not on the same local network. Tailscale is a VPN product; keep the product name untranslated.
+  ///
+  /// en: 'Discover Tailscale devices'
+  String get tailnetDiscovery => 'Discover Tailscale devices';
+
   /// en: 'Multicast address'
   String get multicastGroup => 'Multicast address';
 

--- a/app/lib/model/persistence/tailnet_peer.dart
+++ b/app/lib/model/persistence/tailnet_peer.dart
@@ -1,0 +1,34 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'tailnet_peer.mapper.dart';
+
+/// A peer this device has seen at a tailnet address, persisted so that a
+/// device which cannot enumerate the tailnet (Android, iOS) can still probe
+/// its known peers after an app restart.
+///
+/// Without this list such a device depends on being probed first: a tailnet
+/// carries no announcements and cannot be scanned, so a restart would lose
+/// every peer until one of them happens to probe this device again.
+@MappableClass()
+class TailnetPeer with TailnetPeerMappable {
+  final String fingerprint;
+
+  /// The alias the device most recently carried, for display and debugging;
+  /// the probe itself only needs the address.
+  final String alias;
+
+  /// The tailnet address the peer was last confirmed on.
+  final String ip;
+
+  /// The port of the peer's HTTP server.
+  final int port;
+
+  const TailnetPeer({
+    required this.fingerprint,
+    required this.alias,
+    required this.ip,
+    required this.port,
+  });
+
+  static const fromJson = TailnetPeerMapper.fromJson;
+}

--- a/app/lib/model/persistence/tailnet_peer.mapper.dart
+++ b/app/lib/model/persistence/tailnet_peer.mapper.dart
@@ -1,0 +1,149 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_use_of_protected_member
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'tailnet_peer.dart';
+
+class TailnetPeerMapper extends ClassMapperBase<TailnetPeer> {
+  TailnetPeerMapper._();
+
+  static TailnetPeerMapper? _instance;
+  static TailnetPeerMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TailnetPeerMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TailnetPeer';
+
+  static String _$fingerprint(TailnetPeer v) => v.fingerprint;
+  static const Field<TailnetPeer, String> _f$fingerprint = Field(
+    'fingerprint',
+    _$fingerprint,
+  );
+  static String _$alias(TailnetPeer v) => v.alias;
+  static const Field<TailnetPeer, String> _f$alias = Field('alias', _$alias);
+  static String _$ip(TailnetPeer v) => v.ip;
+  static const Field<TailnetPeer, String> _f$ip = Field('ip', _$ip);
+  static int _$port(TailnetPeer v) => v.port;
+  static const Field<TailnetPeer, int> _f$port = Field('port', _$port);
+
+  @override
+  final MappableFields<TailnetPeer> fields = const {
+    #fingerprint: _f$fingerprint,
+    #alias: _f$alias,
+    #ip: _f$ip,
+    #port: _f$port,
+  };
+
+  static TailnetPeer _instantiate(DecodingData data) {
+    return TailnetPeer(
+      fingerprint: data.dec(_f$fingerprint),
+      alias: data.dec(_f$alias),
+      ip: data.dec(_f$ip),
+      port: data.dec(_f$port),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TailnetPeer fromJson(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TailnetPeer>(map);
+  }
+
+  static TailnetPeer deserialize(String json) {
+    return ensureInitialized().decodeJson<TailnetPeer>(json);
+  }
+}
+
+mixin TailnetPeerMappable {
+  String serialize() {
+    return TailnetPeerMapper.ensureInitialized().encodeJson<TailnetPeer>(
+      this as TailnetPeer,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return TailnetPeerMapper.ensureInitialized().encodeMap<TailnetPeer>(
+      this as TailnetPeer,
+    );
+  }
+
+  TailnetPeerCopyWith<TailnetPeer, TailnetPeer, TailnetPeer> get copyWith =>
+      _TailnetPeerCopyWithImpl<TailnetPeer, TailnetPeer>(
+        this as TailnetPeer,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return TailnetPeerMapper.ensureInitialized().stringifyValue(
+      this as TailnetPeer,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TailnetPeerMapper.ensureInitialized().equalsValue(
+      this as TailnetPeer,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return TailnetPeerMapper.ensureInitialized().hashValue(this as TailnetPeer);
+  }
+}
+
+extension TailnetPeerValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TailnetPeer, $Out> {
+  TailnetPeerCopyWith<$R, TailnetPeer, $Out> get $asTailnetPeer =>
+      $base.as((v, t, t2) => _TailnetPeerCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class TailnetPeerCopyWith<$R, $In extends TailnetPeer, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? fingerprint, String? alias, String? ip, int? port});
+  TailnetPeerCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _TailnetPeerCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TailnetPeer, $Out>
+    implements TailnetPeerCopyWith<$R, TailnetPeer, $Out> {
+  _TailnetPeerCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TailnetPeer> $mapper =
+      TailnetPeerMapper.ensureInitialized();
+  @override
+  $R call({String? fingerprint, String? alias, String? ip, int? port}) =>
+      $apply(
+        FieldCopyWithData({
+          if (fingerprint != null) #fingerprint: fingerprint,
+          if (alias != null) #alias: alias,
+          if (ip != null) #ip: ip,
+          if (port != null) #port: port,
+        }),
+      );
+  @override
+  TailnetPeer $make(CopyWithData data) => TailnetPeer(
+    fingerprint: data.get(#fingerprint, or: $value.fingerprint),
+    alias: data.get(#alias, or: $value.alias),
+    ip: data.get(#ip, or: $value.ip),
+    port: data.get(#port, or: $value.port),
+  );
+
+  @override
+  TailnetPeerCopyWith<$R2, TailnetPeer, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _TailnetPeerCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -38,6 +38,7 @@ class SettingsState with SettingsStateMappable {
   final bool createChecksums; // create checksums when sending files
   final bool verifyChecksums; // verify checksums when receiving files
   final int discoveryTimeout;
+  final bool tailnetDiscovery; // also discover devices reachable over Tailscale
   final bool advancedSettings;
 
   const SettingsState({
@@ -70,6 +71,7 @@ class SettingsState with SettingsStateMappable {
     required this.createChecksums,
     required this.verifyChecksums,
     required this.discoveryTimeout,
+    required this.tailnetDiscovery,
     required this.advancedSettings,
   });
 }

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -164,6 +164,11 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     'discoveryTimeout',
     _$discoveryTimeout,
   );
+  static bool _$tailnetDiscovery(SettingsState v) => v.tailnetDiscovery;
+  static const Field<SettingsState, bool> _f$tailnetDiscovery = Field(
+    'tailnetDiscovery',
+    _$tailnetDiscovery,
+  );
   static bool _$advancedSettings(SettingsState v) => v.advancedSettings;
   static const Field<SettingsState, bool> _f$advancedSettings = Field(
     'advancedSettings',
@@ -201,6 +206,7 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #createChecksums: _f$createChecksums,
     #verifyChecksums: _f$verifyChecksums,
     #discoveryTimeout: _f$discoveryTimeout,
+    #tailnetDiscovery: _f$tailnetDiscovery,
     #advancedSettings: _f$advancedSettings,
   };
 
@@ -235,6 +241,7 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
       createChecksums: data.dec(_f$createChecksums),
       verifyChecksums: data.dec(_f$verifyChecksums),
       discoveryTimeout: data.dec(_f$discoveryTimeout),
+      tailnetDiscovery: data.dec(_f$tailnetDiscovery),
       advancedSettings: data.dec(_f$advancedSettings),
     );
   }
@@ -335,6 +342,7 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out>
     bool? createChecksums,
     bool? verifyChecksums,
     int? discoveryTimeout,
+    bool? tailnetDiscovery,
     bool? advancedSettings,
   });
   SettingsStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
@@ -397,6 +405,7 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     bool? createChecksums,
     bool? verifyChecksums,
     int? discoveryTimeout,
+    bool? tailnetDiscovery,
     bool? advancedSettings,
   }) => $apply(
     FieldCopyWithData({
@@ -433,6 +442,7 @@ class _SettingsStateCopyWithImpl<$R, $Out>
       if (createChecksums != null) #createChecksums: createChecksums,
       if (verifyChecksums != null) #verifyChecksums: verifyChecksums,
       if (discoveryTimeout != null) #discoveryTimeout: discoveryTimeout,
+      if (tailnetDiscovery != null) #tailnetDiscovery: tailnetDiscovery,
       if (advancedSettings != null) #advancedSettings: advancedSettings,
     }),
   );
@@ -479,6 +489,7 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     createChecksums: data.get(#createChecksums, or: $value.createChecksums),
     verifyChecksums: data.get(#verifyChecksums, or: $value.verifyChecksums),
     discoveryTimeout: data.get(#discoveryTimeout, or: $value.discoveryTimeout),
+    tailnetDiscovery: data.get(#tailnetDiscovery, or: $value.tailnetDiscovery),
     advancedSettings: data.get(#advancedSettings, or: $value.advancedSettings),
   );
 

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -479,6 +479,14 @@ class SettingsTab extends StatelessWidget {
                     },
                   ),
                 if (vm.advanced)
+                  _BooleanEntry(
+                    label: t.settingsTab.network.tailnetDiscovery,
+                    value: vm.settings.tailnetDiscovery,
+                    onChanged: (b) async {
+                      await ref.notifier(settingsProvider).setTailnetDiscovery(b);
+                    },
+                  ),
+                if (vm.advanced)
                   _SettingsEntry(
                     label: t.settingsTab.network.multicastGroup,
                     child: TextFieldTv(

--- a/app/lib/provider/device_info_provider.dart
+++ b/app/lib/provider/device_info_provider.dart
@@ -33,7 +33,13 @@ final deviceFullInfoProvider = ViewProvider((ref) {
   final networkInfo = ref.watch(localIpProvider);
   final serverState = ref.watch(serverProvider);
   final rawInfo = ref.watch(deviceInfoProvider);
-  final securityContext = ref.read(securityProvider);
+  // Watched, not read: the manual register probes built from this device
+  // send this fingerprint as the payload while the HTTP client presents the
+  // certificate from [securityProvider] directly. A stale cached value after
+  // a security-context reset would make every peer silently ignore those
+  // registers, because the claimed fingerprint no longer matches the client
+  // certificate of the request.
+  final securityContext = ref.watch(securityProvider);
   return Device(
     signalingId: null,
     ip: networkInfo.localIps.firstOrNull ?? '-',

--- a/app/lib/provider/network/nearby_devices_provider.dart
+++ b/app/lib/provider/network/nearby_devices_provider.dart
@@ -5,6 +5,7 @@ import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/model/state/nearby_devices_state.dart';
 import 'package:localsend_app/provider/favorites_provider.dart';
 import 'package:localsend_app/provider/logging/discovery_logs_provider.dart';
+import 'package:localsend_app/provider/tailnet_peers_provider.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/device.dart';
 import 'package:refena_flutter/refena_flutter.dart';
@@ -18,6 +19,7 @@ final nearbyDevicesProvider = ReduxProvider<NearbyDevicesService, NearbyDevicesS
   return NearbyDevicesService(
     isolateController: ref.notifier(parentIsolateProvider),
     favoriteService: ref.notifier(favoritesProvider),
+    tailnetPeersService: ref.notifier(tailnetPeersProvider),
     discoveryLogs: ref.notifier(discoveryLoggerProvider),
   );
 });
@@ -25,15 +27,18 @@ final nearbyDevicesProvider = ReduxProvider<NearbyDevicesService, NearbyDevicesS
 class NearbyDevicesService extends ReduxNotifier<NearbyDevicesState> {
   final IsolateController _isolateController;
   final FavoritesService _favoriteService;
+  final TailnetPeersService _tailnetPeersService;
   final DiscoveryLogger _discoveryLogger;
 
   NearbyDevicesService({
     required IsolateController isolateController,
     required FavoritesService favoriteService,
+    required TailnetPeersService tailnetPeersService,
     required DiscoveryLogger discoveryLogs,
   }) : _discoveryLogger = discoveryLogs,
        _isolateController = isolateController,
-       _favoriteService = favoriteService;
+       _favoriteService = favoriteService,
+       _tailnetPeersService = tailnetPeersService;
 
   @override
   NearbyDevicesState init() => const NearbyDevicesState(
@@ -93,6 +98,12 @@ class RegisterDeviceAction extends AsyncReduxAction<NearbyDevicesService, Nearby
     } else {
       await Future.microtask(() {});
     }
+
+    // A device confirmed at a tailnet address is remembered across restarts,
+    // because over the tailnet nothing else can ever find it again.
+    // A no-op for every other device.
+    await external(notifier._tailnetPeersService).dispatchAsync(UpsertTailnetPeerAction(device));
+
     return state.copyWith(
       devices: {...state.devices}..update(device.fingerprint, (_) => device, ifAbsent: () => device),
     );
@@ -195,6 +206,13 @@ class StartLegacyScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevic
 /// This method awaits until every stage is finished.
 class StartStagedScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevicesState> {
   final List<FavoriteDevice> favorites;
+
+  /// The persisted tailnet peers, probed like favorites. They are all a
+  /// device that cannot enumerate its tailnet has after a restart, see
+  /// [tailnetPeersProvider]; the Rust side gives a tailnet address the
+  /// patient timeout such a probe needs.
+  final List<(String, int)> tailnetChannels;
+
   final List<String> interfaces;
   final int port;
   final bool https;
@@ -202,6 +220,7 @@ class StartStagedScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevic
 
   StartStagedScan({
     required this.favorites,
+    required this.tailnetChannels,
     required this.interfaces,
     required this.port,
     required this.https,
@@ -217,7 +236,7 @@ class StartStagedScan extends AsyncReduxAction<NearbyDevicesService, NearbyDevic
     await external(notifier._isolateController)
         .dispatchTakeResult(
           IsolateDiscoveryStagedScanAction(
-            favorites: favorites.map((e) => (e.ip, e.port)).toList(),
+            favorites: {...favorites.map((e) => (e.ip, e.port)), ...tailnetChannels}.toList(),
             networkInterfaces: interfaces,
             port: port,
             https: https,

--- a/app/lib/provider/network/scan_facade.dart
+++ b/app/lib/provider/network/scan_facade.dart
@@ -4,6 +4,7 @@ import 'package:localsend_app/provider/favorites_provider.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
 import 'package:localsend_app/provider/network/nearby_devices_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/provider/tailnet_peers_provider.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 
 /// Discovers devices in stages, cheapest first: multicast announcement and
@@ -17,6 +18,7 @@ class StartSmartScan extends AsyncGlobalAction {
   @override
   Future<void> reduce() async {
     final favorites = ref.read(favoritesProvider);
+    final tailnetPeers = ref.read(tailnetPeersProvider);
     final settings = ref.read(settingsProvider);
     final networkInterfaces = ref.read(localIpProvider).localIps.take(maxInterfaces).toList();
 
@@ -25,6 +27,7 @@ class StartSmartScan extends AsyncGlobalAction {
         .dispatchAsync(
           StartStagedScan(
             favorites: favorites,
+            tailnetChannels: tailnetPeers.map((e) => (e.ip, e.port)).toList(),
             interfaces: networkInterfaces,
             port: settings.port,
             https: settings.https,
@@ -45,13 +48,28 @@ class StartLegacySubnetScan extends AsyncGlobalAction {
   @override
   Future<void> reduce() async {
     final settings = ref.read(settingsProvider);
+    final tailnetPeers = ref.read(tailnetPeersProvider);
     final port = settings.port;
     final https = settings.https;
 
-    // send announcement in parallel
-    ref.redux(nearbyDevicesProvider).dispatch(StartMulticastScan());
-
     await Future.wait<void>([
+      // The announcement runs inside the staged scan, which also probes the
+      // tailnet: the user picked one subnet to scan, but the tailnet is
+      // reachable regardless of which interface that is, and skipping it
+      // here would silently lose exactly the peers no subnet scan can find.
+      // No favorites and no interfaces: the selected subnet is scanned below.
+      ref
+          .redux(nearbyDevicesProvider)
+          .dispatchAsync(
+            StartStagedScan(
+              favorites: const [],
+              tailnetChannels: tailnetPeers.map((e) => (e.ip, e.port)).toList(),
+              interfaces: const [],
+              port: port,
+              https: https,
+              grace: Duration.zero,
+            ),
+          ),
       for (final subnet in subnets) ref.redux(nearbyDevicesProvider).dispatchAsync(StartLegacyScan(port: port, localIp: subnet, https: https)),
     ]);
   }

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -25,6 +25,7 @@ import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/util/native/directories.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
+import 'package:localsend_app/util/tailnet_address.dart';
 import 'package:localsend_app/widget/dialogs/open_file_dialog.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/device.dart';
@@ -87,6 +88,20 @@ class ReceiveController {
     // self-reported fingerprint in the JSON payload which is only used as fallback
     // when encryption is disabled.
     final senderFingerprint = event.certFingerprint ?? event.info.fingerprint;
+
+    if (isTailnetAddress(event.ip)) {
+      // Over a tailnet this upload may be the only contact this device ever
+      // gets: there is no announcement to hear, no subnet to scan, and on
+      // Android and iOS the tailnet cannot be enumerated. Feed the sender
+      // into discovery so it can be replied to. A LAN sender is deliberately
+      // not fed — announcements already cover it, and receiving a file is
+      // not supposed to change what a LAN scan shows.
+      server.ref
+          .redux(parentIsolateProvider)
+          .dispatch(
+            IsolateDiscoveryAddDeviceAction(device: event.info.toDevice(event.ip, withChannel: true).copyWith(fingerprint: senderFingerprint)),
+          );
+    }
 
     _logger.info('Session Id: $sessionId');
     _logger.info('Destination Directory: $destinationDir');

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -9,6 +9,7 @@ import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/model/persistence/quick_save_mode.dart';
 import 'package:localsend_app/model/persistence/receive_history_entry.dart';
+import 'package:localsend_app/model/persistence/tailnet_peer.dart';
 import 'package:localsend_app/model/send_mode.dart';
 import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/util/alias_generator.dart';
@@ -58,6 +59,9 @@ const _receiveHistory = 'ls_receive_history';
 // Favorites
 const _favorites = 'ls_favorites';
 
+// Tailnet peers this device has seen
+const _tailnetPeers = 'ls_tailnet_peers';
+
 // App Window Offset and Size info
 const _windowOffsetX = 'ls_window_offset_x';
 const _windowOffsetY = 'ls_window_offset_y';
@@ -77,6 +81,7 @@ const _networkWhitelistKey = 'ls_network_whitelist';
 const _networkBlacklistKey = 'ls_network_blacklist';
 const _timeoutKey = 'ls_timeout';
 const _multicastGroupKey = 'ls_multicast_group';
+const _tailnetDiscoveryKey = 'ls_tailnet_discovery';
 const _destinationKey = 'ls_destination';
 const _saveToGallery = 'ls_save_to_gallery';
 const _saveToHistory = 'ls_save_to_history';
@@ -272,6 +277,16 @@ class PersistenceService {
     await _prefs.setStringList(_favorites, favoritesRaw);
   }
 
+  List<TailnetPeer> getTailnetPeers() {
+    final peersRaw = _prefs.getStringList(_tailnetPeers) ?? [];
+    return peersRaw.map((entry) => TailnetPeer.fromJson(jsonDecode(entry))).toList();
+  }
+
+  Future<void> setTailnetPeers(List<TailnetPeer> peers) async {
+    final peersRaw = peers.map((entry) => jsonEncode(entry.toJson())).toList();
+    await _prefs.setStringList(_tailnetPeers, peersRaw);
+  }
+
   String getShowToken() {
     return _prefs.getString(_showToken)!;
   }
@@ -411,6 +426,17 @@ class PersistenceService {
 
   String getMulticastGroup() {
     return _prefs.getString(_multicastGroupKey) ?? defaultMulticastGroup;
+  }
+
+  /// Whether discovery also probes the peers of this device's tailnet.
+  /// On by default: it costs a single failed socket connect on a device that
+  /// has no Tailscale installed.
+  bool isTailnetDiscovery() {
+    return _prefs.getBool(_tailnetDiscoveryKey) ?? true;
+  }
+
+  Future<void> setTailnetDiscovery(bool tailnetDiscovery) async {
+    await _prefs.setBool(_tailnetDiscoveryKey, tailnetDiscovery);
   }
 
   Future<void> setMulticastGroup(String group) async {

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -21,7 +21,8 @@ final settingsProvider = NotifierProvider<SettingsService, SettingsState>(
     if (_listEq(syncState.networkWhitelist, next.networkWhitelist) &&
         _listEq(syncState.networkBlacklist, next.networkBlacklist) &&
         syncState.multicastGroup == next.multicastGroup &&
-        syncState.discoveryTimeout == next.discoveryTimeout) {
+        syncState.discoveryTimeout == next.discoveryTimeout &&
+        syncState.tailnet == next.tailnetDiscovery) {
       return;
     }
 
@@ -33,6 +34,7 @@ final settingsProvider = NotifierProvider<SettingsService, SettingsState>(
             networkBlacklist: next.networkBlacklist,
             multicastGroup: next.multicastGroup,
             discoveryTimeout: next.discoveryTimeout,
+            tailnet: next.tailnetDiscovery,
           ),
         );
   },
@@ -74,6 +76,7 @@ class SettingsService extends PureNotifier<SettingsState> {
     createChecksums: _persistence.getCreateChecksums(),
     verifyChecksums: _persistence.getVerifyChecksums(),
     discoveryTimeout: _persistence.getDiscoveryTimeout(),
+    tailnetDiscovery: _persistence.isTailnetDiscovery(),
     advancedSettings: _persistence.getAdvancedSettingsEnabled(),
   );
 
@@ -144,6 +147,13 @@ class SettingsService extends PureNotifier<SettingsState> {
     await _persistence.setDiscoveryTimeout(timeout);
     state = state.copyWith(
       discoveryTimeout: timeout,
+    );
+  }
+
+  Future<void> setTailnetDiscovery(bool tailnetDiscovery) async {
+    await _persistence.setTailnetDiscovery(tailnetDiscovery);
+    state = state.copyWith(
+      tailnetDiscovery: tailnetDiscovery,
     );
   }
 

--- a/app/lib/provider/tailnet_peers_provider.dart
+++ b/app/lib/provider/tailnet_peers_provider.dart
@@ -1,0 +1,65 @@
+import 'package:collection/collection.dart';
+import 'package:localsend_app/model/persistence/tailnet_peer.dart';
+import 'package:localsend_app/provider/persistence_provider.dart';
+import 'package:localsend_app/util/tailnet_address.dart';
+import 'package:localsend_isolates/model/device.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+/// How many tailnet peers are persisted. Enough for a personal tailnet;
+/// bounded so that the scan cost and the preference entry cannot be grown
+/// without limit from the network.
+const _maxTailnetPeers = 16;
+
+/// The tailnet peers this device has seen, persisted across restarts.
+///
+/// Every staged scan probes them: a tailnet carries no announcements and
+/// cannot be scanned, so these stored addresses — plus the local daemon's
+/// peer list, on platforms that can enumerate it — are all discovery has
+/// there. See [TailnetPeer] for why they must survive a restart.
+final tailnetPeersProvider = ReduxProvider<TailnetPeersService, List<TailnetPeer>>((ref) {
+  return TailnetPeersService(ref.read(persistenceProvider));
+});
+
+class TailnetPeersService extends ReduxNotifier<List<TailnetPeer>> {
+  final PersistenceService _persistence;
+
+  TailnetPeersService(this._persistence);
+
+  @override
+  List<TailnetPeer> init() => _persistence.getTailnetPeers();
+}
+
+/// Remembers the tailnet address of a confirmed device, replacing the
+/// device's previous entry. Does nothing for a device without one.
+class UpsertTailnetPeerAction extends AsyncReduxAction<TailnetPeersService, List<TailnetPeer>> {
+  final Device device;
+
+  UpsertTailnetPeerAction(this.device);
+
+  @override
+  Future<List<TailnetPeer>> reduce() async {
+    // The channels are best first, so the first tailnet channel is the one
+    // most recently confirmed.
+    final channel = device.channels.whereType<HttpChannel>().firstWhereOrNull((channel) => isTailnetAddress(channel.host));
+    if (channel == null) {
+      await Future.microtask(() {});
+      return state;
+    }
+
+    final peer = TailnetPeer(fingerprint: device.fingerprint, alias: device.alias, ip: channel.host, port: channel.port);
+    if (state.contains(peer)) {
+      // Confirmations arrive in bursts; only a change is worth a write.
+      await Future.microtask(() {});
+      return state;
+    }
+
+    // Newest last, so the cap drops the least recently confirmed peer.
+    final updated = [
+      ...state.where((e) => e.fingerprint != peer.fingerprint),
+      peer,
+    ];
+    final capped = List<TailnetPeer>.unmodifiable(updated.length > _maxTailnetPeers ? updated.sublist(updated.length - _maxTailnetPeers) : updated);
+    await notifier._persistence.setTailnetPeers(capped);
+    return capped;
+  }
+}

--- a/app/lib/util/tailnet_address.dart
+++ b/app/lib/util/tailnet_address.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+/// Whether [host] is an address a tailnet handed out, i.e. one that can only
+/// be reached through the tunnel.
+///
+/// The Dart mirror of `is_tailnet_address` in `packages/core/src/tailscale/`,
+/// for the app-side decisions (persisting a tailnet peer, feeding a transfer
+/// sender into discovery) that happen before Rust is involved. Keep the two
+/// in sync.
+///
+/// The IPv4 range `100.64.0.0/10` is shared carrier-grade NAT space rather
+/// than Tailscale's own, so a LAN behind a CGNAT ISP matches too; treating
+/// such a peer as a tailnet one is the harmless direction of that ambiguity.
+/// `fd7a:115c:a1e0::/48` is Tailscale's fixed IPv6 prefix. Accepts the scoped
+/// form `fe80::1%3` and answers `false` for a host that is not an address.
+bool isTailnetAddress(String host) {
+  // Strip the scope of a link-local address, which never is a tailnet one
+  // but has to parse rather than fall through as a malformed host.
+  final bare = host.split('%').first;
+  final address = InternetAddress.tryParse(bare);
+  if (address == null) {
+    return false;
+  }
+
+  final bytes = address.rawAddress;
+  return switch (address.type) {
+    InternetAddressType.IPv4 => bytes[0] == 100 && (bytes[1] & 0xc0) == 0x40,
+    InternetAddressType.IPv6 => bytes[0] == 0xfd && bytes[1] == 0x7a && bytes[2] == 0x11 && bytes[3] == 0x5c && bytes[4] == 0xa1 && bytes[5] == 0xe0,
+    _ => false,
+  };
+}

--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -18,5 +18,12 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<!-- See Release.entitlements: without these the sandbox hides the local
+	     Tailscale daemon's LocalAPI and tailnet discovery finds nothing. -->
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<array>
+		<string>/Library/Group Containers/W5364U7YZB.group.io.tailscale.ipn.macos/</string>
+		<string>/Library/Group Containers/io.tailscale.ipn.macsys/</string>
+	</array>
 </dict>
 </plist>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -18,5 +18,18 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<!-- Tailnet discovery asks the local Tailscale daemon for the peer list
+	     over its LocalAPI. On macOS that daemon publishes no unix socket: it
+	     listens on loopback and proves the caller is the same user by the
+	     name of a file in its own group container. The sandbox denies both
+	     listing and reading that container, so without these two paths the
+	     app cannot enumerate its tailnet at all, and it then stays invisible
+	     to every device that cannot enumerate either — phones above all.
+	     Read-only, and only these two directories: the parent stays denied. -->
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<array>
+		<string>/Library/Group Containers/W5364U7YZB.group.io.tailscale.ipn.macos/</string>
+		<string>/Library/Group Containers/io.tailscale.ipn.macsys/</string>
+	</array>
 </dict>
 </plist>

--- a/app/test/mocks.mocks.dart
+++ b/app/test/mocks.mocks.dart
@@ -6,19 +6,20 @@
 import 'dart:async' as _i5;
 import 'dart:ui' as _i3;
 
-import 'package:flutter/material.dart' as _i9;
-import 'package:localsend_app/gen/strings.g.dart' as _i11;
-import 'package:localsend_app/model/persistence/color_mode.dart' as _i10;
+import 'package:flutter/material.dart' as _i10;
+import 'package:localsend_app/gen/strings.g.dart' as _i12;
+import 'package:localsend_app/model/persistence/color_mode.dart' as _i11;
 import 'package:localsend_app/model/persistence/favorite_device.dart' as _i7;
-import 'package:localsend_app/model/persistence/quick_save_mode.dart' as _i12;
+import 'package:localsend_app/model/persistence/quick_save_mode.dart' as _i13;
 import 'package:localsend_app/model/persistence/receive_history_entry.dart' as _i6;
-import 'package:localsend_app/model/send_mode.dart' as _i13;
+import 'package:localsend_app/model/persistence/tailnet_peer.dart' as _i8;
+import 'package:localsend_app/model/send_mode.dart' as _i14;
 import 'package:localsend_app/provider/persistence_provider.dart' as _i4;
-import 'package:localsend_isolates/model/device.dart' as _i14;
+import 'package:localsend_isolates/model/device.dart' as _i15;
 import 'package:localsend_isolates/model/stored_security_context.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i8;
-import 'package:shared_preferences/shared_preferences.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i9;
+import 'package:shared_preferences/shared_preferences.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -144,14 +145,32 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as _i5.Future<void>);
 
   @override
+  List<_i8.TailnetPeer> getTailnetPeers() =>
+      (super.noSuchMethod(
+            Invocation.method(#getTailnetPeers, []),
+            returnValue: <_i8.TailnetPeer>[],
+            returnValueForMissingStub: <_i8.TailnetPeer>[],
+          )
+          as List<_i8.TailnetPeer>);
+
+  @override
+  _i5.Future<void> setTailnetPeers(List<_i8.TailnetPeer>? peers) =>
+      (super.noSuchMethod(
+            Invocation.method(#setTailnetPeers, [peers]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
   String getShowToken() =>
       (super.noSuchMethod(
             Invocation.method(#getShowToken, []),
-            returnValue: _i8.dummyValue<String>(
+            returnValue: _i9.dummyValue<String>(
               this,
               Invocation.method(#getShowToken, []),
             ),
-            returnValueForMissingStub: _i8.dummyValue<String>(
+            returnValueForMissingStub: _i9.dummyValue<String>(
               this,
               Invocation.method(#getShowToken, []),
             ),
@@ -162,11 +181,11 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
   String getAlias() =>
       (super.noSuchMethod(
             Invocation.method(#getAlias, []),
-            returnValue: _i8.dummyValue<String>(
+            returnValue: _i9.dummyValue<String>(
               this,
               Invocation.method(#getAlias, []),
             ),
-            returnValueForMissingStub: _i8.dummyValue<String>(
+            returnValueForMissingStub: _i9.dummyValue<String>(
               this,
               Invocation.method(#getAlias, []),
             ),
@@ -183,16 +202,16 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as _i5.Future<void>);
 
   @override
-  _i9.ThemeMode getTheme() =>
+  _i10.ThemeMode getTheme() =>
       (super.noSuchMethod(
             Invocation.method(#getTheme, []),
-            returnValue: _i9.ThemeMode.system,
-            returnValueForMissingStub: _i9.ThemeMode.system,
+            returnValue: _i10.ThemeMode.system,
+            returnValueForMissingStub: _i10.ThemeMode.system,
           )
-          as _i9.ThemeMode);
+          as _i10.ThemeMode);
 
   @override
-  _i5.Future<void> setTheme(_i9.ThemeMode? theme) =>
+  _i5.Future<void> setTheme(_i10.ThemeMode? theme) =>
       (super.noSuchMethod(
             Invocation.method(#setTheme, [theme]),
             returnValue: _i5.Future<void>.value(),
@@ -201,16 +220,16 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as _i5.Future<void>);
 
   @override
-  _i10.ColorMode getColorMode() =>
+  _i11.ColorMode getColorMode() =>
       (super.noSuchMethod(
             Invocation.method(#getColorMode, []),
-            returnValue: _i10.ColorMode.system,
-            returnValueForMissingStub: _i10.ColorMode.system,
+            returnValue: _i11.ColorMode.system,
+            returnValueForMissingStub: _i11.ColorMode.system,
           )
-          as _i10.ColorMode);
+          as _i11.ColorMode);
 
   @override
-  _i5.Future<void> setColorMode(_i10.ColorMode? color) =>
+  _i5.Future<void> setColorMode(_i11.ColorMode? color) =>
       (super.noSuchMethod(
             Invocation.method(#setColorMode, [color]),
             returnValue: _i5.Future<void>.value(),
@@ -243,7 +262,7 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setLocale(_i11.AppLocale? locale) =>
+  _i5.Future<void> setLocale(_i12.AppLocale? locale) =>
       (super.noSuchMethod(
             Invocation.method(#setLocale, [locale]),
             returnValue: _i5.Future<void>.value(),
@@ -387,16 +406,34 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
   String getMulticastGroup() =>
       (super.noSuchMethod(
             Invocation.method(#getMulticastGroup, []),
-            returnValue: _i8.dummyValue<String>(
+            returnValue: _i9.dummyValue<String>(
               this,
               Invocation.method(#getMulticastGroup, []),
             ),
-            returnValueForMissingStub: _i8.dummyValue<String>(
+            returnValueForMissingStub: _i9.dummyValue<String>(
               this,
               Invocation.method(#getMulticastGroup, []),
             ),
           )
           as String);
+
+  @override
+  bool isTailnetDiscovery() =>
+      (super.noSuchMethod(
+            Invocation.method(#isTailnetDiscovery, []),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
+
+  @override
+  _i5.Future<void> setTailnetDiscovery(bool? tailnetDiscovery) =>
+      (super.noSuchMethod(
+            Invocation.method(#setTailnetDiscovery, [tailnetDiscovery]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   _i5.Future<void> setMulticastGroup(String? group) =>
@@ -471,16 +508,16 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as _i5.Future<void>);
 
   @override
-  _i12.QuickSaveMode getQuickSave() =>
+  _i13.QuickSaveMode getQuickSave() =>
       (super.noSuchMethod(
             Invocation.method(#getQuickSave, []),
-            returnValue: _i12.QuickSaveMode.off,
-            returnValueForMissingStub: _i12.QuickSaveMode.off,
+            returnValue: _i13.QuickSaveMode.off,
+            returnValueForMissingStub: _i13.QuickSaveMode.off,
           )
-          as _i12.QuickSaveMode);
+          as _i13.QuickSaveMode);
 
   @override
-  _i5.Future<void> setQuickSave(_i12.QuickSaveMode? mode) =>
+  _i5.Future<void> setQuickSave(_i13.QuickSaveMode? mode) =>
       (super.noSuchMethod(
             Invocation.method(#setQuickSave, [mode]),
             returnValue: _i5.Future<void>.value(),
@@ -552,16 +589,16 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as _i5.Future<void>);
 
   @override
-  _i13.SendMode getSendMode() =>
+  _i14.SendMode getSendMode() =>
       (super.noSuchMethod(
             Invocation.method(#getSendMode, []),
-            returnValue: _i13.SendMode.single,
-            returnValueForMissingStub: _i13.SendMode.single,
+            returnValue: _i14.SendMode.single,
+            returnValueForMissingStub: _i14.SendMode.single,
           )
-          as _i13.SendMode);
+          as _i14.SendMode);
 
   @override
-  _i5.Future<void> setSendMode(_i13.SendMode? mode) =>
+  _i5.Future<void> setSendMode(_i14.SendMode? mode) =>
       (super.noSuchMethod(
             Invocation.method(#setSendMode, [mode]),
             returnValue: _i5.Future<void>.value(),
@@ -642,7 +679,7 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as bool);
 
   @override
-  _i5.Future<void> setDeviceType(_i14.DeviceType? deviceType) =>
+  _i5.Future<void> setDeviceType(_i15.DeviceType? deviceType) =>
       (super.noSuchMethod(
             Invocation.method(#setDeviceType, [deviceType]),
             returnValue: _i5.Future<void>.value(),
@@ -681,7 +718,7 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
 /// A class which mocks [SharedPreferences].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSharedPreferences extends _i1.Mock implements _i15.SharedPreferences {
+class MockSharedPreferences extends _i1.Mock implements _i16.SharedPreferences {
   @override
   Set<String> getKeys() =>
       (super.noSuchMethod(

--- a/app/test/unit/util/tailnet_address_test.dart
+++ b/app/test/unit/util/tailnet_address_test.dart
@@ -1,0 +1,31 @@
+import 'package:localsend_app/util/tailnet_address.dart';
+import 'package:test/test.dart';
+
+/// Mirrors the tests of `is_tailnet_address` in
+/// `packages/core/src/tailscale/mod.rs`, so a drift between the two
+/// classifiers shows up as a failing test on whichever side changed.
+void main() {
+  group('isTailnetAddress', () {
+    test('recognises the ranges a tailnet assigns', () {
+      expect(isTailnetAddress('100.64.0.0'), true, reason: 'the first address');
+      expect(isTailnetAddress('100.90.62.40'), true);
+      expect(isTailnetAddress('100.127.255.255'), true, reason: 'the last address');
+      expect(isTailnetAddress('fd7a:115c:a1e0::d933:3e28'), true);
+    });
+
+    test('rejects addresses outside them', () {
+      expect(isTailnetAddress('100.63.255.255'), false, reason: 'just below the range');
+      expect(isTailnetAddress('100.128.0.0'), false, reason: 'just above the range');
+      expect(isTailnetAddress('192.168.1.42'), false);
+      expect(isTailnetAddress('127.0.0.1'), false);
+      expect(isTailnetAddress('fd7a:115c:a1e1::1'), false, reason: 'a neighbouring /48');
+      expect(isTailnetAddress('2001:db8::1'), false);
+    });
+
+    test('accepts a scoped address and rejects a host that is not one', () {
+      expect(isTailnetAddress('fe80::1%3'), false, reason: 'a scoped link-local address must parse, not be mistaken for one');
+      expect(isTailnetAddress('desktop.tail8182b8.ts.net'), false);
+      expect(isTailnetAddress(''), false);
+    });
+  });
+}

--- a/cli/src/app/mod.rs
+++ b/cli/src/app/mod.rs
@@ -143,6 +143,9 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
                 },
                 timeout: DEFAULT_DISCOVERY_TIMEOUT,
                 event_tx: Some(discovery_tx),
+                // Costs nothing without Tailscale, and is what makes a
+                // headless machine reachable from outside its own network.
+                tailnet: true,
             },
             discovery_stop_rx,
         )

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -54,9 +54,12 @@ required-features = ["http"]
 [features]
 default = []
 crypto = ["ed25519-dalek", "rcgen", "rsa", "sha2", "tokio-util"]
-discovery = ["http", "multicast"]
+discovery = ["http", "multicast", "tailscale"]
 http = ["crypto", "form_urlencoded", "http-body-util", "hyper", "hyper-util", "if-addrs", "pem", "percent-encoding", "reqwest", "rustls", "socket2", "time", "tokio-rustls", "tokio-util", "x509-parser"]
 multicast = ["if-addrs", "socket2", "tokio-util"]
+# Speaks HTTP/1.1 directly on a unix socket, a named pipe or loopback, none of
+# which reqwest can dial, so hyper's client is needed next to the server side.
+tailscale = ["http-body-util", "hyper", "hyper/client", "hyper/http1", "hyper-util", "hyper-util/tokio"]
 webrtc-signaling = ["tokio-tungstenite"]
 webrtc = ["crypto", "flate2", "dep:webrtc", "webrtc-signaling", "x509-parser"]
 full = ["crypto", "discovery", "http", "multicast", "webrtc"]

--- a/packages/core/src/discovery/mod.rs
+++ b/packages/core/src/discovery/mod.rs
@@ -9,6 +9,7 @@ use crate::http::client::{ClientError, LsHttpClientV2};
 use crate::http::dto_v2::{RegisterDtoV2, RegisterResponseDtoV2};
 use crate::model::discovery::{MulticastMessageV2, ProtocolType};
 use crate::multicast::{self, MulticastConfig, MulticastDevice, MulticastEvent, MulticastHandle};
+use crate::tailscale;
 use crate::util::error::ErrorChain;
 use crate::util::interface::InterfaceFilter;
 use futures_util::StreamExt;
@@ -24,6 +25,31 @@ use tokio::sync::{mpsc, oneshot};
 /// the Flutter app's default discovery timeout. Discovery only talks to LAN
 /// peers, which answer quickly or not at all.
 pub const DEFAULT_DISCOVERY_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// The timeout of the register requests sent to tailnet peers.
+///
+/// Much longer than [`DEFAULT_DISCOVERY_TIMEOUT`], because a tailnet peer is
+/// not a LAN peer: the first packet may have to punch through two NATs, and
+/// falls back to a relay on another continent when it cannot. A LAN timeout
+/// would drop exactly the remote devices this stage exists for.
+pub const TAILNET_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// How many times a register request to a tailnet peer is attempted within
+/// one scan.
+///
+/// More than once, because the first packets towards an idle peer are what
+/// wake the VPN and start NAT traversal or the relay fallback, and on a
+/// mobile network that setup regularly outlives
+/// [`TAILNET_DISCOVERY_TIMEOUT`]. The first attempt is then not wasted — the
+/// retry runs on the path it began establishing — but without a retry the
+/// peer stays invisible until the user happens to rescan.
+const TAILNET_PROBE_ATTEMPTS: u32 = 2;
+
+/// The pause between two attempts of a tailnet probe: long enough for the
+/// tunnel setup the first attempt triggered to make progress, short enough
+/// that a scan whose tailnet peer is truly offline still ends within a few
+/// seconds of the announcement burst.
+const TAILNET_PROBE_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Capacity of the internal multicast event channel.
 const MULTICAST_CHANNEL_SIZE: usize = 64;
@@ -75,6 +101,10 @@ pub struct DiscoveryConfig {
     /// Channel on which discovery events are emitted. `None` when the
     /// application only polls [`DiscoveryHandle::devices`].
     pub event_tx: Option<mpsc::Sender<DiscoveryEvent>>,
+
+    /// Whether [`DiscoveryHandle::discover_staged`] also probes the peers of
+    /// this device's tailnet, see [`DiscoveryHandle::set_tailnet`].
+    pub tailnet: bool,
 }
 
 /// An event emitted by the discovery. Every confirmation is also logged in
@@ -117,12 +147,30 @@ struct DiscoveryState {
     /// [`DiscoveryHandle::set_answer_announcements`].
     answering: AtomicBool,
 
+    /// Whether the tailnet peers are probed, see
+    /// [`DiscoveryHandle::set_tailnet`].
+    tailnet: AtomicBool,
+
     /// The interface addresses a subnet scan is currently running for.
     scanning: std::sync::Mutex<HashSet<Ipv4Addr>>,
 
-    /// Number of confirmations in this run, on which
+    /// Number of confirmations over the local network in this run, on which
     /// [`DiscoveryHandle::discover_staged`] decides whether to escalate.
     confirmations: AtomicU64,
+}
+
+/// Where a confirmation came from.
+///
+/// Only [`Origin::Local`] proves that the cheap stages work on the network
+/// this device is attached to, which is the question
+/// [`DiscoveryHandle::discover_staged`] escalates on. A peer answering over
+/// the tailnet says nothing about the local network — it is reached through a
+/// tunnel — so counting it would suppress the subnet scan on exactly the
+/// multicast-less networks the scan exists for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Origin {
+    Local,
+    Tailnet,
 }
 
 impl DiscoveryState {
@@ -142,13 +190,42 @@ impl DiscoveryState {
     /// A client accepting any valid certificate, for peers whose fingerprint
     /// is not known before they answer. The fingerprint is then read off the
     /// handshake and pinned by connections that transfer data.
-    fn unpinned_client(&self) -> Result<LsHttpClientV2, ClientError> {
+    fn unpinned_client(&self, timeout: Duration) -> Result<LsHttpClientV2, ClientError> {
         LsHttpClientV2::try_new(
             &self.identity.private_key_pem,
             &self.identity.cert_pem,
             None,
-            Some(self.timeout),
+            Some(timeout),
         )
+    }
+
+    /// The clients a stage needs for `channels`, see [`Probes::client`]. The
+    /// patient one is only built when one of the addresses is a tailnet
+    /// address, so a stage that has none does exactly the work it always did.
+    fn probes(&self, channels: &[HttpChannel]) -> Result<Probes, ClientError> {
+        let tailnet = channels
+            .iter()
+            .any(|channel| tailscale::is_tailnet_address(&channel.host));
+
+        Ok(Probes {
+            lan: self.unpinned_client(self.timeout)?,
+            tailnet: match tailnet {
+                true => Some(self.unpinned_client(TAILNET_DISCOVERY_TIMEOUT)?),
+                false => None,
+            },
+        })
+    }
+
+    /// The tailnet addresses a device in the store was confirmed on, in
+    /// discovery order, without the channels the caller already probes.
+    ///
+    /// This is what a device that cannot enumerate its own tailnet has
+    /// instead of a peer list: the addresses it has already been reached
+    /// from. Only tailnet addresses are collected, because every other
+    /// address is found again by the stage that exists for it — a LAN peer
+    /// answers the announcement, and a subnet scan walks the rest.
+    fn stored_tailnet_channels(&self, except: &[HttpChannel]) -> Vec<HttpChannel> {
+        tailnet_channels(self.store.devices(), except)
     }
 
     /// Registers with `host:port` and, when a device answers, puts it into
@@ -160,6 +237,7 @@ impl DiscoveryState {
         host: &str,
         port: u16,
         protocol: ProtocolType,
+        origin: Origin,
     ) -> Result<Option<StatefulDevice>, ClientError> {
         let response = client
             .register(protocol, host, port, self.register_dto())
@@ -179,15 +257,17 @@ impl DiscoveryState {
         }
 
         let device = confirmed_device(response.body, host.to_string(), port, protocol, fingerprint);
-        let (_, merged) = self.found(device).await;
+        let (_, merged) = self.found(device, origin).await;
         Ok(Some(merged))
     }
 
     /// Puts a device into the store, logging the confirmation on it, and
     /// emits the resulting event. Returns whether the device is new, and
     /// its stored state after the merge.
-    async fn found(&self, device: DiscoveredDevice) -> (bool, StatefulDevice) {
-        self.confirmations.fetch_add(1, Ordering::Relaxed);
+    async fn found(&self, device: DiscoveredDevice, origin: Origin) -> (bool, StatefulDevice) {
+        if origin == Origin::Local {
+            self.confirmations.fetch_add(1, Ordering::Relaxed);
+        }
         let (event, merged) = self.store.upsert(device, SystemTime::now());
         let is_new = matches!(event, DiscoveryEvent::Discovered { .. });
         if let Some(event_tx) = &self.event_tx {
@@ -207,6 +287,98 @@ impl DiscoveryState {
         }
         (is_new, merged)
     }
+}
+
+/// The clients of a discovery stage whose addresses the application supplied
+/// and may therefore point at a LAN or into the tailnet.
+struct Probes {
+    lan: LsHttpClientV2,
+
+    /// Only built when the stage carries a tailnet address, see
+    /// [`DiscoveryState::probes`].
+    tailnet: Option<LsHttpClientV2>,
+}
+
+impl Probes {
+    /// The client to dial `host` with.
+    ///
+    /// A tailnet address gets [`TAILNET_DISCOVERY_TIMEOUT`], because first
+    /// contact may have to punch through two NATs and falls back to a relay
+    /// when it cannot, which [`DEFAULT_DISCOVERY_TIMEOUT`] would cut off —
+    /// dropping exactly the remote devices such an address stands for. Every
+    /// other address keeps the short timeout it always had.
+    fn client(&self, host: &str) -> &LsHttpClientV2 {
+        match &self.tailnet {
+            Some(tailnet) if tailscale::is_tailnet_address(host) => tailnet,
+            _ => &self.lan,
+        }
+    }
+}
+
+/// What a confirmation over `host` proves, in a stage probing addresses the
+/// application supplied: a peer inside the tailnet answers through a tunnel
+/// and so says nothing about the local network, see [`Origin`].
+fn origin_of(host: &str) -> Origin {
+    if tailscale::is_tailnet_address(host) {
+        Origin::Tailnet
+    } else {
+        Origin::Local
+    }
+}
+
+/// The tailnet addresses among the channels of `devices`, in their order,
+/// without the ones in `except`.
+fn tailnet_channels(devices: Vec<StatefulDevice>, except: &[HttpChannel]) -> Vec<HttpChannel> {
+    devices
+        .into_iter()
+        .flat_map(|known| {
+            known
+                .channels
+                .into_keys()
+                .filter_map(|channel| channel.http().cloned())
+                .collect::<Vec<_>>()
+        })
+        .filter(|channel| {
+            tailscale::is_tailnet_address(&channel.host) && !except.contains(channel)
+        })
+        .collect()
+}
+
+/// Runs `attempt`, a register probe of the tailnet address `host`, retrying
+/// it after a pause when it fails — [`TAILNET_PROBE_ATTEMPTS`] attempts in
+/// all.
+///
+/// The retry is what makes a cold tunnel survivable: the first attempt's
+/// packets wake the VPN and start NAT traversal or the relay fallback, so
+/// the second attempt lands on the path the first one began establishing.
+/// An answer is never retried — `Ok(None)` is an answer too, the peer turned
+/// out to be this device itself.
+///
+/// Failures are logged and mapped to `None`, because an unreachable peer is
+/// the normal case for a stage that probes every address a peer was ever
+/// seen at. Unlike on the LAN stages, the log line matters here: a dropped
+/// tailnet probe has no announcement or subnet scan to catch it, so it must
+/// at least be diagnosable.
+async fn retry_tailnet_probe<T, F, Fut>(host: &str, mut attempt: F) -> Option<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<Option<T>, ClientError>>,
+{
+    for tries_left in (0..TAILNET_PROBE_ATTEMPTS).rev() {
+        match attempt().await {
+            Ok(found) => return found,
+            Err(err) => {
+                tracing::debug!(
+                    "Tailnet probe of {host} failed, {tries_left} attempt(s) left: {}",
+                    ErrorChain(&err)
+                );
+                if tries_left > 0 {
+                    tokio::time::sleep(TAILNET_PROBE_RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+    None
 }
 
 /// A handle to a running discovery: the store of discovered devices and the
@@ -259,8 +431,15 @@ impl DiscoveryHandle {
         port: u16,
         protocol: ProtocolType,
     ) -> Result<Option<StatefulDevice>, ClientError> {
-        let client = self.state.unpinned_client()?;
-        self.state.probe(&client, host, port, protocol).await
+        let channel = HttpChannel {
+            host: host.to_string(),
+            port,
+            protocol,
+        };
+        let probes = self.state.probes(std::slice::from_ref(&channel))?;
+        self.state
+            .probe(probes.client(host), host, port, protocol, origin_of(host))
+            .await
     }
 
     /// Discovers devices at known addresses, e.g. the favorites, by sending
@@ -269,21 +448,126 @@ impl DiscoveryHandle {
     ///
     /// Channels that do not answer are skipped; returns the stored state of
     /// the devices that answered, in completion order.
+    ///
+    /// A channel inside the tailnet is probed with the patience such a peer
+    /// needs — the longer timeout of [`Probes::client`] and the retry of
+    /// [`retry_tailnet_probe`] — so that a favorite reachable only over
+    /// Tailscale is dropped neither by the LAN timeout nor by a tunnel that
+    /// is still waking up.
     pub async fn discover_known_http_channels(
         &self,
         channels: Vec<HttpChannel>,
     ) -> Result<Vec<StatefulDevice>, ClientError> {
-        let client = self.state.unpinned_client()?;
+        let probes = self.state.probes(&channels)?;
+
+        let state = &self.state;
+        let probes = &probes;
+        let found = futures_util::stream::iter(channels)
+            .map(|channel| async move {
+                let client = probes.client(&channel.host);
+                // A tailnet address gets the retry a cold tunnel needs;
+                // every other address keeps the single attempt it always had.
+                if tailscale::is_tailnet_address(&channel.host) {
+                    retry_tailnet_probe(&channel.host, || {
+                        state.probe(client, &channel.host, channel.port, channel.protocol, Origin::Tailnet)
+                    })
+                    .await
+                } else {
+                    state
+                        .probe(client, &channel.host, channel.port, channel.protocol, Origin::Local)
+                        .await
+                        .ok()
+                        .flatten()
+                }
+            })
+            .buffer_unordered(SCAN_CONCURRENCY)
+            .filter_map(std::future::ready)
+            .collect()
+            .await;
+
+        Ok(found)
+    }
+
+    /// Probes every online peer of this device's tailnet with a register
+    /// request, so that devices on the same tailnet find each other even when
+    /// they are on different physical networks — a phone on mobile data and a
+    /// desktop on Wi-Fi, say.
+    ///
+    /// The peer list comes from the local Tailscale daemon, see
+    /// [`crate::tailscale`]. Probing a peer is what makes this two-way: the
+    /// register request also registers *this* device with the peer, so a
+    /// device that cannot enumerate the tailnet itself — Android and iOS
+    /// cannot — still ends up seeing the one that probed it.
+    ///
+    /// A device that cannot enumerate has nothing but the tailnet addresses it
+    /// has already been reached from, so those are probed too, see
+    /// [`DiscoveryState::stored_tailnet_channels`]. Without them a rescan on
+    /// such a device loses the peer for good: the application drops its list
+    /// when the user rescans, and neither an announcement nor a subnet scan
+    /// can ever find a tailnet peer again.
+    ///
+    /// Does nothing, and is not an error, when the tailnet stage is off or no
+    /// local Tailscale daemon can be reached. Every address is probed with
+    /// the retry a cold tunnel needs, see [`retry_tailnet_probe`]. Returns
+    /// the stored state of the peers that answered, in completion order.
+    pub async fn discover_tailnet(
+        &self,
+        port: u16,
+        protocol: ProtocolType,
+    ) -> Result<Vec<StatefulDevice>, ClientError> {
+        if !self.state.tailnet.load(Ordering::Relaxed) {
+            return Ok(Vec::new());
+        }
+
+        // The daemon's peers come first, so that a peer which is enumerated
+        // and also already known is probed at the address the daemon reports.
+        let mut channels: Vec<HttpChannel> = match tailscale::peers().await {
+            Ok(peers) => {
+                // The one line that says whether this device can enumerate
+                // its tailnet at all. A device that cannot reach its daemon —
+                // a sandbox hiding the socket, Tailscale logged out — is
+                // otherwise indistinguishable from one that simply found no
+                // peers, and that silence has already been read once as the
+                // stage never running. It is INFO because the two builds that
+                // do install a subscriber, the CLI and the debug app, would
+                // otherwise need their level raised by hand to answer a
+                // question that costs one line to answer always.
+                tracing::info!("Enumerated {} online tailnet peer(s)", peers.len());
+
+                peers
+                    .into_iter()
+                    .map(|peer| HttpChannel {
+                        host: peer.host,
+                        port,
+                        protocol,
+                    })
+                    .collect()
+            }
+            Err(err) => {
+                // The normal case on a device without Tailscale, and the case
+                // of every Android and iOS device, so this is not worth more
+                // than a debug line.
+                tracing::debug!("No tailnet peers to enumerate: {}", ErrorChain(&err));
+                Vec::new()
+            }
+        };
+        channels.extend(self.state.stored_tailnet_channels(&channels));
+
+        if channels.is_empty() {
+            return Ok(Vec::new());
+        }
+        tracing::debug!("Probing {} tailnet address(es)", channels.len());
+
+        let client = self.state.unpinned_client(TAILNET_DISCOVERY_TIMEOUT)?;
 
         let state = &self.state;
         let client = &client;
         let found = futures_util::stream::iter(channels)
             .map(|channel| async move {
-                state
-                    .probe(client, &channel.host, channel.port, channel.protocol)
-                    .await
-                    .ok()
-                    .flatten()
+                retry_tailnet_probe(&channel.host, || {
+                    state.probe(client, &channel.host, channel.port, channel.protocol, Origin::Tailnet)
+                })
+                .await
             })
             .buffer_unordered(SCAN_CONCURRENCY)
             .filter_map(std::future::ready)
@@ -313,6 +597,16 @@ impl DiscoveryHandle {
         protocol: ProtocolType,
         grace: Duration,
     ) -> Result<(), ClientError> {
+        // A known channel inside the tailnet is probed with retries and a
+        // long timeout, so it must not sit in front of the grace period: the
+        // escalation would start late by exactly that much on the
+        // multicast-less networks the subnet scan exists for. The tailnet
+        // channels ride beside the escalation instead, like the tailnet
+        // stage itself.
+        let (tailnet_channels, known_channels): (Vec<_>, Vec<_>) = known_channels
+            .into_iter()
+            .partition(|channel| tailscale::is_tailnet_address(&channel.host));
+
         let confirmations = self.state.confirmations.load(Ordering::Relaxed);
         let escalate = async {
             self.discover_known_http_channels(known_channels).await?;
@@ -329,7 +623,30 @@ impl DiscoveryHandle {
             Ok(())
         };
 
-        let (_, escalated) = tokio::join!(self.announce(), escalate);
+        // The tailnet stage runs alongside the others rather than inside the
+        // escalation: it reaches a different network, so it neither waits for
+        // the grace period nor influences it. The application's tailnet
+        // channels are probed in this lane for the same reason — but unlike
+        // the enumeration they are not gated on the tailnet setting, because
+        // a favorite has always been probed regardless of it.
+        let tailnet = async {
+            let known = async {
+                if tailnet_channels.is_empty() {
+                    return;
+                }
+                if let Err(err) = self.discover_known_http_channels(tailnet_channels).await {
+                    tracing::debug!("The tailnet channel probes failed: {}", ErrorChain(&err));
+                }
+            };
+            let enumerated = async {
+                if let Err(err) = self.discover_tailnet(port, protocol).await {
+                    tracing::debug!("The tailnet stage failed: {}", ErrorChain(&err));
+                }
+            };
+            tokio::join!(known, enumerated);
+        };
+
+        let (_, _, escalated) = tokio::join!(self.announce(), tailnet, escalate);
         escalated
     }
 
@@ -353,7 +670,7 @@ impl DiscoveryHandle {
             interface_ip,
         };
 
-        let client = self.state.unpinned_client()?;
+        let client = self.state.unpinned_client(self.state.timeout)?;
         let base = interface_ip.octets();
 
         let state = &self.state;
@@ -365,7 +682,7 @@ impl DiscoveryHandle {
         )
         .map(|ip| async move {
             state
-                .probe(client, &ip.to_string(), port, protocol)
+                .probe(client, &ip.to_string(), port, protocol, Origin::Local)
                 .await
                 .ok()
                 .flatten()
@@ -388,12 +705,33 @@ impl DiscoveryHandle {
         self.state.answering.store(answer, Ordering::Relaxed);
     }
 
+    /// Sets whether [`DiscoveryHandle::discover_staged`] also probes the
+    /// peers of this device's tailnet. On by default; it costs nothing on a
+    /// device that has no Tailscale.
+    ///
+    /// Takes effect on the next discovery, so turning the setting off does
+    /// not require the sockets to be rebound.
+    pub fn set_tailnet(&self, tailnet: bool) {
+        self.state.tailnet.store(tailnet, Ordering::Relaxed);
+    }
+
     /// Puts a device confirmed outside of discovery into the store, e.g. one
     /// that answered an announcement by registering with this device's HTTP
     /// server. The confirmation is emitted as `Discovered` or `Updated`;
     /// returns `true` when the device is new.
+    ///
+    /// A device may also have registered through the tailnet — over which it
+    /// hears no announcements, so the register was probably an answer to a
+    /// probe. Such a confirmation must not count towards the escalation
+    /// decision for the same reason a tailnet probe does not (see [`Origin`]):
+    /// it would suppress the subnet scan on exactly the multicast-less
+    /// networks the scan exists for.
     pub async fn add_device(&self, device: DiscoveredDevice) -> bool {
-        self.state.found(device).await.0
+        let origin = match device.http() {
+            Some(channel) => origin_of(&channel.host),
+            None => Origin::Local,
+        };
+        self.state.found(device, origin).await.0
     }
 
     /// All discovered devices in discovery order.
@@ -463,6 +801,7 @@ pub async fn start(config: DiscoveryConfig, stop_rx: oneshot::Receiver<()>) -> D
         store: DeviceStore::new(),
         event_tx: config.event_tx,
         answering: AtomicBool::new(true),
+        tailnet: AtomicBool::new(config.tailnet),
         scanning: std::sync::Mutex::new(HashSet::new()),
         confirmations: AtomicU64::new(0),
     });
@@ -551,7 +890,7 @@ async fn answer_announcement(
                 message.protocol,
                 message.fingerprint,
             );
-            state.found(device).await;
+            state.found(device, Origin::Local).await;
         }
         Err(err) => {
             let url = format!("{}://{host}:{}", message.protocol.as_str(), message.port);
@@ -585,5 +924,157 @@ fn confirmed_device(
             protocol,
         }),
         download: response.download,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::discovery::DeviceType;
+
+    const PORT: u16 = 53317;
+
+    /// A device reachable at `hosts`, shaped like the store hands it out.
+    fn stored(fingerprint: &str, hosts: &[&str]) -> StatefulDevice {
+        let channel = |host: &str| {
+            DeviceChannel::Http(HttpChannel {
+                host: host.to_string(),
+                port: PORT,
+                protocol: ProtocolType::Https,
+            })
+        };
+
+        StatefulDevice {
+            device: DiscoveredDevice {
+                alias: format!("Alias of {fingerprint}"),
+                version: "2.2".to_string(),
+                device_model: None,
+                device_type: Some(DeviceType::Desktop),
+                fingerprint: fingerprint.to_string(),
+                channel: channel(hosts[0]),
+                download: false,
+            },
+            channels: hosts
+                .iter()
+                .map(|host| (channel(host), ChannelStatus::Available))
+                .collect(),
+            logs: Vec::new(),
+        }
+    }
+
+    fn hosts_of(channels: Vec<HttpChannel>) -> Vec<String> {
+        let mut hosts: Vec<String> = channels.into_iter().map(|channel| channel.host).collect();
+        hosts.sort();
+        hosts
+    }
+
+    #[test]
+    fn test_only_the_tailnet_addresses_are_re_probed() {
+        let devices = vec![
+            stored("lan", &["192.168.1.20"]),
+            stored("tailnet", &["100.90.62.40"]),
+        ];
+
+        assert_eq!(
+            hosts_of(tailnet_channels(devices, &[])),
+            ["100.90.62.40"],
+            "a LAN address is found again by the announcement and the subnet scan, \
+             so re-probing it would only add work to every rescan"
+        );
+    }
+
+    #[test]
+    fn test_every_tailnet_address_of_a_multi_homed_device_is_re_probed() {
+        let devices = vec![stored(
+            "both",
+            &["192.168.1.20", "100.90.62.40", "fd7a:115c:a1e0::1"],
+        )];
+
+        assert_eq!(
+            hosts_of(tailnet_channels(devices, &[])),
+            ["100.90.62.40", "fd7a:115c:a1e0::1"]
+        );
+    }
+
+    #[test]
+    fn test_a_channel_the_caller_already_probes_is_skipped() {
+        let devices = vec![stored("tailnet", &["100.90.62.40"])];
+        let except = [HttpChannel {
+            host: "100.90.62.40".to_string(),
+            port: PORT,
+            protocol: ProtocolType::Https,
+        }];
+
+        assert!(
+            tailnet_channels(devices, &except).is_empty(),
+            "a peer the daemon enumerated must not be probed twice"
+        );
+    }
+
+    /// The error an unreachable peer fails a probe with, shaped well enough
+    /// for the retry helper, which only looks at success or failure.
+    fn unreachable() -> ClientError {
+        ClientError::Other(anyhow::anyhow!("connection timed out"))
+    }
+
+    #[tokio::test]
+    async fn test_a_failed_tailnet_probe_is_retried() {
+        let attempts = std::cell::Cell::new(0u32);
+        let found = retry_tailnet_probe("100.64.0.1", || {
+            attempts.set(attempts.get() + 1);
+            let attempt = attempts.get();
+            async move {
+                match attempt {
+                    1 => Err(unreachable()),
+                    later => Ok(Some(later)),
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(
+            found,
+            Some(2),
+            "the answer of the second attempt must be returned"
+        );
+        assert_eq!(
+            attempts.get(),
+            2,
+            "success on the second attempt must stop the loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_an_unreachable_tailnet_peer_is_given_up_on_after_the_retries() {
+        let attempts = std::cell::Cell::new(0u32);
+        let found: Option<u32> = retry_tailnet_probe("100.64.0.1", || {
+            attempts.set(attempts.get() + 1);
+            async { Err(unreachable()) }
+        })
+        .await;
+
+        assert_eq!(found, None);
+        assert_eq!(
+            attempts.get(),
+            TAILNET_PROBE_ATTEMPTS,
+            "an offline peer is the normal case and must not be probed forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_tailnet_probe_answered_by_this_device_itself_is_not_retried() {
+        let attempts = std::cell::Cell::new(0u32);
+        let found: Option<u32> = retry_tailnet_probe("100.64.0.1", || {
+            attempts.set(attempts.get() + 1);
+            async { Ok(None) }
+        })
+        .await;
+
+        assert_eq!(found, None);
+        assert_eq!(
+            attempts.get(),
+            1,
+            "Ok(None) is an answer — the peer was this device itself — not a failure"
+        );
     }
 }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -7,6 +7,8 @@ pub mod http;
 pub mod model;
 #[cfg(feature = "multicast")]
 pub mod multicast;
+#[cfg(feature = "tailscale")]
+pub mod tailscale;
 pub mod util;
 pub mod webrtc;
 

--- a/packages/core/src/tailscale/local_api.rs
+++ b/packages/core/src/tailscale/local_api.rs
@@ -1,0 +1,351 @@
+//! The client for the LocalAPI of the Tailscale daemon running on this device.
+//!
+//! Every platform serves the same HTTP API on a different local transport,
+//! because each has a different way of proving that the caller is the user
+//! who owns the daemon:
+//!
+//! - Linux, and macOS installs that run `tailscaled` themselves: a unix
+//!   socket, world-readable for the read-only endpoints used here.
+//! - Windows: a named pipe, whose ACL is the access check.
+//! - The sandboxed macOS builds: a loopback port guarded by a token, since a
+//!   sandboxed app cannot publish a unix socket. Port and token are the name
+//!   of a file the app leaves in its group container.
+//!
+//! Only `GET /localapi/v0/status` is used, which reads the daemon's in-memory
+//! netmap and changes nothing.
+
+use anyhow::{anyhow, Context};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use bytes::Bytes;
+use http_body_util::{BodyExt, Empty};
+use hyper::header::{AUTHORIZATION, HOST};
+use hyper::Request;
+use hyper_util::rt::TokioIo;
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// The endpoint that returns the netmap, including every peer.
+const STATUS_PATH: &str = "/localapi/v0/status";
+
+/// The `Host` header tailscaled requires. It is never resolved: the transport
+/// already decides which process is talked to.
+const HOST_HEADER: &str = "local-tailscaled.sock";
+
+/// Bounds a wedged daemon. The LocalAPI answers out of memory, so a healthy
+/// tailscaled is orders of magnitude below this; discovery must not stall on
+/// one that is not.
+const TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Fetches the status document from the local daemon.
+///
+/// Tries every transport the platform can offer and reports the last failure
+/// when none worked, which is the normal outcome when Tailscale is simply not
+/// installed.
+pub(super) async fn status() -> anyhow::Result<Vec<u8>> {
+    let mut last_error = None;
+
+    for endpoint in endpoints() {
+        match tokio::time::timeout(TIMEOUT, request_status(&endpoint)).await {
+            Ok(Ok(body)) => return Ok(body),
+            Ok(Err(err)) => last_error = Some(err.context(format!("{endpoint} failed"))),
+            Err(_) => last_error = Some(anyhow!("{endpoint} did not answer within {TIMEOUT:?}")),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow!("This platform exposes no Tailscale LocalAPI")))
+}
+
+/// One way of reaching the local daemon, in the order they are tried.
+enum Endpoint {
+    #[cfg(unix)]
+    UnixSocket(&'static str),
+
+    /// The loopback listener of a sandboxed macOS build, with the token that
+    /// authenticates against it.
+    #[cfg(target_os = "macos")]
+    Loopback { port: u16, token: String },
+
+    #[cfg(windows)]
+    NamedPipe(&'static str),
+}
+
+impl std::fmt::Display for Endpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(unix)]
+            Endpoint::UnixSocket(path) => write!(f, "The Tailscale socket {path}"),
+            // The token is a credential and never logged.
+            #[cfg(target_os = "macos")]
+            Endpoint::Loopback { port, .. } => {
+                write!(f, "The Tailscale loopback API on port {port}")
+            }
+            #[cfg(windows)]
+            Endpoint::NamedPipe(path) => write!(f, "The Tailscale pipe {path}"),
+        }
+    }
+}
+
+fn endpoints() -> Vec<Endpoint> {
+    #[allow(unused_mut)]
+    let mut endpoints = Vec::new();
+
+    #[cfg(unix)]
+    {
+        // Linux, and macOS installs managed by the Tailscale CLI.
+        endpoints.push(Endpoint::UnixSocket("/var/run/tailscale/tailscaled.sock"));
+        // The same socket where /var/run is not a symlink to /run.
+        endpoints.push(Endpoint::UnixSocket("/run/tailscale/tailscaled.sock"));
+        // The open-source tailscaled on macOS, e.g. from Homebrew.
+        endpoints.push(Endpoint::UnixSocket("/var/run/tailscaled.socket"));
+    }
+
+    #[cfg(target_os = "macos")]
+    if let Some((port, token)) = loopback_credentials() {
+        endpoints.push(Endpoint::Loopback { port, token });
+    }
+
+    #[cfg(windows)]
+    endpoints.push(Endpoint::NamedPipe(
+        r"\\.\pipe\ProtectedPrefix\Administrators\Tailscale\tailscaled",
+    ));
+
+    endpoints
+}
+
+async fn request_status(endpoint: &Endpoint) -> anyhow::Result<Vec<u8>> {
+    match endpoint {
+        #[cfg(unix)]
+        Endpoint::UnixSocket(path) => {
+            let stream = tokio::net::UnixStream::connect(path)
+                .await
+                .context("Could not connect")?;
+            get(stream, None).await
+        }
+
+        #[cfg(target_os = "macos")]
+        Endpoint::Loopback { port, token } => {
+            let stream = tokio::net::TcpStream::connect(("127.0.0.1", *port))
+                .await
+                .context("Could not connect")?;
+            get(stream, Some(token)).await
+        }
+
+        #[cfg(windows)]
+        Endpoint::NamedPipe(path) => {
+            use tokio::net::windows::named_pipe::ClientOptions;
+
+            // tailscaled refuses connections opened at the anonymous
+            // impersonation level, because it cannot then tell who is
+            // calling. These are the flags that ask for an identification
+            // token; they are Tokio's default, but the request depends on
+            // them, so they are spelled out.
+            const SECURITY_SQOS_PRESENT: u32 = 0x0010_0000;
+            const SECURITY_IDENTIFICATION: u32 = 0x0001_0000;
+
+            let stream = ClientOptions::new()
+                .security_qos_flags(SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION)
+                .open(path)
+                .context("Could not connect")?;
+            get(stream, None).await
+        }
+    }
+}
+
+/// Sends `GET /localapi/v0/status` over an already connected transport and
+/// returns the response body.
+async fn get<S>(stream: S, token: Option<&str>) -> anyhow::Result<Vec<u8>>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    let (mut sender, connection) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+        .await
+        .context("Could not speak HTTP")?;
+
+    // Drives the transport until the response has been read; ends by itself
+    // once `sender` is dropped at the end of this function.
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            tracing::trace!("The Tailscale LocalAPI connection ended: {err}");
+        }
+    });
+
+    let mut request = Request::builder()
+        .uri(STATUS_PATH)
+        .header(HOST, HOST_HEADER);
+    if let Some(token) = token {
+        // The daemon expects the token as the password of an otherwise empty
+        // basic-auth pair.
+        let credentials = STANDARD.encode(format!(":{token}"));
+        request = request.header(AUTHORIZATION, format!("Basic {credentials}"));
+    }
+
+    let response = sender
+        .send_request(request.body(Empty::<Bytes>::new())?)
+        .await
+        .context("The request failed")?;
+
+    let status = response.status();
+    let body = response.into_body().collect().await?.to_bytes();
+    if !status.is_success() {
+        return Err(anyhow!("The LocalAPI answered {status}"));
+    }
+
+    Ok(body.to_vec())
+}
+
+/// The loopback port and token of a sandboxed macOS build, when one is
+/// installed.
+///
+/// The app writes a file whose *name* carries both, in the group container it
+/// shares with its network extension: `sameuserproof-<port>-<token>`. Being
+/// able to read that name is the proof that the caller runs as the same user.
+#[cfg(target_os = "macos")]
+fn loopback_credentials() -> Option<(u16, String)> {
+    for container in tailscale_group_containers() {
+        let Ok(files) = std::fs::read_dir(&container) else {
+            continue;
+        };
+        for file in files.filter_map(Result::ok) {
+            let name = file.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            let Some(suffix) = name.strip_prefix("sameuserproof-") else {
+                continue;
+            };
+            // The token may itself contain `-`, so split only once.
+            if let Some((port, token)) = suffix.split_once('-') {
+                if let Ok(port) = port.parse() {
+                    return Some((port, token.to_owned()));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// The group containers a Tailscale build may have left its loopback
+/// credentials in, the ones that are named outright first.
+///
+/// LocalSend is itself sandboxed on macOS, and that decides the shape of this
+/// search: `~/Library/Group Containers` cannot be listed from inside the App
+/// Sandbox at all — `opendir` answers `EPERM`, because a group container
+/// belongs to the applications entitled to it and LocalSend is not entitled
+/// to Tailscale's. A named path is a different check and does succeed, given
+/// the read-only exception in `Runner/*.entitlements`, so the two names
+/// Tailscale actually ships under are addressed directly rather than found.
+///
+/// The listing is still attempted afterwards, for the callers that are not
+/// sandboxed — the CLI, and the tests — so that a build signed under a team
+/// this code does not know about keeps working there.
+#[cfg(target_os = "macos")]
+fn tailscale_group_containers() -> Vec<std::path::PathBuf> {
+    // The App Store build lives under Tailscale's own team identifier; the
+    // standalone one carries no prefix. Neither has changed since the builds
+    // existed, and a wrong guess here costs nothing but the fallback below.
+    const WELL_KNOWN: [&str; 2] = [
+        "W5364U7YZB.group.io.tailscale.ipn.macos",
+        "io.tailscale.ipn.macsys",
+    ];
+
+    let Some(home) = real_home() else {
+        return Vec::new();
+    };
+    let containers = home.join("Library/Group Containers");
+
+    let mut candidates: Vec<std::path::PathBuf> =
+        WELL_KNOWN.iter().map(|name| containers.join(name)).collect();
+
+    let listed = std::fs::read_dir(&containers)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            let name = path.file_name()?.to_str()?;
+            (name.ends_with("io.tailscale.ipn.macos") || name.ends_with("io.tailscale.ipn.macsys"))
+                .then_some(path)
+        });
+    for path in listed {
+        if !candidates.contains(&path) {
+            candidates.push(path);
+        }
+    }
+
+    candidates
+}
+
+/// The home directory of the user running this process, read from the
+/// password database rather than from the environment.
+///
+/// The App Sandbox rewrites `HOME` to the calling application's own
+/// container, so `$HOME/Library/Group Containers` would name a directory
+/// inside LocalSend's data folder that holds only LocalSend's own groups, and
+/// the Tailscale container would never be looked at. `getpwuid` is not
+/// rewritten and still reports the real home.
+#[cfg(target_os = "macos")]
+fn real_home() -> Option<std::path::PathBuf> {
+    use std::ffi::{CStr, OsStr};
+    use std::os::unix::ffi::OsStrExt;
+
+    // SAFETY: `getpwuid` returns a pointer into a buffer libc owns, valid
+    // until this thread calls it again; the path is copied out before this
+    // function returns, so nothing borrows it afterwards.
+    let entry = unsafe { libc::getpwuid(libc::getuid()) };
+    if entry.is_null() {
+        return None;
+    }
+
+    let directory = unsafe { (*entry).pw_dir };
+    if directory.is_null() {
+        return None;
+    }
+
+    let directory = unsafe { CStr::from_ptr(directory) };
+    Some(std::path::PathBuf::from(OsStr::from_bytes(
+        directory.to_bytes(),
+    )))
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    /// The regression guard for the bug that made the macOS app blind to its
+    /// own tailnet: the container has to be named, because inside the App
+    /// Sandbox its parent cannot be listed.
+    #[test]
+    fn names_the_tailscale_containers_instead_of_searching_for_them() {
+        let containers = tailscale_group_containers();
+        let home = real_home().expect("the password database should report a home directory");
+
+        for name in [
+            "W5364U7YZB.group.io.tailscale.ipn.macos",
+            "io.tailscale.ipn.macsys",
+        ] {
+            let expected = home.join("Library/Group Containers").join(name);
+            assert!(
+                containers.contains(&expected),
+                "{name} must be addressed directly, since the App Sandbox denies listing its parent"
+            );
+        }
+    }
+
+    /// `HOME` is what the App Sandbox rewrites, so reading it would have
+    /// pointed the search at LocalSend's own container.
+    #[test]
+    fn does_not_take_the_home_directory_from_the_environment() {
+        std::env::set_var("HOME", "/nowhere/that/exists");
+
+        let home = real_home().expect("the password database should report a home directory");
+
+        assert_ne!(home, std::path::Path::new("/nowhere/that/exists"));
+        assert!(
+            tailscale_group_containers()
+                .iter()
+                .all(|path| !path.starts_with("/nowhere/that/exists")),
+            "the container search must not follow HOME"
+        );
+    }
+}

--- a/packages/core/src/tailscale/mod.rs
+++ b/packages/core/src/tailscale/mod.rs
@@ -1,0 +1,150 @@
+//! Discovery of the peers in this device's tailnet.
+//!
+//! Neither of LocalSend's discovery mechanisms finds anything over a
+//! [Tailscale](https://tailscale.com) tailnet. A tailnet carries no multicast,
+//! so announcements are never seen, and it hands out addresses from
+//! `100.64.0.0/10` — four million hosts, far past what a subnet scan can walk.
+//! Devices on the same tailnet but on different physical networks therefore
+//! stay invisible to each other, even though every one of them is directly
+//! reachable.
+//!
+//! The peer list has to come from the one process that already knows it: the
+//! Tailscale daemon running on this device. It is asked over its LocalAPI (see
+//! [`local_api`]) and the answer is turned into the addresses discovery then
+//! probes exactly like a favorite.
+//!
+//! Nothing here talks to Tailscale's servers, and no credential, key or node
+//! identity is read — only the addresses of the peers, which the device can
+//! dial anyway.
+//!
+//! This works the same way for a self-hosted control plane such as Headscale,
+//! because the daemon and its LocalAPI are the same. It cannot work on Android
+//! and iOS, where Tailscale runs as a VPN service that exposes no API to other
+//! apps — but it does not need to: a probe is a register request, so a desktop
+//! that enumerates the tailnet also makes itself visible to the phone it
+//! probes.
+
+mod local_api;
+mod status;
+
+pub use status::TailnetPeer;
+
+use status::Status;
+use std::net::IpAddr;
+use thiserror::Error;
+
+/// Whether `host` is an address a tailnet handed out, i.e. one that can only
+/// be reached through the tunnel.
+///
+/// Discovery uses this to decide how patient to be with a peer: a tailnet
+/// address may need a NAT to be punched or a relay on another continent, so
+/// the LAN timeout would drop it, while a LAN address must not be given the
+/// tailnet timeout or a subnet scan would take half a minute.
+///
+/// Accepts the scoped form `fe80::1%3` that [`crate::http::server::PeerIp`]
+/// renders, and answers `false` for a host that is not an address at all.
+pub fn is_tailnet_address(host: &str) -> bool {
+    // `100.64.0.0/10`, the range a tailnet assigns to its nodes. It is
+    // shared carrier-grade NAT space rather than Tailscale's own, so a LAN
+    // behind a CGNAT ISP lands in it too; being slower with such a peer is
+    // the harmless direction of that ambiguity.
+    const TAILNET_V4: u32 = 100 << 24 | 64 << 16;
+    const TAILNET_V4_MASK: u32 = !0 << 22;
+
+    // The first three groups of `fd7a:115c:a1e0::/48`. Unlike the IPv4 range
+    // this one is Tailscale's alone, being a fixed prefix it picked inside
+    // the private `fc00::/7` space.
+    const TAILNET_V6: [u16; 3] = [0xfd7a, 0x115c, 0xa1e0];
+
+    // Strip the scope of a link-local address, which never is a tailnet one
+    // but has to parse rather than fall through as a malformed host.
+    let host = host.split('%').next().unwrap_or(host);
+
+    match host.parse::<IpAddr>() {
+        Ok(IpAddr::V4(ip)) => u32::from(ip) & TAILNET_V4_MASK == TAILNET_V4,
+        Ok(IpAddr::V6(ip)) => ip.segments()[..3] == TAILNET_V6,
+        Err(_) => false,
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TailscaleError {
+    /// The local Tailscale daemon could not be reached: Tailscale is not
+    /// installed, not running, or its API is not readable by this process —
+    /// which is the case under a sandbox that hides the socket, e.g. some
+    /// Snap and Flatpak confinements.
+    ///
+    /// The expected outcome on a device without Tailscale, so callers treat
+    /// it as "no peers" rather than as a failure.
+    #[error("The local Tailscale daemon is not reachable: {0:#}")]
+    Unreachable(#[source] anyhow::Error),
+
+    /// The daemon answered with a document this version cannot read.
+    #[error("The Tailscale status could not be read: {0}")]
+    Malformed(#[source] serde_json::Error),
+}
+
+/// The peers in this device's tailnet that are worth probing: the ones that
+/// are online and hold an address.
+///
+/// Empty — not an error — when Tailscale is installed but not logged in or
+/// stopped, and when this device is the only node in its tailnet.
+pub async fn peers() -> Result<Vec<TailnetPeer>, TailscaleError> {
+    let body = local_api::status()
+        .await
+        .map_err(TailscaleError::Unreachable)?;
+
+    let status: Status = serde_json::from_slice(&body).map_err(TailscaleError::Malformed)?;
+
+    Ok(status.peers())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognises_the_ranges_a_tailnet_assigns() {
+        assert!(is_tailnet_address("100.64.0.0"), "the first address");
+        assert!(is_tailnet_address("100.90.62.40"));
+        assert!(is_tailnet_address("100.127.255.255"), "the last address");
+        assert!(is_tailnet_address("fd7a:115c:a1e0::d933:3e28"));
+    }
+
+    #[test]
+    fn rejects_addresses_outside_them() {
+        assert!(!is_tailnet_address("100.63.255.255"), "just below the range");
+        assert!(!is_tailnet_address("100.128.0.0"), "just above the range");
+        assert!(!is_tailnet_address("192.168.1.42"));
+        assert!(!is_tailnet_address("127.0.0.1"));
+        assert!(!is_tailnet_address("fd7a:115c:a1e1::1"), "a neighbouring /48");
+        assert!(!is_tailnet_address("2001:db8::1"));
+    }
+
+    #[test]
+    fn accepts_a_scoped_address_and_rejects_a_host_that_is_not_one() {
+        assert!(
+            !is_tailnet_address("fe80::1%3"),
+            "a scoped link-local address must parse, not be mistaken for one"
+        );
+        assert!(!is_tailnet_address("desktop.tail8182b8.ts.net"));
+        assert!(!is_tailnet_address(""));
+    }
+
+    /// Talks to the Tailscale daemon actually installed on the machine
+    /// running the test, which is the only way to cover the transport: the
+    /// LocalAPI is a real socket, not something that can be faked.
+    ///
+    /// Ignored by default, since most machines have no Tailscale. Run with
+    /// `cargo test --features tailscale -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore = "requires a running Tailscale daemon"]
+    async fn reads_the_peers_of_the_local_tailnet() {
+        let peers = peers().await.expect("the local daemon should answer");
+
+        println!("{} online tailnet peers", peers.len());
+        for peer in &peers {
+            println!("  {} ({})", peer.name, peer.host);
+        }
+    }
+}

--- a/packages/core/src/tailscale/status.rs
+++ b/packages/core/src/tailscale/status.rs
@@ -1,0 +1,239 @@
+//! The subset of the Tailscale status document that peer discovery reads.
+//!
+//! Both sources produce the same document — Tailscale's `ipnstate.Status` —
+//! so the LocalAPI response and the output of `tailscale status --json` are
+//! parsed by the same code. Only the handful of fields needed to dial a peer
+//! are modelled; everything else is ignored, so a tailscaled that is newer or
+//! older than this code still parses.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+/// The value of `BackendState` while the local node is logged in and up.
+/// Anything else (`NeedsLogin`, `Stopped`, `NoState`, ...) means there is no
+/// usable tailnet, and the peer list is then stale or empty.
+const RUNNING: &str = "Running";
+
+/// A peer in the local node's tailnet, reduced to what is needed to send it
+/// a register request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TailnetPeer {
+    /// The tailnet address to dial.
+    pub host: String,
+
+    /// The peer's MagicDNS name without its trailing dot, its hostname when
+    /// MagicDNS is off, and its address when it has neither. Only used for
+    /// logging: devices are identified by their LocalSend fingerprint, never
+    /// by anything Tailscale reports.
+    pub name: String,
+}
+
+/// The status document of the local Tailscale daemon.
+#[derive(Debug, Deserialize)]
+pub(super) struct Status {
+    #[serde(rename = "BackendState", default)]
+    backend_state: String,
+
+    /// Every other node in the tailnet, keyed by public key. `null` while
+    /// the local node is alone in its tailnet.
+    #[serde(rename = "Peer", default)]
+    peer: Option<BTreeMap<String, Node>>,
+}
+
+/// One node in the tailnet.
+#[derive(Debug, Deserialize)]
+struct Node {
+    /// The MagicDNS name including a trailing dot, e.g. `phone.tail1234.ts.net.`.
+    /// Empty when MagicDNS is disabled for the tailnet.
+    #[serde(rename = "DNSName", default)]
+    dns_name: String,
+
+    #[serde(rename = "HostName", default)]
+    host_name: String,
+
+    /// Every address the node holds inside the tailnet, IPv4 first.
+    /// Empty for a node that has not been assigned any yet.
+    #[serde(rename = "TailscaleIPs", default)]
+    tailscale_ips: Vec<IpAddr>,
+
+    /// Whether the peer currently holds a session with the control plane.
+    /// An offline peer cannot answer, so it is not probed.
+    #[serde(rename = "Online", default)]
+    online: bool,
+}
+
+impl Status {
+    /// The peers worth sending a register request: the online ones that hold
+    /// a tailnet address.
+    ///
+    /// Skipping the offline peers is what keeps this cheap — a tailnet of a
+    /// hundred mostly-idle nodes costs only as many probes as there are nodes
+    /// actually up, and an offline peer could not answer anyway.
+    ///
+    /// Empty while the local node is not up: the peer list is then stale, and
+    /// nothing in the tailnet is reachable regardless.
+    pub(super) fn peers(&self) -> Vec<TailnetPeer> {
+        if self.backend_state != RUNNING {
+            return Vec::new();
+        }
+
+        self.peer
+            .iter()
+            .flatten()
+            .filter(|(_, node)| node.online)
+            .filter_map(|(_, node)| node.to_peer())
+            .collect()
+    }
+}
+
+impl Node {
+    fn to_peer(&self) -> Option<TailnetPeer> {
+        let host = self.dial_address()?;
+        Some(TailnetPeer {
+            host: host.to_string(),
+            name: self.name(host),
+        })
+    }
+
+    /// The address to dial, preferring IPv4.
+    ///
+    /// A tailnet always assigns an IPv4 address from `100.64.0.0/10`, while
+    /// the IPv6 one is only routable when the local node has IPv6 enabled,
+    /// so IPv4 is the address that works in every setup.
+    fn dial_address(&self) -> Option<IpAddr> {
+        self.tailscale_ips
+            .iter()
+            .find(|ip| ip.is_ipv4())
+            .or_else(|| self.tailscale_ips.first())
+            .copied()
+    }
+
+    fn name(&self, host: IpAddr) -> String {
+        let dns_name = self.dns_name.trim_end_matches('.');
+        if !dns_name.is_empty() {
+            return dns_name.to_owned();
+        }
+        if !self.host_name.is_empty() {
+            return self.host_name.clone();
+        }
+        host.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A status document shaped like the real one, with a peer per case that
+    /// the filtering has to get right.
+    const STATUS: &str = r#"{
+        "Version": "1.102.2-t6cac91817-g6ff0ddc72",
+        "BackendState": "Running",
+        "TailscaleIPs": ["100.90.62.40", "fd7a:115c:a1e0::d933:3e28"],
+        "Self": {
+            "HostName": "desktop",
+            "DNSName": "desktop.tail8182b8.ts.net.",
+            "TailscaleIPs": ["100.90.62.40", "fd7a:115c:a1e0::d933:3e28"],
+            "Online": true
+        },
+        "Peer": {
+            "nodekey:aaa": {
+                "HostName": "phone",
+                "DNSName": "phone.tail8182b8.ts.net.",
+                "OS": "android",
+                "TailscaleIPs": ["100.110.244.93", "fd7a:115c:a1e0::ca36:f45d"],
+                "Online": true,
+                "Active": false
+            },
+            "nodekey:bbb": {
+                "HostName": "server",
+                "DNSName": "server.tail8182b8.ts.net.",
+                "TailscaleIPs": ["100.64.0.7"],
+                "Online": false
+            },
+            "nodekey:ccc": {
+                "HostName": "v6only",
+                "DNSName": "",
+                "TailscaleIPs": ["fd7a:115c:a1e0::1234:5678"],
+                "Online": true
+            },
+            "nodekey:ddd": {
+                "HostName": "",
+                "DNSName": "",
+                "TailscaleIPs": [],
+                "Online": true
+            }
+        }
+    }"#;
+
+    fn parse(json: &str) -> Status {
+        serde_json::from_str(json).expect("the status document should parse")
+    }
+
+    #[test]
+    fn takes_the_ipv4_address_and_the_magic_dns_name() {
+        let peers = parse(STATUS).peers();
+
+        assert!(peers.contains(&TailnetPeer {
+            host: "100.110.244.93".to_owned(),
+            name: "phone.tail8182b8.ts.net".to_owned(),
+        }));
+    }
+
+    #[test]
+    fn skips_offline_peers() {
+        let peers = parse(STATUS).peers();
+
+        assert!(!peers.iter().any(|peer| peer.host == "100.64.0.7"));
+    }
+
+    #[test]
+    fn falls_back_to_ipv6_and_to_the_hostname() {
+        let peers = parse(STATUS).peers();
+
+        assert!(peers.contains(&TailnetPeer {
+            host: "fd7a:115c:a1e0::1234:5678".to_owned(),
+            name: "v6only".to_owned(),
+        }));
+    }
+
+    #[test]
+    fn skips_peers_without_an_address() {
+        assert_eq!(parse(STATUS).peers().len(), 2);
+    }
+
+    #[test]
+    fn ignores_the_peers_of_a_node_that_is_not_up() {
+        let json = STATUS.replace(
+            r#""BackendState": "Running""#,
+            r#""BackendState": "NeedsLogin""#,
+        );
+
+        assert!(parse(&json).peers().is_empty());
+    }
+
+    #[test]
+    fn accepts_a_node_that_is_alone_in_its_tailnet() {
+        let json = r#"{"BackendState": "Running", "Peer": null}"#;
+
+        assert!(parse(json).peers().is_empty());
+    }
+
+    #[test]
+    fn ignores_unknown_and_missing_fields() {
+        let json = r#"{
+            "BackendState": "Running",
+            "SomethingAddedLater": {"nested": true},
+            "Peer": {"nodekey:aaa": {"TailscaleIPs": ["100.1.2.3"], "Online": true}}
+        }"#;
+
+        assert_eq!(
+            parse(json).peers(),
+            vec![TailnetPeer {
+                host: "100.1.2.3".to_owned(),
+                name: "100.1.2.3".to_owned(),
+            }]
+        );
+    }
+}

--- a/packages/core/tests/discovery.rs
+++ b/packages/core/tests/discovery.rs
@@ -10,7 +10,8 @@
 
 use localsend::crypto::cert::generate_self_signed;
 use localsend::discovery::{
-    self, DeviceIdentity, DiscoveryConfig, DiscoveryEvent, DiscoveryHandle,
+    self, DeviceChannel, DeviceIdentity, DiscoveredDevice, DiscoveryConfig, DiscoveryEvent,
+    DiscoveryHandle, HttpChannel,
 };
 use localsend::http::server::{start_with_port, ServerConfigV2, TlsConfig};
 use localsend::http::state::ClientInfo;
@@ -156,6 +157,9 @@ async fn start_instance_with_cert(
             },
             timeout: discovery::DEFAULT_DISCOVERY_TIMEOUT,
             event_tx: Some(event_tx),
+            // These tests cover the LAN stages; the tailnet stage would talk
+            // to whatever Tailscale daemon the test machine happens to run.
+            tailnet: false,
         },
         stop_rx,
     )
@@ -383,6 +387,7 @@ async fn test_discovery_works_without_multicast() {
             },
             timeout: discovery::DEFAULT_DISCOVERY_TIMEOUT,
             event_tx: None,
+            tailnet: false,
         },
         stop_rx,
     )
@@ -450,5 +455,132 @@ async fn test_announcement_is_answered_and_device_stored() {
             .device_by_fingerprint(&receiver.fingerprint)
             .is_none(),
         "answering over HTTP must not make the receiver appear on the announcer's side"
+    );
+}
+
+/// Starts a discovery instance whose multicast side fails deterministically
+/// (no interface matches the whitelist). The escalation tests below need
+/// this: an announcement answered by an unrelated instance on the machine
+/// would count as a local confirmation and suppress the scan on its own.
+async fn start_instance_without_multicast(alias: &str) -> (DiscoveryHandle, oneshot::Sender<()>) {
+    let cert = generate_self_signed().expect("Failed to generate an identity");
+    let (stop_tx, stop_rx) = oneshot::channel();
+    let handle = discovery::start(
+        DiscoveryConfig {
+            group: TEST_GROUP,
+            group_v6: Some(TEST_GROUP_V6),
+            port: NEXT_MULTICAST_PORT.fetch_add(1, Ordering::Relaxed),
+            interface_filter: InterfaceFilter {
+                whitelist: Some(vec!["203.0.113.1".to_string()]),
+                blacklist: None,
+            },
+            device: MulticastDevice {
+                alias: alias.to_string(),
+                version: PROTOCOL_VERSION_V2.to_string(),
+                device_model: Some("Rust".to_string()),
+                device_type: Some(DeviceType::Headless),
+                fingerprint: cert.fingerprint.clone(),
+                port: announce_port(),
+                protocol: ProtocolType::Http,
+                download: false,
+            },
+            identity: DeviceIdentity {
+                cert_pem: cert.certificate_pem,
+                private_key_pem: cert.private_key_pem,
+            },
+            timeout: discovery::DEFAULT_DISCOVERY_TIMEOUT,
+            event_tx: None,
+            tailnet: false,
+        },
+        stop_rx,
+    )
+    .await;
+    assert!(
+        handle.multicast_error().is_some(),
+        "no interface matches the whitelist, so multicast must be unavailable"
+    );
+    (handle, stop_tx)
+}
+
+/// A device as the application feeds it back after an inbound register,
+/// reachable at `host`.
+fn registered_device(fingerprint: &str, host: &str) -> DiscoveredDevice {
+    DiscoveredDevice {
+        alias: format!("Alias of {fingerprint}"),
+        version: PROTOCOL_VERSION_V2.to_string(),
+        device_model: Some("Rust".to_string()),
+        device_type: Some(DeviceType::Headless),
+        fingerprint: fingerprint.to_string(),
+        channel: DeviceChannel::Http(HttpChannel {
+            host: host.to_string(),
+            port: 53317,
+            protocol: ProtocolType::Http,
+        }),
+        download: false,
+    }
+}
+
+/// A register arriving through the tailnet during the grace period says
+/// nothing about the local network, so the subnet scan must still run —
+/// otherwise a phone whose only contact is a tailnet peer never scans the
+/// multicast-less LAN it sits on.
+#[tokio::test]
+async fn test_tailnet_registration_does_not_suppress_subnet_scan() {
+    let (server_port, _server_stop) = start_register_server("ScanTarget", "scan-target", None).await;
+
+    let (handle, _stop_tx) = start_instance_without_multicast("TailnetFed").await;
+
+    let staged = handle.discover_staged(
+        Vec::new(),
+        vec![Ipv4Addr::new(127, 0, 0, 99)],
+        server_port,
+        ProtocolType::Http,
+        Duration::from_millis(1500),
+    );
+    // Lands well inside the grace period, like a peer probing this device
+    // over the tailnet while it scans.
+    let inject = async {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        handle
+            .add_device(registered_device("tailnet-peer", "100.64.0.1"))
+            .await;
+    };
+    let (result, ()) = tokio::join!(staged, inject);
+    result.expect("Staged discovery failed");
+
+    assert!(
+        handle.device_by_fingerprint("scan-target").is_some(),
+        "a tailnet registration must not suppress the subnet scan"
+    );
+}
+
+/// The control for the test above: the same registration from a LAN address
+/// proves the local network works, so the escalation is skipped — the
+/// behavior every register-fed confirmation had before the tailnet stage.
+#[tokio::test]
+async fn test_lan_registration_suppresses_subnet_scan() {
+    let (server_port, _server_stop) = start_register_server("ScanTarget", "scan-target", None).await;
+
+    let (handle, _stop_tx) = start_instance_without_multicast("LanFed").await;
+
+    let staged = handle.discover_staged(
+        Vec::new(),
+        vec![Ipv4Addr::new(127, 0, 0, 99)],
+        server_port,
+        ProtocolType::Http,
+        Duration::from_millis(1500),
+    );
+    let inject = async {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        handle
+            .add_device(registered_device("lan-peer", "192.168.1.20"))
+            .await;
+    };
+    let (result, ()) = tokio::join!(staged, inject);
+    result.expect("Staged discovery failed");
+
+    assert!(
+        handle.device_by_fingerprint("scan-target").is_none(),
+        "a local registration proves the cheap stages work, so the scan must be skipped"
     );
 }

--- a/packages/core/tests/event_backpressure.rs
+++ b/packages/core/tests/event_backpressure.rs
@@ -134,6 +134,7 @@ async fn subnet_scan_finishes_when_events_are_not_consumed() {
             },
             timeout: discovery::DEFAULT_DISCOVERY_TIMEOUT,
             event_tx: Some(event_tx),
+            tailnet: false,
         },
         discovery_stop_rx,
     )

--- a/packages/localsend_isolates/lib/rust/api/discovery.dart
+++ b/packages/localsend_isolates/lib/rust/api/discovery.dart
@@ -22,6 +22,9 @@ import 'package:localsend_isolates/rust/frb_generated.dart';
 /// device's TLS identity, sent as client certificate with every register
 /// request; [fingerprint] must be the certificate's SHA-256 fingerprint.
 ///
+/// [tailnet] additionally probes the peers of this device's tailnet on every
+/// staged discovery, see [RsDiscovery::set_tailnet].
+///
 /// Nothing is announced until [RsDiscovery::announce] is called.
 ///
 /// Cannot fail besides an invalid [group]: when no multicast socket could be
@@ -44,6 +47,7 @@ Future<RsDiscovery> startDiscovery({
   required String certPem,
   required String privateKeyPem,
   required BigInt timeoutMs,
+  required bool tailnet,
 }) => RustLib.instance.api.crateApiDiscoveryStartDiscovery(
   group: group,
   port: port,
@@ -59,6 +63,7 @@ Future<RsDiscovery> startDiscovery({
   certPem: certPem,
   privateKeyPem: privateKeyPem,
   timeoutMs: timeoutMs,
+  tailnet: tailnet,
 );
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsDiscovery>>
@@ -134,6 +139,16 @@ abstract class RsDiscovery implements RustOpaqueInterface {
   /// Turned off while the HTTP server is not running: the answer would
   /// advertise a port that nobody listens on.
   Future<void> setAnswerAnnouncements({required bool answer});
+
+  /// Sets whether [RsDiscovery::discover_staged] also probes the peers of
+  /// this device's tailnet, for devices that are reachable over Tailscale
+  /// but not on the same physical network.
+  ///
+  /// Takes effect on the next discovery, so the setting can be toggled
+  /// without rebinding the sockets. Costs nothing on a device that has no
+  /// Tailscale, and cannot work on Android and iOS, where Tailscale exposes
+  /// no API to other apps.
+  Future<void> setTailnet({required bool tailnet});
 
   /// Stops the discovery, which also ends the [RsDiscovery::listen] stream.
   /// Returns after all sockets are closed, so the port can be bound again.

--- a/packages/localsend_isolates/lib/rust/frb_generated.dart
+++ b/packages/localsend_isolates/lib/rust/frb_generated.dart
@@ -76,7 +76,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1979579466;
+  int get rustContentHash => 830273978;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'rust_lib_localsend_app',
@@ -141,6 +141,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateApiDiscoveryRsDiscoverySetAnswerAnnouncements({required RsDiscovery that, required bool answer});
+
+  Future<void> crateApiDiscoveryRsDiscoverySetTailnet({required RsDiscovery that, required bool tailnet});
 
   Future<void> crateApiDiscoveryRsDiscoveryStop({required RsDiscovery that});
 
@@ -298,6 +300,7 @@ abstract class RustLibApi extends BaseApi {
     required String certPem,
     required String privateKeyPem,
     required BigInt timeoutMs,
+    required bool tailnet,
   });
 
   Future<RsHttpServer> crateApiServerStartServer({
@@ -798,13 +801,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<void> crateApiDiscoveryRsDiscoverySetTailnet({required RsDiscovery that, required bool tailnet}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
+          sse_encode_bool(tailnet, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15, port: port_);
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiDiscoveryRsDiscoverySetTailnetConstMeta,
+        argValues: [that, tailnet],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiDiscoveryRsDiscoverySetTailnetConstMeta => const TaskConstMeta(
+    debugName: 'RsDiscovery_set_tailnet',
+    argNames: ['that', 'tailnet'],
+  );
+
+  @override
   Future<void> crateApiDiscoveryRsDiscoveryStop({required RsDiscovery that}) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -839,7 +868,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ip, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_String(sessionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -880,7 +909,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_String(publicKey, serializer);
           sse_encode_opt_String(pin, serializer);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_prepare_upload_result,
@@ -915,7 +944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ip, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_box_autoadd_register_dto(payload, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_result_with_public_key_register_response_dto,
@@ -972,7 +1001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(contentLength, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1015,7 +1044,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1042,7 +1071,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1069,7 +1098,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1097,7 +1126,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
             sse_encode_StreamSink_rs_server_event_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1134,7 +1163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(fileId, serializer);
           sse_encode_opt_String(path, serializer);
           sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1174,7 +1203,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_String(path, serializer);
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(fileSize, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1203,7 +1232,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_bool(accept, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1229,7 +1258,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_opt_list_String(acceptedFileIds, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1254,7 +1283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1279,7 +1308,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1307,7 +1336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
             sse_encode_StreamSink_list_prim_u_8_strict_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1335,7 +1364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender(that, serializer);
           sse_encode_list_prim_u_8_loose(data, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1360,7 +1389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1388,7 +1417,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1415,7 +1444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_file_dto,
@@ -1443,7 +1472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1473,7 +1502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1501,7 +1530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_box_autoadd_rtc_send_file_response(status, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1527,7 +1556,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1553,7 +1582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_Set_String_None(selection, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1581,7 +1610,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1608,7 +1637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Set_String_None,
@@ -1636,7 +1665,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1664,7 +1693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender,
@@ -1690,7 +1719,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1729,7 +1758,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               onConnection,
               serializer,
             );
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1755,7 +1784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken,
@@ -1790,7 +1819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_ls_http_client_version(version, serializer);
           sse_encode_opt_String(expectedFingerprint, serializer);
           sse_encode_opt_box_autoadd_u_32(timeoutMs, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpClient,
@@ -1814,7 +1843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1839,7 +1868,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1863,7 +1892,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_key_pair,
@@ -1887,7 +1916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_security_context,
@@ -1918,7 +1947,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_opt_list_prim_u_8_strict(bytes, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1945,7 +1974,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1970,7 +1999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(path, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_file_metadata,
@@ -1995,7 +2024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2029,6 +2058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String certPem,
     required String privateKeyPem,
     required BigInt timeoutMs,
+    required bool tailnet,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -2048,7 +2078,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(certPem, serializer);
           sse_encode_String(privateKeyPem, serializer);
           sse_encode_u_64(timeoutMs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56, port: port_);
+          sse_encode_bool(tailnet, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery,
@@ -2070,6 +2101,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           certPem,
           privateKeyPem,
           timeoutMs,
+          tailnet,
         ],
         apiImpl: this,
       ),
@@ -2093,6 +2125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       'certPem',
       'privateKeyPem',
       'timeoutMs',
+      'tailnet',
     ],
   );
 
@@ -2125,7 +2158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_bool(verifyChecksums, serializer);
           sse_encode_opt_box_autoadd_web_params(web, serializer);
           sse_encode_opt_String(showToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer,
@@ -2151,7 +2184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cert, serializer);
           sse_encode_String(publicKey, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -6518,6 +6551,16 @@ class RsDiscoveryImpl extends RustOpaque implements RsDiscovery {
   /// advertise a port that nobody listens on.
   Future<void> setAnswerAnnouncements({required bool answer}) =>
       RustLib.instance.api.crateApiDiscoveryRsDiscoverySetAnswerAnnouncements(that: this, answer: answer);
+
+  /// Sets whether [RsDiscovery::discover_staged] also probes the peers of
+  /// this device's tailnet, for devices that are reachable over Tailscale
+  /// but not on the same physical network.
+  ///
+  /// Takes effect on the next discovery, so the setting can be toggled
+  /// without rebinding the sockets. Costs nothing on a device that has no
+  /// Tailscale, and cannot work on Android and iOS, where Tailscale exposes
+  /// no API to other apps.
+  Future<void> setTailnet({required bool tailnet}) => RustLib.instance.api.crateApiDiscoveryRsDiscoverySetTailnet(that: this, tailnet: tailnet);
 
   /// Stops the discovery, which also ends the [RsDiscovery::listen] stream.
   /// Returns after all sockets are closed, so the port can be bound again.

--- a/packages/localsend_isolates/lib/src/isolate/child/sync_provider.dart
+++ b/packages/localsend_isolates/lib/src/isolate/child/sync_provider.dart
@@ -21,6 +21,9 @@ class SyncState with SyncStateMappable {
   final String multicastGroup;
   final int discoveryTimeout;
 
+  /// Whether discovery also probes the peers of this device's tailnet.
+  final bool tailnet;
+
   final bool serverRunning;
   final bool download;
 
@@ -35,13 +38,14 @@ class SyncState with SyncStateMappable {
     required this.protocol,
     required this.multicastGroup,
     required this.discoveryTimeout,
+    required this.tailnet,
     required this.serverRunning,
     required this.download,
   });
 
   @override
   String toString() {
-    return 'SyncState(securityContext: <SecurityContext>, deviceInfo: $deviceInfo, alias: $alias, port: $port, networkWhitelist: $networkWhitelist, networkBlacklist: $networkBlacklist, protocol: $protocol, multicastGroup: $multicastGroup, discoveryTimeout: $discoveryTimeout, serverRunning: $serverRunning, download: $download)';
+    return 'SyncState(securityContext: <SecurityContext>, deviceInfo: $deviceInfo, alias: $alias, port: $port, networkWhitelist: $networkWhitelist, networkBlacklist: $networkBlacklist, protocol: $protocol, multicastGroup: $multicastGroup, discoveryTimeout: $discoveryTimeout, tailnet: $tailnet, serverRunning: $serverRunning, download: $download)';
   }
 }
 

--- a/packages/localsend_isolates/lib/src/isolate/child/sync_provider.mapper.dart
+++ b/packages/localsend_isolates/lib/src/isolate/child/sync_provider.mapper.dart
@@ -67,6 +67,8 @@ class SyncStateMapper extends ClassMapperBase<SyncState> {
     'discoveryTimeout',
     _$discoveryTimeout,
   );
+  static bool _$tailnet(SyncState v) => v.tailnet;
+  static const Field<SyncState, bool> _f$tailnet = Field('tailnet', _$tailnet);
   static bool _$serverRunning(SyncState v) => v.serverRunning;
   static const Field<SyncState, bool> _f$serverRunning = Field(
     'serverRunning',
@@ -90,6 +92,7 @@ class SyncStateMapper extends ClassMapperBase<SyncState> {
     #protocol: _f$protocol,
     #multicastGroup: _f$multicastGroup,
     #discoveryTimeout: _f$discoveryTimeout,
+    #tailnet: _f$tailnet,
     #serverRunning: _f$serverRunning,
     #download: _f$download,
   };
@@ -106,6 +109,7 @@ class SyncStateMapper extends ClassMapperBase<SyncState> {
       protocol: data.dec(_f$protocol),
       multicastGroup: data.dec(_f$multicastGroup),
       discoveryTimeout: data.dec(_f$discoveryTimeout),
+      tailnet: data.dec(_f$tailnet),
       serverRunning: data.dec(_f$serverRunning),
       download: data.dec(_f$download),
     );
@@ -191,6 +195,7 @@ abstract class SyncStateCopyWith<$R, $In extends SyncState, $Out>
     ProtocolType? protocol,
     String? multicastGroup,
     int? discoveryTimeout,
+    bool? tailnet,
     bool? serverRunning,
     bool? download,
   });
@@ -243,6 +248,7 @@ class _SyncStateCopyWithImpl<$R, $Out>
     ProtocolType? protocol,
     String? multicastGroup,
     int? discoveryTimeout,
+    bool? tailnet,
     bool? serverRunning,
     bool? download,
   }) => $apply(
@@ -257,6 +263,7 @@ class _SyncStateCopyWithImpl<$R, $Out>
       if (protocol != null) #protocol: protocol,
       if (multicastGroup != null) #multicastGroup: multicastGroup,
       if (discoveryTimeout != null) #discoveryTimeout: discoveryTimeout,
+      if (tailnet != null) #tailnet: tailnet,
       if (serverRunning != null) #serverRunning: serverRunning,
       if (download != null) #download: download,
     }),
@@ -273,6 +280,7 @@ class _SyncStateCopyWithImpl<$R, $Out>
     protocol: data.get(#protocol, or: $value.protocol),
     multicastGroup: data.get(#multicastGroup, or: $value.multicastGroup),
     discoveryTimeout: data.get(#discoveryTimeout, or: $value.discoveryTimeout),
+    tailnet: data.get(#tailnet, or: $value.tailnet),
     serverRunning: data.get(#serverRunning, or: $value.serverRunning),
     download: data.get(#download, or: $value.download),
   );

--- a/packages/localsend_isolates/lib/src/isolate/parent/actions_sync.dart
+++ b/packages/localsend_isolates/lib/src/isolate/parent/actions_sync.dart
@@ -53,12 +53,14 @@ class IsolateSyncSettingsAction extends ReduxAction<IsolateController, ParentIso
   final List<String>? networkBlacklist;
   final String multicastGroup;
   final int discoveryTimeout;
+  final bool tailnet;
 
   IsolateSyncSettingsAction({
     required this.networkWhitelist,
     required this.networkBlacklist,
     required this.multicastGroup,
     required this.discoveryTimeout,
+    required this.tailnet,
   });
 
   @override
@@ -70,6 +72,7 @@ class IsolateSyncSettingsAction extends ReduxAction<IsolateController, ParentIso
           networkBlacklist: networkBlacklist,
           multicastGroup: multicastGroup,
           discoveryTimeout: discoveryTimeout,
+          tailnet: tailnet,
         ),
       ),
     );

--- a/packages/localsend_isolates/lib/src/task/discovery/discovery.dart
+++ b/packages/localsend_isolates/lib/src/task/discovery/discovery.dart
@@ -11,6 +11,17 @@ import 'package:refena_flutter/refena_flutter.dart';
 
 final _logger = Logger('Discovery');
 
+/// How many registrations are held while the discovery is down.
+/// Bounded because nothing limits how many devices may register in that
+/// window, and the isolate must not grow its memory from the network.
+const _maxPendingDevices = 64;
+
+/// The default of [DiscoveryService.startTimeout]. Generous compared to the
+/// startup itself, which only binds the multicast sockets, because the cost
+/// of waiting is invisible while the cost of skipping a scan is a device
+/// list that stays empty until the user rescans by hand.
+const _defaultStartTimeout = Duration(seconds: 5);
+
 final discoveryProvider = Provider((ref) {
   return DiscoveryService(ref);
 });
@@ -20,16 +31,49 @@ final discoveryProvider = Provider((ref) {
 /// of confirmed devices all live on the Rust side. This service configures it
 /// from the [syncProvider] state and maps every confirmation to a [Device].
 class DiscoveryService {
-  DiscoveryService(this._ref);
+  DiscoveryService(this._ref, {this.startTimeout = _defaultStartTimeout});
 
   final Ref _ref;
+
+  /// How long a scan waits for the discovery to come up before it is skipped.
+  ///
+  /// The app dispatches its first automatic scan without awaiting the
+  /// discovery startup, so that scan regularly arrives while [_discovery] is
+  /// still null. Dropping it there is only recoverable on a LAN, where the
+  /// startup announcement makes every peer register again; over a tailnet a
+  /// dropped scan means the persisted peers are not probed until the user
+  /// rescans by hand.
+  final Duration startTimeout;
+
   RsDiscovery? _discovery;
   Completer<void> _retryCompleter = Completer();
+
+  /// Whether the last start attempt failed and the listener is parked until
+  /// [restartListener]. A scan skips immediately in this state: only a
+  /// settings change can end it, so the wait of [_runningDiscovery] could
+  /// never be answered.
+  bool _startFailed = false;
+
+  /// Completed once the discovery runs, re-created when it stops: what a
+  /// scan awaits when it arrives while the discovery is still starting.
+  Completer<void> _started = Completer();
+
   bool _listening = false;
 
   /// Whether the current discovery was stopped by [restartListener], as
   /// opposed to stopping itself because the multicast sockets failed.
   bool _restartRequested = false;
+
+  /// Devices that registered with this device's HTTP server while the
+  /// discovery was starting or restarting, by fingerprint, newest last.
+  ///
+  /// On a LAN such a device would come back by itself, because the
+  /// announcement sent when the discovery starts makes it register again.
+  /// A peer reached over a tailnet answers no announcement and its address
+  /// range cannot be scanned, so dropping it here would lose it until that
+  /// peer happens to probe this device again — which on Android and iOS,
+  /// where the tailnet cannot be enumerated, is the only way it is ever found.
+  final Map<String, Device> _pending = {};
 
   /// Starts the discovery and emits every device confirmation:
   /// answered announcements, scan results and devices fed in
@@ -54,6 +98,11 @@ class DiscoveryService {
       if (event.prev.serverRunning != event.next.serverRunning) {
         unawaited(_discovery?.setAnswerAnnouncements(answer: event.next.serverRunning));
       }
+      // Applied without rebinding the sockets: the tailnet stage only runs
+      // during a scan, so the next one already picks up the new value.
+      if (event.prev.tailnet != event.next.tailnet) {
+        unawaited(_discovery?.setTailnet(tailnet: event.next.tailnet));
+      }
     });
 
     while (true) {
@@ -76,12 +125,15 @@ class DiscoveryService {
           certPem: syncState.securityContext.certificate,
           privateKeyPem: syncState.securityContext.privateKey,
           timeoutMs: BigInt.from(syncState.discoveryTimeout),
+          tailnet: syncState.tailnet,
         );
       } catch (e) {
         _logger.warning('Could not start discovery (group: ${syncState.multicastGroup}, port: ${syncState.port})', e);
         // Wait for the next restart request instead of hot-looping
+        _startFailed = true;
         _retryCompleter = Completer();
         await _retryCompleter.future;
+        _startFailed = false;
         continue;
       }
 
@@ -95,6 +147,10 @@ class DiscoveryService {
       }
 
       _discovery = discovery;
+      if (!_started.isCompleted) {
+        _started.complete();
+      }
+      await _flushPending();
 
       // Tell everyone in the network that I am online.
       unawaited(discovery.announce());
@@ -106,6 +162,10 @@ class DiscoveryService {
       }
 
       _discovery = null;
+      // Re-armed before the restart branch below: the discovery is already down
+      // at this point, so a scan arriving during the restart delay must wait for
+      // the rebind rather than read the completer the previous run left completed.
+      _started = Completer();
 
       if (_restartRequested) {
         // The stream ended because [restartListener] stopped the discovery.
@@ -151,9 +211,9 @@ class DiscoveryService {
   /// Found devices arrive on the [startListener] stream; this method returns
   /// once the whole scan has finished.
   Future<void> scanSubnet({required String networkInterface, required int port, required bool https}) async {
-    final discovery = _discovery;
+    final discovery = await _runningDiscovery();
     if (discovery == null) {
-      _logger.info('Discovery is not running, skipping subnet scan');
+      _logger.warning('Discovery did not start within $startTimeout, skipping subnet scan');
       return;
     }
 
@@ -162,6 +222,24 @@ class DiscoveryService {
       port: port,
       protocol: https ? rust_model.ProtocolType.https : rust_model.ProtocolType.http,
     );
+  }
+
+  /// The running discovery, waited for up to [startTimeout] when it is still
+  /// starting. Null when it did not come up in time, e.g. because starting
+  /// failed and the retry is waiting for a settings change.
+  Future<RsDiscovery?> _runningDiscovery() async {
+    if (_discovery != null) {
+      return _discovery;
+    }
+    if (_startFailed) {
+      return null;
+    }
+    try {
+      await _started.future.timeout(startTimeout);
+    } on TimeoutException {
+      return null;
+    }
+    return _discovery;
   }
 
   /// Discovers devices in stages, cheapest first: announces this device and
@@ -177,9 +255,9 @@ class DiscoveryService {
     required bool https,
     required Duration grace,
   }) async {
-    final discovery = _discovery;
+    final discovery = await _runningDiscovery();
     if (discovery == null) {
-      _logger.info('Discovery is not running, skipping staged discovery');
+      _logger.warning('Discovery did not start within $startTimeout, skipping staged discovery');
       return;
     }
 
@@ -211,16 +289,44 @@ class DiscoveryService {
   /// Feeds a device confirmed outside of the discovery into the store, e.g.
   /// one that registered with this device's HTTP server.
   /// The device comes back on the [startListener] stream.
+  ///
+  /// A device that arrives while the discovery is starting or restarting is
+  /// held until it runs again, see [_pending].
   Future<void> addDevice(Device device) async {
-    final discovery = _discovery;
     final ip = device.ip;
-    if (discovery == null || ip == null) {
-      // A device lost here re-appears on its next register request, which the
-      // announcement sent when the discovery (re)starts triggers by itself.
-      _logger.info('Discovery is not running, skipping device ${device.alias} ($ip)');
+    if (ip == null) {
+      _logger.info('Skipping device ${device.alias} without an address');
+      return;
+    }
+
+    final discovery = _discovery;
+    if (discovery == null) {
+      if (_pending.length >= _maxPendingDevices) {
+        _pending.remove(_pending.keys.first);
+      }
+      _pending[device.fingerprint] = device;
+      _logger.info('Discovery is not running, holding device ${device.alias} ($ip)');
       return;
     }
 
     await discovery.addDevice(device: device.toRsDiscoveredDevice(ip));
+  }
+
+  /// Registers the devices held while the discovery was down, oldest first.
+  Future<void> _flushPending() async {
+    final discovery = _discovery;
+    if (discovery == null || _pending.isEmpty) {
+      return;
+    }
+
+    final pending = List<Device>.of(_pending.values);
+    _pending.clear();
+    _logger.info('Registering ${pending.length} device(s) held while the discovery was down');
+    for (final device in pending) {
+      final ip = device.ip;
+      if (ip != null) {
+        await discovery.addDevice(device: device.toRsDiscoveredDevice(ip));
+      }
+    }
   }
 }

--- a/packages/localsend_isolates/rust/src/api/discovery.rs
+++ b/packages/localsend_isolates/rust/src/api/discovery.rs
@@ -155,6 +155,9 @@ static RUNNING_DISCOVERY: Mutex<Option<Arc<DiscoveryInstance>>> = Mutex::const_n
 /// device's TLS identity, sent as client certificate with every register
 /// request; [fingerprint] must be the certificate's SHA-256 fingerprint.
 ///
+/// [tailnet] additionally probes the peers of this device's tailnet on every
+/// staged discovery, see [RsDiscovery::set_tailnet].
+///
 /// Nothing is announced until [RsDiscovery::announce] is called.
 ///
 /// Cannot fail besides an invalid [group]: when no multicast socket could be
@@ -177,6 +180,7 @@ pub async fn start_discovery(
     cert_pem: String,
     private_key_pem: String,
     timeout_ms: u64,
+    tailnet: bool,
 ) -> anyhow::Result<RsDiscovery> {
     let group = group
         .parse()
@@ -218,6 +222,7 @@ pub async fn start_discovery(
             },
             timeout: Duration::from_millis(timeout_ms),
             event_tx: Some(event_tx),
+            tailnet,
         },
         stop_rx,
     )
@@ -317,6 +322,18 @@ impl RsDiscovery {
     /// advertise a port that nobody listens on.
     pub fn set_answer_announcements(&self, answer: bool) {
         self.instance.handle.set_answer_announcements(answer);
+    }
+
+    /// Sets whether [RsDiscovery::discover_staged] also probes the peers of
+    /// this device's tailnet, for devices that are reachable over Tailscale
+    /// but not on the same physical network.
+    ///
+    /// Takes effect on the next discovery, so the setting can be toggled
+    /// without rebinding the sockets. Costs nothing on a device that has no
+    /// Tailscale, and cannot work on Android and iOS, where Tailscale exposes
+    /// no API to other apps.
+    pub fn set_tailnet(&self, tailnet: bool) {
+        self.instance.handle.set_tailnet(tailnet);
     }
 
     /// Discovers devices in stages, cheapest first: announces this device to

--- a/packages/localsend_isolates/rust/src/frb_generated.rs
+++ b/packages/localsend_isolates/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1979579466;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 830273978;
 
 // Section: executor
 
@@ -875,6 +875,61 @@ fn wire__crate__api__discovery__RsDiscovery_set_answer_announcements_impl(
                         crate::api::discovery::RsDiscovery::set_answer_announcements(
                             &*api_that_guard,
                             api_answer,
+                        );
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__discovery__RsDiscovery_set_tailnet_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "RsDiscovery_set_tailnet",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsDiscovery>,
+            >>::sse_decode(&mut deserializer);
+            let api_tailnet = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::discovery::RsDiscovery::set_tailnet(
+                            &*api_that_guard,
+                            api_tailnet,
                         );
                     })?;
                     Ok(output_ok)
@@ -3242,6 +3297,7 @@ fn wire__crate__api__discovery__start_discovery_impl(
             let api_cert_pem = <String>::sse_decode(&mut deserializer);
             let api_private_key_pem = <String>::sse_decode(&mut deserializer);
             let api_timeout_ms = <u64>::sse_decode(&mut deserializer);
+            let api_tailnet = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -3261,6 +3317,7 @@ fn wire__crate__api__discovery__start_discovery_impl(
                             api_cert_pem,
                             api_private_key_pem,
                             api_timeout_ms,
+                            api_tailnet,
                         )
                         .await?;
                         Ok(output_ok)
@@ -5223,170 +5280,176 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__api__discovery__RsDiscovery_stop_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__http__RsHttpClient_cancel_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
+        15 => wire__crate__api__discovery__RsDiscovery_set_tailnet_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        18 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
+        16 => wire__crate__api__discovery__RsDiscovery_stop_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__http__RsHttpClient_cancel_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        21 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
+        19 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        22 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
+        22 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
+        23 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        25 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
+        24 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        26 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
+        26 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        27 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
+        27 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
+        28 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
+        29 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
+        31 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
+        32 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
+        34 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
+        35 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
+        36 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
+        37 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
+        38 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
+        39 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
+        40 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
+        41 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
+        42 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
+        43 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
+        44 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        45 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        46 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
+        50 => {
             wire__crate__api__logging__enable_debug_logging_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__crypto__generate_security_context_impl(
+        51 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__crypto__generate_security_context_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
-        54 => {
+        53 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
+        55 => {
             wire__crate__api__metadata__read_file_metadata_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5401,10 +5464,10 @@ fn pde_ffi_dispatcher_sync_impl(
     match func_id {
         2 => wire__crate__api__stream__Dart2RustStreamSink_close_impl(ptr, rust_vec_len, data_len),
         6 => wire__crate__api__cancel__RsCancellationToken_cancel_impl(ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/packages/localsend_isolates/test/task/discovery/discovery_test.dart
+++ b/packages/localsend_isolates/test/task/discovery/discovery_test.dart
@@ -1,0 +1,35 @@
+// Regression test: a staged scan dispatched while the discovery is still
+// starting used to be dropped silently. The app's first automatic scan races
+// the discovery startup (the listener is dispatched un-awaited at app start),
+// and a dropped scan is only recoverable on a LAN, where the startup
+// announcement makes every peer register again — over a tailnet nothing
+// re-finds a peer until the user manually rescans.
+//
+// Needs no Rust dylib: the scan must wait before it ever reaches the bridge.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localsend_isolates/src/task/discovery/discovery.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+void main() {
+  test('a staged scan waits for the discovery to start instead of being dropped', () async {
+    final container = RefenaContainer();
+    const startTimeout = Duration(milliseconds: 200);
+    final service = DiscoveryService(container, startTimeout: startTimeout);
+
+    final stopwatch = Stopwatch()..start();
+    await service.discoverStaged(
+      favorites: const [],
+      networkInterfaces: const [],
+      port: 53317,
+      https: true,
+      grace: Duration.zero,
+    );
+    stopwatch.stop();
+
+    expect(
+      stopwatch.elapsed,
+      greaterThanOrEqualTo(startTimeout),
+      reason: 'a scan arriving while the discovery is starting must wait for it, not be silently dropped',
+    );
+  });
+}


### PR DESCRIPTION
Devices on the same Tailscale tailnet cannot find each other (#1123). A tailnet carries no multicast,
so announcements are never seen, and its `100.64.0.0/10` range is far past what the `/24` subnet scan
can walk. Every device is directly dialable, yet each stays invisible — the workaround in #1123 is
typing the `100.x` address by hand and saving it as a favourite.

This adds a discovery stage that asks the one process which already knows the peer list — the local
Tailscale daemon — over its LocalAPI, and probes the online peers with the same register request
discovery already sends to a favourite.

|                                       | before                | after                                                                 |
|---------------------------------------|-----------------------|-----------------------------------------------------------------------|
| desktop scan, tailnet peers elsewhere | finds nothing         | probes every online peer the daemon reports (7 of 18 on the test tailnet); the one running LocalSend appears and receives files |
| the phone's list                      | desktop never appears | desktop appears once it has probed or sent to the phone               |
| discovery on a LAN                    | works                 | unchanged — same stages, same timeouts, same escalation               |

## What this changes

- New `packages/core/src/tailscale/` behind a `tailscale` Cargo feature (pulled in by `discovery`).
  It reads the peer list from the local daemon: a unix socket on Linux and on macOS installs running
  `tailscaled`, a named pipe on Windows, the token-guarded loopback port of the sandboxed macOS
  Tailscale builds. Only each peer's address, online flag and display name are used — no key, no node
  identity, and nothing talks to Tailscale's servers. Headscale is the same daemon and works as is.
- Online peers are probed in a stage running beside the announcement. A probe is a register request,
  so a desktop that enumerates the tailnet also becomes visible to the phones — Android and iOS run
  Tailscale as a VPN service with no API for other apps, so a tailnet of only mobile devices still
  cannot discover itself. That limit is the mobile app's, not one this stage can lift.
- LocalSend's own macOS app is sandboxed, which hid the daemon from it entirely: `HOME` names the
  app's container, and the group container holding the loopback credentials cannot be listed. They
  are now read at the two container paths Tailscale ships under, beneath a home taken from the
  password database, and `Runner/*.entitlements` gain a read-only exception for exactly those two
  directories — a temporary-exception entitlement, which App Store review will want justified.
- An inbound registration is the only thing a phone ever gets over a tailnet, so it is never
  discarded: a device sending from a tailnet address is registered on receive, persisted (upsert by
  fingerprint, capped at 16) and re-probed on the first scan after a restart.
- A tailnet address gets a 3 s probe timeout and one retry a second later, where a LAN address keeps
  its 500 ms — first contact has to wake the VPN and punch through NAT or fall back to a relay, which
  on a mobile network regularly outlives a single attempt.
- Two startup-window fixes, not tailnet-scoped because the window exists on any network: a
  registration arriving while discovery is still starting is held (cap 64) and replayed rather than
  dropped, and a scan racing that startup waits briefly instead of being skipped. On a LAN the next
  announcement papered over both; a tailnet has no next announcement.
- Settings → Network (advanced) → "Discover Tailscale devices", on by default. Without Tailscale
  installed the stage costs one failed connect to the local daemon.

## What this deliberately does not change

How devices are found on a LAN. Tailnet confirmations do not count towards the staged-scan
escalation — a peer answering through a tunnel says nothing about whether the local network carries
multicast, and counting it would suppress the subnet scan on exactly the multicast-less networks it
exists for. One knowing ambiguity: `100.64.0.0/10` is shared CGNAT space, so a LAN peer behind such
an ISP classifies as tailnet and is probed with the patient timeout — slower with that peer is the
harmless direction. Only `en.json` is touched; the other locales are Weblate's.

### Tests

Tested on one tailnet between a Linux desktop and an Android phone in both directions, and from a
sandboxed, signed macOS build to that phone, where the desktop probe reached it at its tailnet
address and the transfer completed. `packages/core` gains unit tests for the address classifier,
tailnet channel collection, the probe retry, and the macOS container lookup, plus two integration
tests in `tests/discovery.rs` proving a tailnet-sourced registration does not suppress the
subnet-scan escalation, with a LAN-sourced control. Dart gains a mirror of the classifier test, so
the two classifiers cannot drift apart silently, and an isolate test for the scan/startup race
written against the old code first, where it fails. Not proven: the Windows named-pipe transport is
compile-checked but has not spoken to a live daemon, and phone-to-macOS discovery after a phone
restart has not been observed.

### Scope

Discovery only — transfers over a tailnet already work once devices know each other, which is #1123's
manual workaround. NetBird and ZeroTier run different daemons and are not covered. #2266 and #2725
are adjacent but separate defects and are not claimed here.
