### PR TITLE
fix: avoid response TLS info dependency

### DIFF
--- a/packages/core/src/http/client/mod.rs
+++ b/packages/core/src/http/client/mod.rs
@@ -195,13 +195,20 @@ pub(super) fn upload_body(
 /// custom certificate verifier. reqwest passes such a config straight through,
 /// which means the client certificate and ALPN have to be set here as well:
 /// `identity()` and the HTTP version preference of the builder no longer apply.
+pub(super) struct ConfiguredClient {
+    client: reqwest::Client,
+    peer_certificates: server_cert_verifier::PeerCertificateStore,
+}
+
 pub(super) fn create_reqwest_client(
     private_key: &str,
     cert: &str,
     expected_fingerprint: Option<String>,
     timeout: Option<std::time::Duration>,
-) -> Result<reqwest::Client, ClientError> {
+) -> Result<ConfiguredClient, ClientError> {
     let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let peer_certificates = server_cert_verifier::PeerCertificateStore::default();
 
     let mut tls_config = {
         let certs =
@@ -215,6 +222,7 @@ pub(super) fn create_reqwest_client(
                 server_cert_verifier::PinnedServerCertVerifier::try_new(
                     cert,
                     expected_fingerprint,
+                    peer_certificates.clone(),
                 )?,
             ))
             .with_client_auth_cert(certs, key)
@@ -235,7 +243,10 @@ pub(super) fn create_reqwest_client(
 
     let client = builder.build()?;
 
-    Ok(client)
+    Ok(ConfiguredClient {
+        client,
+        peer_certificates,
+    })
 }
 
 /// DNS resolver that turns the synthetic host names produced by
@@ -259,39 +270,23 @@ impl reqwest::dns::Resolve for ScopedHostResolver {
     }
 }
 
-/// Verifies the certificate from the response.
-/// Returns the public key extracted from the certificate.
-pub(super) fn verify_cert_from_res(
-    response: &Response,
+/// Verifies a certificate captured during the successful TLS handshake and
+/// returns the public key and SHA-256 fingerprint that identify the peer.
+pub(super) fn peer_identity(
+    peer_certificates: &server_cert_verifier::PeerCertificateStore,
+    host: &str,
     public_key: Option<String>,
-) -> anyhow::Result<String> {
-    let tls_info_ext = response
-        .extensions()
-        .get::<reqwest::tls::TlsInfo>()
-        .ok_or_else(|| anyhow::anyhow!("TLS info not found"))?;
-    let cert = tls_info_ext
-        .peer_certificate()
-        .ok_or_else(|| anyhow::anyhow!("Certificate not found"))?;
-    crypto::cert::verify_cert_from_der(cert, public_key.as_deref())?;
+) -> anyhow::Result<(String, String)> {
+    let cert = peer_certificates
+        .get(host)
+        .ok_or_else(|| anyhow::anyhow!("Certificate not found for host {host}"))?;
+    crypto::cert::verify_cert_from_der(&cert, public_key.as_deref())?;
     let public_key = match public_key {
         Some(public_key) => public_key,
-        None => crypto::cert::public_key_from_cert_der(cert)?,
+        None => crypto::cert::public_key_from_cert_der(&cert)?,
     };
-    Ok(public_key)
-}
-
-/// The SHA-256 fingerprint (uppercase hex) of the peer certificate the
-/// response was received over. This — not any fingerprint claimed in the
-/// body — is the peer's identity in HTTPS mode.
-pub(super) fn cert_fingerprint_from_res(response: &Response) -> anyhow::Result<String> {
-    let tls_info_ext = response
-        .extensions()
-        .get::<reqwest::tls::TlsInfo>()
-        .ok_or_else(|| anyhow::anyhow!("TLS info not found"))?;
-    let cert = tls_info_ext
-        .peer_certificate()
-        .ok_or_else(|| anyhow::anyhow!("Certificate not found"))?;
-    Ok(crypto::cert::fingerprint_from_cert_der(cert))
+    let fingerprint = crypto::cert::fingerprint_from_cert_der(&cert);
+    Ok((public_key, fingerprint))
 }
 
 #[derive(Serialize, Deserialize)]

--- a/packages/core/src/http/client/server_cert_verifier.rs
+++ b/packages/core/src/http/client/server_cert_verifier.rs
@@ -6,9 +6,34 @@ use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{
     CertificateError, DigitallySignedStruct, Error, OtherError, RootCertStore, SignatureScheme,
 };
+use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use x509_parser::nom::AsBytes;
+
+/// Certificates observed during successful TLS handshakes, keyed by the TLS
+/// server name. Discovery needs this to learn a peer's identity before a
+/// fingerprint is known.
+///
+/// Keeping this data at the verifier layer avoids depending on reqwest's
+/// optional response `TlsInfo` extension, which can be absent when traffic is
+/// routed through a macOS packet tunnel.
+#[derive(Clone, Default)]
+pub(crate) struct PeerCertificateStore {
+    certificates: Arc<RwLock<HashMap<String, Vec<u8>>>>,
+}
+
+impl PeerCertificateStore {
+    fn record(&self, server_name: &ServerName<'_>, certificate: &[u8]) {
+        let mut certificates = self.certificates.write().unwrap();
+        certificates.insert(server_name.to_str().into_owned(), certificate.to_vec());
+    }
+
+    pub(crate) fn get(&self, host: &str) -> Option<Vec<u8>> {
+        let server_name = super::scoped_host::encode(host).unwrap_or_else(|| host.to_string());
+        self.certificates.read().unwrap().get(&server_name).cloned()
+    }
+}
 
 /// The reason a peer certificate was rejected, as an error that rustls carries
 /// along.
@@ -55,6 +80,8 @@ fn rejected(reason: String) -> Error {
 pub(crate) struct PinnedServerCertVerifier {
     inner: Arc<dyn ServerCertVerifier>,
 
+    peer_certificates: PeerCertificateStore,
+
     /// The SHA-256 fingerprint (uppercase hex) the peer certificate must have.
     ///
     /// [`None`] accepts any valid certificate. This is trust on first use and
@@ -67,6 +94,7 @@ impl PinnedServerCertVerifier {
     pub(crate) fn try_new(
         cert: &str,
         expected_fingerprint: Option<String>,
+        peer_certificates: PeerCertificateStore,
     ) -> anyhow::Result<Self> {
         // The root store must not be empty, so we add our own certificate.
         // It is never used as an authority: `verify_server_cert` below does not
@@ -76,6 +104,7 @@ impl PinnedServerCertVerifier {
 
         Ok(Self {
             inner: WebPkiServerVerifier::builder(Arc::new(root_cert_store)).build()?,
+            peer_certificates,
             expected_fingerprint: expected_fingerprint.map(|f| f.to_ascii_uppercase()),
         })
     }
@@ -92,7 +121,7 @@ impl ServerCertVerifier for PinnedServerCertVerifier {
         &self,
         end_entity: &CertificateDer<'_>,
         _: &[CertificateDer<'_>],
-        _: &ServerName<'_>,
+        server_name: &ServerName<'_>,
         _: &[u8],
         _: UnixTime,
     ) -> Result<ServerCertVerified, Error> {
@@ -110,6 +139,10 @@ impl ServerCertVerifier for PinnedServerCertVerifier {
                 )));
             }
         }
+
+        // Record only certificates that passed every verifier check above.
+        self.peer_certificates
+            .record(server_name, end_entity.as_bytes());
 
         Ok(ServerCertVerified::assertion())
     }
@@ -168,9 +201,12 @@ VRus1zGVD8IVpIdPMyz01WJyS7M0fWaHXKWo+Bo=
     fn verify(expected_fingerprint: Option<&str>) -> Result<(), Error> {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
-        let verifier =
-            PinnedServerCertVerifier::try_new(CERT, expected_fingerprint.map(|f| f.to_string()))
-                .unwrap();
+        let verifier = PinnedServerCertVerifier::try_new(
+            CERT,
+            expected_fingerprint.map(|f| f.to_string()),
+            PeerCertificateStore::default(),
+        )
+        .unwrap();
 
         verifier
             .verify_server_cert(

--- a/packages/core/src/http/client/v2.rs
+++ b/packages/core/src/http/client/v2.rs
@@ -13,6 +13,7 @@ use tokio_util::sync::CancellationToken;
 /// HTTP client for LocalSend Protocol v2.2.
 pub struct LsHttpClientV2 {
     client: reqwest::Client,
+    peer_certificates: super::server_cert_verifier::PeerCertificateStore,
 }
 
 impl LsHttpClientV2 {
@@ -35,8 +36,11 @@ impl LsHttpClientV2 {
         expected_fingerprint: Option<String>,
         timeout: Option<std::time::Duration>,
     ) -> Result<Self, ClientError> {
+        let configured =
+            super::create_reqwest_client(private_key, cert, expected_fingerprint, timeout)?;
         Ok(Self {
-            client: super::create_reqwest_client(private_key, cert, expected_fingerprint, timeout)?,
+            client: configured.client,
+            peer_certificates: configured.peer_certificates,
         })
     }
 
@@ -52,7 +56,10 @@ impl LsHttpClientV2 {
             .tls_info(true)
             .build()?;
 
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            peer_certificates: Default::default(),
+        })
     }
 
     /// Registers with another device for discovery.
@@ -97,10 +104,11 @@ impl LsHttpClientV2 {
         }
 
         let (public_key, cert_fingerprint) = match protocol {
-            ProtocolType::Https => (
-                Some(super::verify_cert_from_res(&res, None)?),
-                Some(super::cert_fingerprint_from_res(&res)?),
-            ),
+            ProtocolType::Https => {
+                let (public_key, fingerprint) =
+                    super::peer_identity(&self.peer_certificates, ip, None)?;
+                (Some(public_key), Some(fingerprint))
+            }
             _ => (None, None),
         };
 
@@ -179,7 +187,7 @@ impl LsHttpClientV2 {
         };
 
         if protocol == ProtocolType::Https {
-            super::verify_cert_from_res(&res, public_key)?;
+            super::peer_identity(&self.peer_certificates, ip, public_key)?;
         }
 
         let status = res.status();
@@ -258,7 +266,7 @@ impl LsHttpClientV2 {
         };
 
         if protocol == ProtocolType::Https {
-            super::verify_cert_from_res(&res, public_key)?;
+            super::peer_identity(&self.peer_certificates, ip, public_key)?;
         }
 
         if res.status() != StatusCode::OK {

--- a/packages/core/src/http/client/v3.rs
+++ b/packages/core/src/http/client/v3.rs
@@ -13,6 +13,8 @@ use tokio_util::sync::CancellationToken;
 pub struct LsHttpClientV3 {
     client: reqwest::Client,
 
+    peer_certificates: super::server_cert_verifier::PeerCertificateStore,
+
     /// Maps client identifiers to nonces that have been received from remote.
     received_nonce_map: Arc<Mutex<LruCache<String, Vec<u8>>>>,
 
@@ -27,8 +29,11 @@ impl LsHttpClientV3 {
         expected_fingerprint: Option<String>,
         timeout: Option<std::time::Duration>,
     ) -> Result<Self, ClientError> {
+        let configured =
+            super::create_reqwest_client(private_key, cert, expected_fingerprint, timeout)?;
         Ok(Self {
-            client: super::create_reqwest_client(private_key, cert, expected_fingerprint, timeout)?,
+            client: configured.client,
+            peer_certificates: configured.peer_certificates,
             received_nonce_map: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(200).unwrap(),
             ))),
@@ -73,7 +78,13 @@ impl LsHttpClientV3 {
             return res.into_error().await;
         }
 
-        let remote_key = to_identifier(&res, protocol == ProtocolType::Https, None)?;
+        let remote_key = to_identifier(
+            &res,
+            protocol == ProtocolType::Https,
+            &self.peer_certificates,
+            ip,
+            None,
+        )?;
         let body = res.json::<http::dto::NonceResponse>().await?;
 
         // Save the response nonce and our generated nonce
@@ -124,10 +135,11 @@ impl LsHttpClientV3 {
             .await?;
 
         let (public_key, cert_fingerprint) = match protocol {
-            ProtocolType::Https => (
-                Some(super::verify_cert_from_res(&res, None)?),
-                Some(super::cert_fingerprint_from_res(&res)?),
-            ),
+            ProtocolType::Https => {
+                let (public_key, fingerprint) =
+                    super::peer_identity(&self.peer_certificates, ip, None)?;
+                (Some(public_key), Some(fingerprint))
+            }
             _ => (None, None),
         };
 
@@ -174,7 +186,7 @@ impl LsHttpClientV3 {
         };
 
         if protocol == ProtocolType::Https {
-            super::verify_cert_from_res(&res, public_key)?;
+            super::peer_identity(&self.peer_certificates, ip, public_key)?;
         }
 
         let status = res.status();
@@ -242,7 +254,7 @@ impl LsHttpClientV3 {
         };
 
         if protocol == ProtocolType::Https {
-            super::verify_cert_from_res(&res, public_key)?;
+            super::peer_identity(&self.peer_certificates, ip, public_key)?;
         }
 
         if res.status() != StatusCode::OK {
@@ -281,10 +293,12 @@ impl LsHttpClientV3 {
 fn to_identifier(
     response: &Response,
     require_cert: bool,
+    peer_certificates: &super::server_cert_verifier::PeerCertificateStore,
+    host: &str,
     public_key: Option<String>,
 ) -> Result<String, ClientError> {
     match require_cert {
-        true => Ok(super::verify_cert_from_res(response, public_key)?),
+        true => Ok(super::peer_identity(peer_certificates, host, public_key)?.0),
         false => response
             .remote_addr()
             .map(|addr| addr.ip().to_string())

--- a/packages/core/tests/v2_tls_pinning.rs
+++ b/packages/core/tests/v2_tls_pinning.rs
@@ -14,6 +14,8 @@ use localsend::http::server::{start_with_port, ServerConfigV2, TlsConfig};
 use localsend::http::state::ClientInfo;
 use localsend::model::discovery::ProtocolType;
 use localsend::model::transfer::FileDto;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::CertificateDer;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex};
@@ -345,6 +347,36 @@ async fn test_upload_body_not_sent_on_fingerprint_mismatch() {
     assert!(server.received.lock().await.is_empty());
 }
 
+/// Legacy callers can still verify a peer by public key. The certificate used
+/// for that check comes from the handshake verifier, so this remains reliable
+/// when response TLS metadata is absent behind a system packet tunnel.
+#[tokio::test]
+async fn test_prepare_upload_verifies_captured_certificate() {
+    let server_identity = generate_identity();
+    let sender = generate_identity();
+    let server = start_tls_server(&server_identity).await;
+    let client = client(&sender, None);
+
+    let cert_der = CertificateDer::from_pem_slice(server_identity.cert.as_bytes()).unwrap();
+    let public_key =
+        localsend::crypto::cert::public_key_from_cert_der(cert_der.as_ref()).unwrap();
+
+    let files = vec![file_dto("file-1", 10)];
+    let result = client
+        .prepare_upload(
+            ProtocolType::Https,
+            "127.0.0.1",
+            server.port,
+            Some(public_key),
+            prepare_upload_request(&sender, &files),
+            None,
+            CancellationToken::new(),
+        )
+        .await;
+
+    result.expect("prepare-upload should use the certificate captured at the handshake");
+}
+
 /// Without the web pages, the client certificate stays mandatory: a client
 /// without one (e.g. a browser) must fail the handshake.
 #[tokio::test]
@@ -429,5 +461,9 @@ async fn test_register_without_pin_returns_public_key() {
         .expect("register should succeed");
 
     assert!(response.public_key.is_some());
+    assert_eq!(
+        response.cert_fingerprint.as_deref(),
+        Some(server_identity.fingerprint.as_str())
+    );
     assert_eq!(response.body.fingerprint, server_identity.fingerprint);
 }


### PR DESCRIPTION
## Summary

- capture peer certificates after they pass the custom rustls verifier, keyed by TLS server name;
- use the verified handshake certificate for discovery identity and legacy public-key checks;
- remove the HTTP client's dependency on reqwest response `TlsInfo`, which can be absent behind a macOS packet tunnel.

Fixes #3299.

## Security properties preserved

This does not skip or weaken certificate verification:

- certificate validity is checked before a certificate is recorded;
- pinned transfer clients still compare the expected SHA-256 fingerprint during the TLS handshake, before HTTP request data is sent;
- a fingerprint mismatch is rejected before file metadata reaches the peer;
- upload bodies are not read or transmitted when the fingerprint check fails;
- unpinned discovery derives the public key and fingerprint from the verified handshake certificate rather than trusting identity data in the response body;
- captured certificates remain in memory and are separated by TLS server name.

The response-level certificate check was redundant for pinned clients and unreliable because `reqwest::tls::TlsInfo` is an optional response extension. The custom rustls verifier is the authoritative point at which LocalSend sees and authenticates the peer certificate.

## Testing

- `cargo test --features full --test v2_tls_pinning` (7 passed)
- `cargo clippy --features full --all-targets` (passes with existing repository warnings)
- focused discovery tests passed, including reading the HTTPS identity from the certificate
- real encrypted macOS-to-iPhone transfer with the macOS default route on an active `utun` packet tunnel: registration, certificate fingerprint pinning, receiver acceptance, and upload all succeeded

The same real-world flow failed in LocalSend 1.18.0 with `RsHttpClientError.other(field0: TLS info not found)` when Shadowrocket was active on macOS.

## User context

In mainland China, proxy/VPN tools such as Shadowrocket are commonly kept active for normal access to online services. Using LocalSend and a packet-tunnel application at the same time is therefore an everyday configuration for many Chinese users, not just an unusual edge case. Disabling the tunnel for every local transfer would also interrupt unrelated internet access.

Development note: this bug fix was prepared with AI assistance and validated through source review, automated security regression tests, and a real-device reproduction before and after the change.
