### PR TITLE
Add Android Wi-Fi Aware transport with paired interop

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "org.localsend.localsend_app"
-    compileSdkVersion 36
+    compileSdkVersion 37
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -87,6 +87,10 @@ flutter {
     source '../..'
 }
 
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
+}
+
 // To comply with F-Droid version code schema
 // https://github.com/localsend/localsend/issues/1534
 ext.abiCodes = ["x86_64": 1, "armeabi-v7a": 2, "arm64-v8a": 3]

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,16 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
+    <!-- Wi-Fi Aware (NAN) discovery and data paths. Location is only needed
+         on Android 12L and older; Android 13+ uses Nearby Wi-Fi Devices. -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="33" />
+
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
@@ -25,6 +35,7 @@
     <!-- Android TV -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.hardware.wifi.aware" android:required="false" />
 
     <application
         android:label="LocalSend"

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -23,6 +23,7 @@ private const val REQUEST_CODE_PICK_DIRECTORY = 1
 private const val REQUEST_CODE_PICK_DIRECTORY_PATH = 2
 private const val REQUEST_CODE_PICK_FILE = 3
 private const val REQUEST_CODE_LOCAL_NETWORK = 4
+private const val REQUEST_CODE_WIFI_AWARE = 5
 
 // Not available as a constant in compileSdk 36.
 private const val PERMISSION_ACCESS_LOCAL_NETWORK = "android.permission.ACCESS_LOCAL_NETWORK"
@@ -31,6 +32,7 @@ private const val API_LEVEL_ANDROID_17 = 37
 class MainActivity : FlutterActivity() {
     private var pendingResult: MethodChannel.Result? = null
     private var pendingPermissionResult: MethodChannel.Result? = null
+    private var wifiAwareController: WifiAwareController? = null
 
     /// share_handler drops share intents arriving via onNewIntent while the Dart side
     /// is not subscribed to its media stream yet, which happens when this singleTask
@@ -71,10 +73,12 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-        MethodChannel(
+        val channel = MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             CHANNEL
-        ).setMethodCallHandler { call, result ->
+        )
+        wifiAwareController = WifiAwareController(this, channel)
+        channel.setMethodCallHandler { call, result ->
             when (call.method) {
                 "pickDirectory" -> {
                     pendingResult = result
@@ -131,8 +135,45 @@ class MainActivity : FlutterActivity() {
                     }
                 }
 
+                "requestWifiAwarePermission" -> requestWifiAwarePermission(result)
+
+                "startWifiAware" -> {
+                    val port = call.argument<Int>("port")
+                    val https = call.argument<Boolean>("https")
+                    if (port == null || https == null) {
+                        result.error("INVALID_ARGUMENT", "Missing port or https", null)
+                    } else {
+                        result.success(wifiAwareController?.start(port, https) ?: false)
+                    }
+                }
+
+                "stopWifiAware" -> {
+                    wifiAwareController?.stop()
+                    result.success(null)
+                }
+
                 else -> result.notImplemented()
             }
+        }
+    }
+
+    private fun requestWifiAwarePermission(result: MethodChannel.Result) {
+        // Android 10 exposes the peer IPv6 address through WifiAwareNetworkInfo.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || !packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_AWARE)) {
+            result.success(false)
+            return
+        }
+
+        val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            android.Manifest.permission.NEARBY_WIFI_DEVICES
+        } else {
+            android.Manifest.permission.ACCESS_FINE_LOCATION
+        }
+        if (checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
+            result.success(true)
+        } else {
+            pendingPermissionResult = result
+            requestPermissions(arrayOf(permission), REQUEST_CODE_WIFI_AWARE)
         }
     }
 
@@ -149,7 +190,16 @@ class MainActivity : FlutterActivity() {
         if (requestCode == REQUEST_CODE_LOCAL_NETWORK) {
             pendingPermissionResult?.success(grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)
             pendingPermissionResult = null
+        } else if (requestCode == REQUEST_CODE_WIFI_AWARE) {
+            pendingPermissionResult?.success(grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)
+            pendingPermissionResult = null
         }
+    }
+
+    override fun onDestroy() {
+        wifiAwareController?.stop()
+        wifiAwareController = null
+        super.onDestroy()
     }
 
     /// Absolute path of the shared "Download" directory (usually /storage/emulated/0/Download).

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/WifiAwareController.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/WifiAwareController.kt
@@ -1,6 +1,7 @@
 package org.localsend.localsend_app
 
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -10,11 +11,15 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.wifi.aware.AttachCallback
+import android.net.wifi.aware.AwareDataPathRequest
+import android.net.wifi.aware.AwarePairingConfig
+import android.net.wifi.aware.Characteristics
 import android.net.wifi.aware.DiscoverySession
 import android.net.wifi.aware.DiscoverySessionCallback
 import android.net.wifi.aware.PeerHandle
 import android.net.wifi.aware.PublishConfig
 import android.net.wifi.aware.PublishDiscoverySession
+import android.net.wifi.aware.ServiceDiscoveryInfo
 import android.net.wifi.aware.SubscribeConfig
 import android.net.wifi.aware.SubscribeDiscoverySession
 import android.net.wifi.aware.WifiAwareManager
@@ -23,7 +28,10 @@ import android.net.wifi.aware.WifiAwareSession
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.text.InputType
 import android.util.Log
+import android.widget.EditText
+import android.widget.TextView
 import io.flutter.plugin.common.MethodChannel
 import java.security.SecureRandom
 import java.util.concurrent.ConcurrentHashMap
@@ -65,9 +73,11 @@ class WifiAwareController(
 ) {
     companion object {
         private const val TAG = "LocalSendWifiAware"
-        private const val SERVICE_NAME = "localsend"
+        // RFC 6763 service type used by Apple's Wi-Fi Aware API and on the air.
+        private const val SERVICE_NAME = "_localsend._tcp"
         private const val MESSAGE_CONNECT = "connect-v1"
         private const val MESSAGE_READY = "ready-v1"
+        private const val IP_PROTOCOL_TCP = 6
     }
 
     private data class PeerService(
@@ -84,6 +94,9 @@ class WifiAwareController(
     private val discoveredPeers = ConcurrentHashMap<PeerHandle, PeerService>()
     private val requestedPeers = ConcurrentHashMap.newKeySet<PeerHandle>()
     private val respondedPeers = ConcurrentHashMap.newKeySet<PeerHandle>()
+    private val pairingPeers = ConcurrentHashMap.newKeySet<PeerHandle>()
+    private val pairingPasswords = ConcurrentHashMap<PeerHandle, String>()
+    private val pendingPairingRequests = ConcurrentHashMap<PeerHandle, Pair<Int, DiscoverySession>>()
     private var receiverRegistered = false
     private var requested = false
     private var port = 0
@@ -165,10 +178,11 @@ class WifiAwareController(
     @SuppressLint("MissingPermission")
     private fun publish(session: WifiAwareSession) {
         val serviceInfo = WifiAwareServiceInfoCodec.encode(WifiAwareServiceInfo(port, https, passphrase))
-        val config = PublishConfig.Builder()
+        val configBuilder = PublishConfig.Builder()
             .setServiceName(SERVICE_NAME)
             .setServiceSpecificInfo(serviceInfo)
-            .build()
+        pairingConfig()?.let(configBuilder::setPairingConfig)
+        val config = configBuilder.build()
         session.publish(config, object : DiscoverySessionCallback() {
             override fun onPublishStarted(session: PublishDiscoverySession) {
                 publishSession = session
@@ -183,6 +197,34 @@ class WifiAwareController(
                 current.sendMessage(peerHandle, 0, MESSAGE_READY.toByteArray(Charsets.UTF_8))
             }
 
+            override fun onPairingSetupRequestReceived(peerHandle: PeerHandle, requestId: Int) {
+                acceptPairingWhenReady(publishSession, peerHandle, requestId)
+            }
+
+            override fun onBootstrappingSucceeded(peerHandle: PeerHandle, method: Int) {
+                completeBootstrapping(publishSession, peerHandle, method, initiator = false)
+            }
+
+            override fun onPairingSetupSucceeded(peerHandle: PeerHandle, alias: String) {
+                pairingPeers.add(peerHandle)
+                Log.i(TAG, "Wi-Fi Aware pairing established with publisher peer")
+            }
+
+            override fun onPairingVerificationSucceed(peerHandle: PeerHandle, alias: String) {
+                pairingPeers.add(peerHandle)
+            }
+
+            override fun onDataPathRequestReceived(peerHandle: PeerHandle) {
+                if (Build.VERSION.SDK_INT < 37 || !pairingPeers.contains(peerHandle)) return
+                val request = AwareDataPathRequest.Builder()
+                    .setPort(port)
+                    .setTransportProtocol(IP_PROTOCOL_TCP)
+                    .build()
+                if (publishSession?.acceptDataPathRequest(peerHandle, request) != true) {
+                    Log.w(TAG, "Could not accept paired Wi-Fi Aware data path")
+                }
+            }
+
             override fun onSessionConfigFailed() {
                 Log.w(TAG, "Wi-Fi Aware publish configuration failed")
             }
@@ -191,9 +233,10 @@ class WifiAwareController(
 
     @SuppressLint("MissingPermission")
     private fun subscribe(session: WifiAwareSession) {
-        val config = SubscribeConfig.Builder()
+        val configBuilder = SubscribeConfig.Builder()
             .setServiceName(SERVICE_NAME)
-            .build()
+        pairingConfig()?.let(configBuilder::setPairingConfig)
+        val config = configBuilder.build()
         session.subscribe(config, object : DiscoverySessionCallback() {
             override fun onSubscribeStarted(session: SubscribeDiscoverySession) {
                 subscribeSession = session
@@ -201,9 +244,21 @@ class WifiAwareController(
             }
 
             override fun onServiceDiscovered(peerHandle: PeerHandle, serviceSpecificInfo: ByteArray, matchFilter: List<ByteArray>) {
-                val service = parseService(peerHandle, serviceSpecificInfo) ?: return
-                discoveredPeers[peerHandle] = service
-                subscribeSession?.sendMessage(peerHandle, 0, MESSAGE_CONNECT.toByteArray(Charsets.UTF_8))
+                discoverLegacyPeer(peerHandle, serviceSpecificInfo)
+            }
+
+            override fun onServiceDiscovered(info: ServiceDiscoveryInfo) {
+                val peer = info.peerHandle
+                val serviceInfo = info.serviceSpecificInfo ?: return
+                parseService(peer, serviceInfo)?.let { discoveredPeers[peer] = it }
+                val pairing = info.pairingConfig
+                val method = pairing?.let(::selectBootstrappingMethod)
+                if (Build.VERSION.SDK_INT >= 37 && method != null) {
+                    pairingPeers.add(peer)
+                    subscribeSession?.initiateBootstrappingRequest(peer, method)
+                } else {
+                    discoverLegacyPeer(peer, serviceInfo)
+                }
             }
 
             override fun onMessageReceived(peerHandle: PeerHandle, message: ByteArray) {
@@ -216,6 +271,49 @@ class WifiAwareController(
 
             override fun onServiceLost(peerHandle: PeerHandle, reason: Int) {
                 discoveredPeers.remove(peerHandle)
+                pairingPeers.remove(peerHandle)
+            }
+
+            override fun onPairingSetupRequestReceived(peerHandle: PeerHandle, requestId: Int) {
+                acceptPairingWhenReady(subscribeSession, peerHandle, requestId)
+            }
+
+            override fun onBootstrappingSucceeded(peerHandle: PeerHandle, method: Int) {
+                completeBootstrapping(subscribeSession, peerHandle, method, initiator = true)
+            }
+
+            override fun onBootstrappingFailed(peerHandle: PeerHandle) {
+                fallbackToLegacy(peerHandle)
+            }
+
+            override fun onPairingSetupSucceeded(peerHandle: PeerHandle, alias: String) {
+                initiatePairedDataPath(peerHandle)
+            }
+
+            override fun onPairingVerificationSucceed(peerHandle: PeerHandle, alias: String) {
+                initiatePairedDataPath(peerHandle)
+            }
+
+            override fun onPairingSetupFailed(peerHandle: PeerHandle) {
+                fallbackToLegacy(peerHandle)
+            }
+
+            override fun onPairingVerificationFailed(peerHandle: PeerHandle) {
+                fallbackToLegacy(peerHandle)
+            }
+
+            override fun onDataPathConnected(peerHandle: PeerHandle, networkInfo: WifiAwareNetworkInfo) {
+                val service = discoveredPeers[peerHandle]
+                emitEndpoint(
+                    networkInfo,
+                    service?.port ?: networkInfo.port,
+                    service?.https ?: true,
+                )
+            }
+
+            override fun onDataPathRequestFailed(peerHandle: PeerHandle, reason: Int) {
+                Log.w(TAG, "Paired Wi-Fi Aware data path failed ($reason)")
+                fallbackToLegacy(peerHandle)
             }
 
             override fun onSessionConfigFailed() {
@@ -223,6 +321,163 @@ class WifiAwareController(
             }
         }, handler)
     }
+
+    private fun discoverLegacyPeer(peer: PeerHandle, serviceSpecificInfo: ByteArray) {
+        val service = parseService(peer, serviceSpecificInfo) ?: return
+        discoveredPeers[peer] = service
+        subscribeSession?.sendMessage(peer, 0, MESSAGE_CONNECT.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun fallbackToLegacy(peer: PeerHandle) {
+        pairingPeers.remove(peer)
+        val service = discoveredPeers[peer] ?: return
+        subscribeSession?.sendMessage(service.peer, 0, MESSAGE_CONNECT.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun initiatePairedDataPath(peer: PeerHandle) {
+        if (Build.VERSION.SDK_INT < 37 || !requestedPeers.add(peer)) return
+        val request = AwareDataPathRequest.Builder()
+            .setTransportProtocol(IP_PROTOCOL_TCP)
+            .build()
+        if (subscribeSession?.initiateDataPathRequest(peer, request) != true) {
+            requestedPeers.remove(peer)
+            fallbackToLegacy(peer)
+        }
+    }
+
+    private fun pairingConfig(): AwarePairingConfig? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return null
+        val characteristics = runCatching { awareManager?.characteristics }.getOrNull() ?: return null
+        if (!characteristics.isAwarePairingSupported) return null
+        return AwarePairingConfig.Builder()
+            .setPairingSetupEnabled(true)
+            .setPairingVerificationEnabled(true)
+            .setPairingCacheEnabled(true)
+            .setBootstrappingMethods(
+                AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_DISPLAY or
+                    AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_KEYPAD,
+            )
+            .build()
+    }
+
+    private fun selectBootstrappingMethod(config: AwarePairingConfig): Int? {
+        val methods = config.bootstrappingMethods
+        return when {
+            methods and AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_DISPLAY != 0 ->
+                AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_DISPLAY
+            methods and AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_KEYPAD != 0 ->
+                AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_KEYPAD
+            else -> null
+        }
+    }
+
+    private fun pairingCipherSuite(): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_PK_PASN_128
+        }
+        val suites = runCatching { awareManager?.characteristics?.supportedPairingCipherSuites }.getOrNull() ?: 0
+        return if (suites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_PK_PASN_256 != 0) {
+            Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_PK_PASN_256
+        } else {
+            Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_PK_PASN_128
+        }
+    }
+
+    private fun completeBootstrapping(
+        session: DiscoverySession?,
+        peer: PeerHandle,
+        method: Int,
+        initiator: Boolean,
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE || session == null) return
+        pairingPeers.add(peer)
+        val localEntersPin = if (initiator) {
+            method == AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_DISPLAY
+        } else {
+            method == AwarePairingConfig.PAIRING_BOOTSTRAPPING_PIN_CODE_KEYPAD
+        }
+        if (localEntersPin) {
+            promptForPairingPin { pin -> finishBootstrapping(session, peer, pin, initiator) }
+        } else {
+            val pin = randomPin()
+            showPairingPin(pin)
+            finishBootstrapping(session, peer, pin, initiator)
+        }
+    }
+
+    private fun finishBootstrapping(session: DiscoverySession, peer: PeerHandle, pin: String?, initiator: Boolean) {
+        if (pin == null) {
+            pairingPeers.remove(peer)
+            fallbackToLegacy(peer)
+            return
+        }
+        pairingPasswords[peer] = pin
+        if (initiator) {
+            session.initiatePairingRequest(peer, peerAlias(peer), pairingCipherSuite(), pin)
+        } else {
+            pendingPairingRequests.remove(peer)?.let { (requestId, pendingSession) ->
+                acceptPairing(pendingSession, peer, requestId, pin)
+            }
+        }
+    }
+
+    private fun acceptPairingWhenReady(session: DiscoverySession?, peer: PeerHandle, requestId: Int) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE || session == null) return
+        pairingPasswords[peer]?.let { pin ->
+            acceptPairing(session, peer, requestId, pin)
+        } ?: run {
+            pendingPairingRequests[peer] = requestId to session
+        }
+    }
+
+    private fun acceptPairing(session: DiscoverySession, peer: PeerHandle, requestId: Int, pin: String) {
+        session.acceptPairingRequest(requestId, peer, peerAlias(peer), pairingCipherSuite(), pin)
+    }
+
+    private fun promptForPairingPin(onResult: (String?) -> Unit) {
+        handler.post {
+            var completed = false
+            fun complete(pin: String?) {
+                if (!completed) {
+                    completed = true
+                    onResult(pin)
+                }
+            }
+            val input = EditText(context).apply {
+                inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_PASSWORD
+                hint = context.getString(R.string.wifi_aware_pairing_code_hint)
+            }
+            AlertDialog.Builder(context)
+                .setTitle(R.string.wifi_aware_pairing_title)
+                .setMessage(R.string.wifi_aware_pairing_enter_message)
+                .setView(input)
+                .setPositiveButton(R.string.wifi_aware_pairing_action) { _, _ ->
+                    complete(input.text.toString().takeIf { it.matches(Regex("[0-9]{8}")) })
+                }
+                .setNegativeButton(android.R.string.cancel) { _, _ -> complete(null) }
+                .setOnCancelListener { complete(null) }
+                .show()
+        }
+    }
+
+    private fun showPairingPin(pin: String) {
+        handler.post {
+            val code = TextView(context).apply {
+                text = pin
+                textSize = 28f
+                textAlignment = TextView.TEXT_ALIGNMENT_CENTER
+                setPadding(32, 24, 32, 24)
+            }
+            AlertDialog.Builder(context)
+                .setTitle(R.string.wifi_aware_pairing_title)
+                .setMessage(R.string.wifi_aware_pairing_display_message)
+                .setView(code)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
+        }
+    }
+
+    private fun peerAlias(peer: PeerHandle): String = "localsend-${peer.hashCode().toUInt().toString(16)}"
 
     private fun parseService(peer: PeerHandle, bytes: ByteArray): PeerService? {
         val info = WifiAwareServiceInfoCodec.decode(bytes) ?: return null
@@ -248,17 +503,8 @@ class WifiAwareController(
                 if (emitted || endpoint == null) return
                 val info = capabilities.transportInfo as? WifiAwareNetworkInfo ?: return
                 val address = info.peerIpv6Addr ?: return
-                val scopeId = address.scopeId
-                if (scopeId == 0) return
-                val hostAddress = address.hostAddress ?: return
                 emitted = true
-                val host = "${hostAddress.substringBefore('%')}%$scopeId"
-                handler.post {
-                    channel.invokeMethod(
-                        "wifiAwareEndpoint",
-                        mapOf("host" to host, "port" to endpoint.port, "https" to endpoint.https),
-                    )
-                }
+                emitEndpoint(info, endpoint.port, endpoint.https)
             }
 
             override fun onUnavailable() {
@@ -271,6 +517,21 @@ class WifiAwareController(
         }
         synchronized(networkCallbacks) { networkCallbacks.add(callback) }
         connectivityManager.requestNetwork(request, callback, handler)
+    }
+
+    private fun emitEndpoint(info: WifiAwareNetworkInfo, port: Int, https: Boolean) {
+        if (port !in 1..65535) return
+        val address = info.peerIpv6Addr ?: return
+        val scopeId = address.scopeId
+        if (scopeId == 0) return
+        val hostAddress = address.hostAddress ?: return
+        val host = "${hostAddress.substringBefore('%')}%$scopeId"
+        handler.post {
+            channel.invokeMethod(
+                "wifiAwareEndpoint",
+                mapOf("host" to host, "port" to port, "https" to https),
+            )
+        }
     }
 
     private fun removeNetworkCallback(callback: ConnectivityManager.NetworkCallback, peer: PeerHandle, initiator: Boolean) {
@@ -295,6 +556,9 @@ class WifiAwareController(
         discoveredPeers.clear()
         requestedPeers.clear()
         respondedPeers.clear()
+        pairingPeers.clear()
+        pairingPasswords.clear()
+        pendingPairingRequests.clear()
         val callbacks = synchronized(networkCallbacks) {
             networkCallbacks.toList().also { networkCallbacks.clear() }
         }
@@ -308,4 +572,6 @@ class WifiAwareController(
             repeat(24) { append(alphabet[random.nextInt(alphabet.length)]) }
         }
     }
+
+    private fun randomPin(): String = SecureRandom().nextInt(100_000_000).toString().padStart(8, '0')
 }

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/WifiAwareController.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/WifiAwareController.kt
@@ -1,0 +1,311 @@
+package org.localsend.localsend_app
+
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.aware.AttachCallback
+import android.net.wifi.aware.DiscoverySession
+import android.net.wifi.aware.DiscoverySessionCallback
+import android.net.wifi.aware.PeerHandle
+import android.net.wifi.aware.PublishConfig
+import android.net.wifi.aware.PublishDiscoverySession
+import android.net.wifi.aware.SubscribeConfig
+import android.net.wifi.aware.SubscribeDiscoverySession
+import android.net.wifi.aware.WifiAwareManager
+import android.net.wifi.aware.WifiAwareNetworkInfo
+import android.net.wifi.aware.WifiAwareSession
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import io.flutter.plugin.common.MethodChannel
+import java.security.SecureRandom
+import java.util.concurrent.ConcurrentHashMap
+
+internal data class WifiAwareServiceInfo(
+    val port: Int,
+    val https: Boolean,
+    val passphrase: String,
+)
+
+internal object WifiAwareServiceInfoCodec {
+    private const val VERSION = "1"
+
+    fun encode(info: WifiAwareServiceInfo): ByteArray = "$VERSION|${info.port}|${if (info.https) 1 else 0}|${info.passphrase}".toByteArray(Charsets.UTF_8)
+
+    fun decode(bytes: ByteArray): WifiAwareServiceInfo? {
+        val parts = bytes.toString(Charsets.UTF_8).split('|')
+        if (parts.size != 4 || parts[0] != VERSION) return null
+        val port = parts[1].toIntOrNull()?.takeIf { it in 1..65535 } ?: return null
+        val https = when (parts[2]) {
+            "1" -> true
+            "0" -> false
+            else -> return null
+        }
+        val passphrase = parts[3].takeIf { it.length in 8..63 } ?: return null
+        return WifiAwareServiceInfo(port, https, passphrase)
+    }
+}
+
+/**
+ * Bridges Android Wi-Fi Aware discovery/data paths into LocalSend's existing
+ * HTTP discovery. The native layer only establishes a network and reports a
+ * scoped IPv6 endpoint; identity, registration, TLS, and transfers continue
+ * through the regular Rust LocalSend protocol stack.
+ */
+class WifiAwareController(
+    private val context: Context,
+    private val channel: MethodChannel,
+) {
+    companion object {
+        private const val TAG = "LocalSendWifiAware"
+        private const val SERVICE_NAME = "localsend"
+        private const val MESSAGE_CONNECT = "connect-v1"
+        private const val MESSAGE_READY = "ready-v1"
+    }
+
+    private data class PeerService(
+        val peer: PeerHandle,
+        val port: Int,
+        val https: Boolean,
+        val passphrase: String,
+    )
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val awareManager = context.getSystemService(WifiAwareManager::class.java)
+    private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+    private val networkCallbacks = mutableSetOf<ConnectivityManager.NetworkCallback>()
+    private val discoveredPeers = ConcurrentHashMap<PeerHandle, PeerService>()
+    private val requestedPeers = ConcurrentHashMap.newKeySet<PeerHandle>()
+    private val respondedPeers = ConcurrentHashMap.newKeySet<PeerHandle>()
+    private var receiverRegistered = false
+    private var requested = false
+    private var port = 0
+    private var https = true
+    private var passphrase = ""
+    private var awareSession: WifiAwareSession? = null
+    private var publishSession: PublishDiscoverySession? = null
+    private var subscribeSession: SubscribeDiscoverySession? = null
+
+    private val availabilityReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != WifiAwareManager.ACTION_WIFI_AWARE_STATE_CHANGED) return
+            if (awareManager?.isAvailable == true) {
+                attach()
+            } else {
+                closeSessions()
+            }
+        }
+    }
+
+    /** Starts or reconfigures Wi-Fi Aware. Returns false when unsupported. */
+    @SuppressLint("MissingPermission")
+    fun start(port: Int, https: Boolean): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || awareManager == null) {
+            return false
+        }
+
+        val configurationChanged = this.port != port || this.https != https
+        requested = true
+        this.port = port
+        this.https = https
+        if (!receiverRegistered) {
+            val filter = IntentFilter(WifiAwareManager.ACTION_WIFI_AWARE_STATE_CHANGED)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(availabilityReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                context.registerReceiver(availabilityReceiver, filter)
+            }
+            receiverRegistered = true
+        }
+        if (configurationChanged || awareSession == null) {
+            closeSessions()
+            passphrase = randomPassphrase()
+            attach()
+        }
+        return true
+    }
+
+    fun stop() {
+        requested = false
+        closeSessions()
+        if (receiverRegistered) {
+            context.unregisterReceiver(availabilityReceiver)
+            receiverRegistered = false
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun attach() {
+        if (!requested || awareSession != null || awareManager?.isAvailable != true) return
+        awareManager.attach(object : AttachCallback() {
+            override fun onAttached(session: WifiAwareSession) {
+                if (!requested) {
+                    session.close()
+                    return
+                }
+                awareSession = session
+                Log.i(TAG, "Attached to Wi-Fi Aware")
+                publish(session)
+                subscribe(session)
+            }
+
+            override fun onAttachFailed() {
+                Log.w(TAG, "Could not attach to Wi-Fi Aware")
+            }
+        }, handler)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun publish(session: WifiAwareSession) {
+        val serviceInfo = WifiAwareServiceInfoCodec.encode(WifiAwareServiceInfo(port, https, passphrase))
+        val config = PublishConfig.Builder()
+            .setServiceName(SERVICE_NAME)
+            .setServiceSpecificInfo(serviceInfo)
+            .build()
+        session.publish(config, object : DiscoverySessionCallback() {
+            override fun onPublishStarted(session: PublishDiscoverySession) {
+                publishSession = session
+                Log.i(TAG, "Wi-Fi Aware publisher started")
+            }
+
+            override fun onMessageReceived(peerHandle: PeerHandle, message: ByteArray) {
+                if (message.toString(Charsets.UTF_8) != MESSAGE_CONNECT) return
+                val current = publishSession ?: return
+                if (!respondedPeers.add(peerHandle)) return
+                requestNetwork(current, peerHandle, passphrase, null)
+                current.sendMessage(peerHandle, 0, MESSAGE_READY.toByteArray(Charsets.UTF_8))
+            }
+
+            override fun onSessionConfigFailed() {
+                Log.w(TAG, "Wi-Fi Aware publish configuration failed")
+            }
+        }, handler)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun subscribe(session: WifiAwareSession) {
+        val config = SubscribeConfig.Builder()
+            .setServiceName(SERVICE_NAME)
+            .build()
+        session.subscribe(config, object : DiscoverySessionCallback() {
+            override fun onSubscribeStarted(session: SubscribeDiscoverySession) {
+                subscribeSession = session
+                Log.i(TAG, "Wi-Fi Aware subscriber started")
+            }
+
+            override fun onServiceDiscovered(peerHandle: PeerHandle, serviceSpecificInfo: ByteArray, matchFilter: List<ByteArray>) {
+                val service = parseService(peerHandle, serviceSpecificInfo) ?: return
+                discoveredPeers[peerHandle] = service
+                subscribeSession?.sendMessage(peerHandle, 0, MESSAGE_CONNECT.toByteArray(Charsets.UTF_8))
+            }
+
+            override fun onMessageReceived(peerHandle: PeerHandle, message: ByteArray) {
+                if (message.toString(Charsets.UTF_8) != MESSAGE_READY) return
+                val service = discoveredPeers[peerHandle] ?: return
+                val current = subscribeSession ?: return
+                if (!requestedPeers.add(peerHandle)) return
+                requestNetwork(current, service.peer, service.passphrase, service)
+            }
+
+            override fun onServiceLost(peerHandle: PeerHandle, reason: Int) {
+                discoveredPeers.remove(peerHandle)
+            }
+
+            override fun onSessionConfigFailed() {
+                Log.w(TAG, "Wi-Fi Aware subscribe configuration failed")
+            }
+        }, handler)
+    }
+
+    private fun parseService(peer: PeerHandle, bytes: ByteArray): PeerService? {
+        val info = WifiAwareServiceInfoCodec.decode(bytes) ?: return null
+        return PeerService(peer, info.port, info.https, info.passphrase)
+    }
+
+    @Suppress("DEPRECATION")
+    @SuppressLint("MissingPermission")
+    private fun requestNetwork(
+        discoverySession: DiscoverySession,
+        peer: PeerHandle,
+        passphrase: String,
+        endpoint: PeerService?,
+    ) {
+        val specifier = discoverySession.createNetworkSpecifierPassphrase(peer, passphrase)
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI_AWARE)
+            .setNetworkSpecifier(specifier)
+            .build()
+        var emitted = false
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+                if (emitted || endpoint == null) return
+                val info = capabilities.transportInfo as? WifiAwareNetworkInfo ?: return
+                val address = info.peerIpv6Addr ?: return
+                val scopeId = address.scopeId
+                if (scopeId == 0) return
+                val hostAddress = address.hostAddress ?: return
+                emitted = true
+                val host = "${hostAddress.substringBefore('%')}%$scopeId"
+                handler.post {
+                    channel.invokeMethod(
+                        "wifiAwareEndpoint",
+                        mapOf("host" to host, "port" to endpoint.port, "https" to endpoint.https),
+                    )
+                }
+            }
+
+            override fun onUnavailable() {
+                removeNetworkCallback(this, peer, endpoint != null)
+            }
+
+            override fun onLost(network: Network) {
+                removeNetworkCallback(this, peer, endpoint != null)
+            }
+        }
+        synchronized(networkCallbacks) { networkCallbacks.add(callback) }
+        connectivityManager.requestNetwork(request, callback, handler)
+    }
+
+    private fun removeNetworkCallback(callback: ConnectivityManager.NetworkCallback, peer: PeerHandle, initiator: Boolean) {
+        val removed = synchronized(networkCallbacks) { networkCallbacks.remove(callback) }
+        if (removed) {
+            runCatching { connectivityManager.unregisterNetworkCallback(callback) }
+        }
+        if (initiator) {
+            requestedPeers.remove(peer)
+        } else {
+            respondedPeers.remove(peer)
+        }
+    }
+
+    private fun closeSessions() {
+        subscribeSession?.close()
+        subscribeSession = null
+        publishSession?.close()
+        publishSession = null
+        awareSession?.close()
+        awareSession = null
+        discoveredPeers.clear()
+        requestedPeers.clear()
+        respondedPeers.clear()
+        val callbacks = synchronized(networkCallbacks) {
+            networkCallbacks.toList().also { networkCallbacks.clear() }
+        }
+        callbacks.forEach { runCatching { connectivityManager.unregisterNetworkCallback(it) } }
+    }
+
+    private fun randomPassphrase(): String {
+        val alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        val random = SecureRandom()
+        return buildString(24) {
+            repeat(24) { append(alphabet[random.nextInt(alphabet.length)]) }
+        }
+    }
+}

--- a/app/android/app/src/main/res/values/strings.xml
+++ b/app/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="wifi_aware_pairing_title">Pair nearby device</string>
+    <string name="wifi_aware_pairing_enter_message">Enter the code displayed on the other device.</string>
+    <string name="wifi_aware_pairing_display_message">Enter this code on the other device.</string>
+    <string name="wifi_aware_pairing_code_hint">8-digit code</string>
+    <string name="wifi_aware_pairing_action">Pair</string>
+</resources>

--- a/app/android/app/src/test/kotlin/org/localsend/localsend_app/WifiAwareServiceInfoCodecTest.kt
+++ b/app/android/app/src/test/kotlin/org/localsend/localsend_app/WifiAwareServiceInfoCodecTest.kt
@@ -1,0 +1,22 @@
+package org.localsend.localsend_app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WifiAwareServiceInfoCodecTest {
+    @Test
+    fun roundTripsServiceInfo() {
+        val info = WifiAwareServiceInfo(port = 53317, https = true, passphrase = "12345678abcdefgh")
+
+        assertEquals(info, WifiAwareServiceInfoCodec.decode(WifiAwareServiceInfoCodec.encode(info)))
+    }
+
+    @Test
+    fun rejectsMalformedOrUnsafeServiceInfo() {
+        assertNull(WifiAwareServiceInfoCodec.decode("2|53317|1|12345678".toByteArray()))
+        assertNull(WifiAwareServiceInfoCodec.decode("1|0|1|12345678".toByteArray()))
+        assertNull(WifiAwareServiceInfoCodec.decode("1|53317|2|12345678".toByteArray()))
+        assertNull(WifiAwareServiceInfoCodec.decode("1|53317|1|short".toByteArray()))
+    }
+}

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -17,8 +17,8 @@ subprojects {
         if (project.plugins.hasPlugin("com.android.application") ||
                 project.plugins.hasPlugin("com.android.library")) {
             project.android {
-                compileSdkVersion 36
-                buildToolsVersion "36.0.0"
+                compileSdkVersion 37
+                buildToolsVersion "37.0.0"
             }
         }
     }

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -36,6 +36,7 @@ import 'package:localsend_app/util/native/device_info_helper.dart';
 import 'package:localsend_app/util/native/macos_channel.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
+import 'package:localsend_app/util/native/wifi_aware_helper.dart';
 import 'package:localsend_app/util/notification_strings.dart';
 import 'package:localsend_app/util/ui/dynamic_colors.dart';
 import 'package:localsend_app/util/ui/snackbar.dart';
@@ -217,6 +218,8 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
   } catch (e) {
     _logger.warning('Starting discovery listener failed', e);
   }
+
+  await setupWifiAwareDiscovery(ref);
 
   // ignore: dead_code
   if (webRTCEnabled) {

--- a/app/lib/util/native/wifi_aware_helper.dart
+++ b/app/lib/util/native/wifi_aware_helper.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:localsend_app/model/state/server/server_state.dart';
+import 'package:localsend_app/provider/network/server/server_provider.dart';
+import 'package:localsend_isolates/isolate.dart';
+import 'package:logging/logging.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+const _methodChannel = MethodChannel('org.localsend.localsend_app/localsend');
+final _logger = Logger('WifiAware');
+StreamSubscription? _serverSubscription;
+(int, bool)? _configuration;
+
+/// Connects Android Wi-Fi Aware discovery to LocalSend's regular discovery
+/// store. Wi-Fi Aware supplies only an endpoint; the normal LocalSend register
+/// request still authenticates and confirms the peer before it is shown.
+Future<void> setupWifiAwareDiscovery(Ref ref) async {
+  if (defaultTargetPlatform != TargetPlatform.android) {
+    return;
+  }
+
+  _methodChannel.setMethodCallHandler((call) async {
+    if (call.method != 'wifiAwareEndpoint') {
+      throw MissingPluginException('Unknown native method ${call.method}');
+    }
+    final arguments = (call.arguments as Map).cast<String, dynamic>();
+    final host = arguments['host'] as String?;
+    final port = arguments['port'] as int?;
+    final https = arguments['https'] as bool?;
+    if (host == null || port == null || https == null) {
+      _logger.warning('Ignoring an invalid Wi-Fi Aware endpoint: $arguments');
+      return;
+    }
+
+    try {
+      await ref.redux(parentIsolateProvider).dispatchTakeResult(IsolateDiscoveryProbeAction(host: host, port: port, https: https)).drain<void>();
+    } catch (e, stackTrace) {
+      _logger.warning('Wi-Fi Aware endpoint probe failed ($host:$port)', e, stackTrace);
+    }
+  });
+
+  final permissionGranted = await _methodChannel.invokeMethod<bool>('requestWifiAwarePermission') ?? false;
+  if (!permissionGranted) {
+    _logger.info('Wi-Fi Aware is unsupported or permission was not granted');
+    return;
+  }
+
+  await _serverSubscription?.cancel();
+  _serverSubscription = ref.stream(serverProvider).listen((event) {
+    unawaited(_configureWifiAware(event.next));
+  });
+  await _configureWifiAware(ref.read(serverProvider));
+}
+
+Future<void> _configureWifiAware(ServerState? server) async {
+  try {
+    if (server == null) {
+      _configuration = null;
+      await _methodChannel.invokeMethod<void>('stopWifiAware');
+      return;
+    }
+
+    final next = (server.port, server.https);
+    if (_configuration == next) {
+      return;
+    }
+    _configuration = next;
+    final supported = await _methodChannel.invokeMethod<bool>('startWifiAware', {'port': server.port, 'https': server.https}) ?? false;
+    if (!supported) {
+      _logger.info('Wi-Fi Aware is unavailable on this Android device');
+    }
+  } catch (e, stackTrace) {
+    _configuration = null;
+    _logger.warning('Could not configure Wi-Fi Aware', e, stackTrace);
+  }
+}

--- a/packages/localsend_isolates/lib/rust/api/discovery.dart
+++ b/packages/localsend_isolates/lib/rust/api/discovery.dart
@@ -83,6 +83,12 @@ abstract class RsDiscovery implements RustOpaqueInterface {
   /// the store's log limit. Empty when the fingerprint is unknown.
   Future<List<RsDeviceLog>> deviceLogs({required String fingerprint});
 
+  /// Probes one endpoint that was discovered by a platform transport, such
+  /// as an Android Wi-Fi Aware data path. A successful LocalSend register
+  /// response is merged into the regular discovery store and emitted on
+  /// [RsDiscovery::listen].
+  Future<void> discover({required String host, required int port, required ProtocolType protocol});
+
   /// Discovers devices in stages, cheapest first: announces this device to
   /// the network and probes [channels] (e.g. the favorites), then falls
   /// back to scanning the `/24` subnets of the local interface addresses

--- a/packages/localsend_isolates/lib/rust/frb_generated.dart
+++ b/packages/localsend_isolates/lib/rust/frb_generated.dart
@@ -76,7 +76,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1979579466;
+  int get rustContentHash => -454181894;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'rust_lib_localsend_app',
@@ -119,6 +119,13 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiDiscoveryRsDiscoveryAnnounce({required RsDiscovery that});
 
   Future<List<RsDeviceLog>> crateApiDiscoveryRsDiscoveryDeviceLogs({required RsDiscovery that, required String fingerprint});
+
+  Future<void> crateApiDiscoveryRsDiscoveryDiscover({
+    required RsDiscovery that,
+    required String host,
+    required int port,
+    required ProtocolType protocol,
+  });
 
   Future<void> crateApiDiscoveryRsDiscoveryDiscoverStaged({
     required RsDiscovery that,
@@ -647,6 +654,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<void> crateApiDiscoveryRsDiscoveryDiscover({
+    required RsDiscovery that,
+    required String host,
+    required int port,
+    required ProtocolType protocol,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
+          sse_encode_String(host, serializer);
+          sse_encode_u_16(port, serializer);
+          sse_encode_protocol_type(protocol, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10, port: port_);
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiDiscoveryRsDiscoveryDiscoverConstMeta,
+        argValues: [that, host, port, protocol],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiDiscoveryRsDiscoveryDiscoverConstMeta => const TaskConstMeta(
+    debugName: 'RsDiscovery_discover',
+    argNames: ['that', 'host', 'port', 'protocol'],
+  );
+
+  @override
   Future<void> crateApiDiscoveryRsDiscoveryDiscoverStaged({
     required RsDiscovery that,
     required List<RsDeviceChannel> channels,
@@ -665,7 +705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_16(port, serializer);
           sse_encode_protocol_type(protocol, serializer);
           sse_encode_u_64(graceMs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -693,7 +733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
             sse_encode_StreamSink_rs_stored_device_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -720,7 +760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -753,7 +793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(interfaceIp, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_protocol_type(protocol, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -779,7 +819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
           sse_encode_bool(answer, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -804,7 +844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -839,7 +879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ip, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_String(sessionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -880,7 +920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_String(publicKey, serializer);
           sse_encode_opt_String(pin, serializer);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_prepare_upload_result,
@@ -915,7 +955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ip, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_box_autoadd_register_dto(payload, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_result_with_public_key_register_response_dto,
@@ -972,7 +1012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(contentLength, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1015,7 +1055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1042,7 +1082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1069,7 +1109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1097,7 +1137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
             sse_encode_StreamSink_rs_server_event_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1134,7 +1174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(fileId, serializer);
           sse_encode_opt_String(path, serializer);
           sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1174,7 +1214,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_String(path, serializer);
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(fileSize, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1203,7 +1243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_bool(accept, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1229,7 +1269,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_opt_list_String(acceptedFileIds, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1254,7 +1294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1279,7 +1319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1307,7 +1347,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
             sse_encode_StreamSink_list_prim_u_8_strict_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1335,7 +1375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender(that, serializer);
           sse_encode_list_prim_u_8_loose(data, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1360,7 +1400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1388,7 +1428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1415,7 +1455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_file_dto,
@@ -1443,7 +1483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1473,7 +1513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1501,7 +1541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_box_autoadd_rtc_send_file_response(status, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1527,7 +1567,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1553,7 +1593,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_Set_String_None(selection, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1581,7 +1621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1608,7 +1648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Set_String_None,
@@ -1636,7 +1676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1664,7 +1704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender,
@@ -1690,7 +1730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1729,7 +1769,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               onConnection,
               serializer,
             );
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1755,7 +1795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken,
@@ -1790,7 +1830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_ls_http_client_version(version, serializer);
           sse_encode_opt_String(expectedFingerprint, serializer);
           sse_encode_opt_box_autoadd_u_32(timeoutMs, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpClient,
@@ -1814,7 +1854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1839,7 +1879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1863,7 +1903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_key_pair,
@@ -1887,7 +1927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_security_context,
@@ -1918,7 +1958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_opt_list_prim_u_8_strict(bytes, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1945,7 +1985,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1970,7 +2010,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(path, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_file_metadata,
@@ -1995,7 +2035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2048,7 +2088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(certPem, serializer);
           sse_encode_String(privateKeyPem, serializer);
           sse_encode_u_64(timeoutMs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery,
@@ -2125,7 +2165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_bool(verifyChecksums, serializer);
           sse_encode_opt_box_autoadd_web_params(web, serializer);
           sse_encode_opt_String(showToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer,
@@ -2151,7 +2191,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cert, serializer);
           sse_encode_String(publicKey, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -6362,6 +6402,13 @@ class RsDiscoveryImpl extends RustOpaque implements RsDiscovery {
   /// the store's log limit. Empty when the fingerprint is unknown.
   Future<List<RsDeviceLog>> deviceLogs({required String fingerprint}) =>
       RustLib.instance.api.crateApiDiscoveryRsDiscoveryDeviceLogs(that: this, fingerprint: fingerprint);
+
+  /// Probes one endpoint that was discovered by a platform transport, such
+  /// as an Android Wi-Fi Aware data path. A successful LocalSend register
+  /// response is merged into the regular discovery store and emitted on
+  /// [RsDiscovery::listen].
+  Future<void> discover({required String host, required int port, required ProtocolType protocol}) =>
+      RustLib.instance.api.crateApiDiscoveryRsDiscoveryDiscover(that: this, host: host, port: port, protocol: protocol);
 
   /// Discovers devices in stages, cheapest first: announces this device to
   /// the network and probes [channels] (e.g. the favorites), then falls

--- a/packages/localsend_isolates/lib/src/isolate/child/discovery_isolate.dart
+++ b/packages/localsend_isolates/lib/src/isolate/child/discovery_isolate.dart
@@ -76,6 +76,21 @@ class DiscoveryStagedScanTask implements DiscoveryTask {
   });
 }
 
+/// Probes a single endpoint discovered through a native platform transport.
+/// Completes when the endpoint answered or the probe failed; successful
+/// devices arrive on the [DiscoveryListenTask] stream.
+class DiscoveryProbeTask implements DiscoveryTask {
+  final String host;
+  final int port;
+  final bool https;
+
+  DiscoveryProbeTask({
+    required this.host,
+    required this.port,
+    required this.https,
+  });
+}
+
 /// Feeds a device confirmed outside of the discovery into the store, e.g. one
 /// that registered with this device's HTTP server. The device comes back on
 /// the [DiscoveryListenTask] stream.
@@ -145,6 +160,9 @@ Future<void> setupDiscoveryIsolate(
                 https: data.https,
                 grace: data.grace,
               );
+          break;
+        case DiscoveryProbeTask data:
+          await ref.read(discoveryProvider).probe(host: data.host, port: data.port, https: data.https);
           break;
         case DiscoveryAddDeviceTask data:
           await ref.read(discoveryProvider).addDevice(data.device);

--- a/packages/localsend_isolates/lib/src/isolate/parent/actions.dart
+++ b/packages/localsend_isolates/lib/src/isolate/parent/actions.dart
@@ -116,6 +116,38 @@ class IsolateDiscoveryStagedScanAction extends ReduxActionWithResult<IsolateCont
   }
 }
 
+/// Probes a single endpoint discovered by a native platform transport.
+/// The returned stream completes when the probe finishes; a successful device
+/// arrives on the [IsolateDiscoveryListenAction] stream.
+class IsolateDiscoveryProbeAction extends ReduxActionWithResult<IsolateController, ParentIsolateState, Stream<Device>> {
+  final String host;
+  final int port;
+  final bool https;
+
+  IsolateDiscoveryProbeAction({
+    required this.host,
+    required this.port,
+    required this.https,
+  });
+
+  @override
+  (ParentIsolateState, Stream<Device>) reduce() {
+    final connection = state.discovery;
+    if (connection == null) {
+      throw StateError('discovery is not initialized');
+    }
+
+    return (
+      state,
+      connection
+          .sendWrappedTaskAndListenStream(
+            task: DiscoveryProbeTask(host: host, port: port, https: https),
+          )
+          .toDeviceStream(),
+    );
+  }
+}
+
 /// Fetches the retained confirmations of a stored device, oldest first.
 /// The logs are empty when the fingerprint is unknown or the discovery is
 /// not running.

--- a/packages/localsend_isolates/lib/src/task/discovery/discovery.dart
+++ b/packages/localsend_isolates/lib/src/task/discovery/discovery.dart
@@ -24,6 +24,7 @@ class DiscoveryService {
 
   final Ref _ref;
   RsDiscovery? _discovery;
+  Completer<void> _readyCompleter = Completer<void>();
   Completer<void> _retryCompleter = Completer();
   bool _listening = false;
 
@@ -91,6 +92,9 @@ class DiscoveryService {
       }
 
       _discovery = discovery;
+      if (!_readyCompleter.isCompleted) {
+        _readyCompleter.complete();
+      }
 
       // Tell everyone in the network that I am online.
       unawaited(discovery.announce());
@@ -103,6 +107,7 @@ class DiscoveryService {
 
       // The stream ended because [restartListener] stopped the discovery.
       _discovery = null;
+      _readyCompleter = Completer<void>();
     }
   }
 
@@ -179,6 +184,29 @@ class DiscoveryService {
     );
   }
 
+  /// Probes one endpoint found by a native transport such as Wi-Fi Aware.
+  /// Successful devices are emitted by [startListener].
+  Future<void> probe({required String host, required int port, required bool https}) async {
+    if (_discovery == null) {
+      try {
+        await _readyCompleter.future.timeout(const Duration(seconds: 5));
+      } on TimeoutException {
+        _logger.info('Discovery did not become ready, skipping endpoint $host:$port');
+        return;
+      }
+    }
+    final discovery = _discovery;
+    if (discovery == null) {
+      _logger.info('Discovery is not running, skipping endpoint $host:$port');
+      return;
+    }
+
+    await discovery.discover(
+      host: host,
+      port: port,
+      protocol: https ? rust_model.ProtocolType.https : rust_model.ProtocolType.http,
+    );
+  }
 
   /// The retained confirmations of a stored device, oldest first.
   /// Empty when the fingerprint is unknown or the discovery is not running.

--- a/packages/localsend_isolates/rust/src/api/discovery.rs
+++ b/packages/localsend_isolates/rust/src/api/discovery.rs
@@ -335,6 +335,23 @@ impl RsDiscovery {
         Ok(())
     }
 
+    /// Probes one endpoint that was discovered by a platform transport, such
+    /// as an Android Wi-Fi Aware data path. A successful LocalSend register
+    /// response is merged into the regular discovery store and emitted on
+    /// [RsDiscovery::listen].
+    pub async fn discover(
+        &self,
+        host: String,
+        port: u16,
+        protocol: ProtocolType,
+    ) -> anyhow::Result<()> {
+        self.instance
+            .handle
+            .discover(&host, port, protocol)
+            .await?;
+        Ok(())
+    }
+
     /// Scans the `/24` subnet of the local interface address [interface_ip]
     /// by sending every other host a register request, for networks that do
     /// not carry multicast.

--- a/packages/localsend_isolates/rust/src/frb_generated.rs
+++ b/packages/localsend_isolates/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1979579466;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -454181894;
 
 // Section: executor
 
@@ -578,6 +578,70 @@ fn wire__crate__api__discovery__RsDiscovery_device_logs_impl(
                         ))?;
                     Ok(output_ok)
                 })())
+            }
+        },
+    )
+}
+fn wire__crate__api__discovery__RsDiscovery_discover_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "RsDiscovery_discover",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsDiscovery>,
+            >>::sse_decode(&mut deserializer);
+            let api_host = <String>::sse_decode(&mut deserializer);
+            let api_port = <u16>::sse_decode(&mut deserializer);
+            let api_protocol = <crate::api::model::ProtocolType>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::api::discovery::RsDiscovery::discover(
+                            &*api_that_guard,
+                            api_host,
+                            api_port,
+                            api_protocol,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
             }
         },
     )
@@ -5156,197 +5220,203 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__discovery__RsDiscovery_discover_staged_impl(
+        10 => wire__crate__api__discovery__RsDiscovery_discover_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => {
+        11 => wire__crate__api__discovery__RsDiscovery_discover_staged_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        12 => {
             wire__crate__api__discovery__RsDiscovery_listen_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__discovery__RsDiscovery_multicast_error_impl(
+        13 => wire__crate__api__discovery__RsDiscovery_multicast_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        13 => wire__crate__api__discovery__RsDiscovery_scan_subnet_impl(
+        14 => wire__crate__api__discovery__RsDiscovery_scan_subnet_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        14 => wire__crate__api__discovery__RsDiscovery_set_answer_announcements_impl(
+        15 => wire__crate__api__discovery__RsDiscovery_set_answer_announcements_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__api__discovery__RsDiscovery_stop_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__http__RsHttpClient_cancel_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
+        16 => wire__crate__api__discovery__RsDiscovery_stop_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__http__RsHttpClient_cancel_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        18 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
+        19 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        21 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
+        22 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        22 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
+        23 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
+        24 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        25 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
+        26 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        26 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
+        27 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        27 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
+        28 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
+        29 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
+        31 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
+        32 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
+        34 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
+        35 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
+        36 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
+        37 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
+        38 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
+        39 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
+        40 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
+        41 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
+        42 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
+        43 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
+        44 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
+        45 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        46 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
+        50 => {
             wire__crate__api__logging__enable_debug_logging_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__crypto__generate_security_context_impl(
+        51 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__crypto__generate_security_context_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
-        54 => {
+        53 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
+        55 => {
             wire__crate__api__metadata__read_file_metadata_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5361,10 +5431,10 @@ fn pde_ffi_dispatcher_sync_impl(
     match func_id {
         2 => wire__crate__api__stream__Dart2RustStreamSink_close_impl(ptr, rust_vec_len, data_len),
         6 => wire__crate__api__cancel__RsCancellationToken_cancel_impl(ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/support/docs/wifi-aware.md
+++ b/support/docs/wifi-aware.md
@@ -17,13 +17,20 @@ Android support requires:
   on Android 13 and newer. On older releases the system may also require
   Location services to be enabled before Wi-Fi Aware is reported available.
 
-Both LocalSend devices publish and subscribe to the `localsend` service. The
-publisher advertises a versioned, bounded service-info record containing its
-HTTP server port, HTTP/HTTPS mode, and an ephemeral Wi-Fi Aware passphrase.
-After discovery, the subscriber requests a data path and reports the peer's
-scoped link-local IPv6 address to Dart. The Rust discovery layer then performs
-the normal LocalSend register request. A peer is not shown until that request
-succeeds, and HTTPS continues to use LocalSend's mutual-certificate identity.
+Both LocalSend devices publish and subscribe to the RFC 6763 service type
+`_localsend._tcp`. The publisher advertises a versioned, bounded service-info
+record containing its HTTP server port, HTTP/HTTPS mode, and an ephemeral
+Wi-Fi Aware passphrase. After discovery, the subscriber requests a data path
+and reports the peer's scoped link-local IPv6 address to Dart. The Rust
+discovery layer then performs the normal LocalSend register request. A peer is
+not shown until that request succeeds, and HTTPS continues to use LocalSend's
+mutual-certificate identity.
+
+On Android 14 or newer, hardware that advertises Wi-Fi Aware Pairing also
+publishes PIN display/keypad bootstrapping support. Android 16 QPR/API 37 adds
+the paired data-path APIs used for standards-based peers such as iOS 26. If
+pairing or its data path fails, LocalSend retries the existing ephemeral
+passphrase data path. Devices without pairing support use that path directly.
 
 Wi-Fi Aware therefore changes only how a reachable IP path is obtained. File
 transfer, authentication, pins, protocol negotiation, and the LAN path are not
@@ -34,21 +41,22 @@ not provide a Wi-Fi Aware radio.
 
 ## Apple platforms
 
-Apple's Wi-Fi Aware framework is not an interchangeable implementation of
-Android's open publish/subscribe flow. The public API requires:
+Apple's Wi-Fi Aware framework requires:
 
-- the Apple-granted `com.apple.developer.wifi-aware` entitlement;
+- the `com.apple.developer.wifi-aware` entitlement;
 - services declared in `WiFiAwareServices`;
 - `WAPairedDevice` identities created through the system accessory-pairing
   flow before a browser or listener can connect.
 
-LocalSend currently has no accessory identity or pairing enrollment, and the
-entitlement cannot be enabled or tested by an unaffiliated fork. Adding the
-entitlement or `Info.plist` declarations alone would either fail signing or
-leave the app without eligible peers. For that reason this change does not
-claim iOS peer support. An Apple implementation needs an approved entitlement
-and a product decision for a user-visible pairing flow before it can share the
-transport abstraction described above.
+The Android pairing path in this change supplies the standards-based PIN
+bootstrap and paired data path needed by an iOS implementation. The iOS native
+listener, browser, system pairing UI, signing entitlement, and transport bridge
+remain a separate change. iPhones that do not support iOS 26 Wi-Fi Aware keep
+using LocalSend's existing LAN discovery and transfer path.
+
+End-to-end pairing must be verified on two capable devices. In particular,
+`Characteristics.isAwarePairingSupported` is hardware/firmware dependent even
+on API 37; when it is false, only the passphrase path can be exercised.
 
 Relevant platform documentation:
 

--- a/support/docs/wifi-aware.md
+++ b/support/docs/wifi-aware.md
@@ -1,0 +1,57 @@
+# Wi-Fi Aware transport
+
+LocalSend can use Android Wi-Fi Aware (NAN) as an additional discovery and
+network path when no shared LAN is available. The existing multicast and
+subnet discovery remain active and are the fallback on unsupported devices or
+when the user denies the Nearby Wi-Fi permission.
+
+## Android
+
+Android support requires:
+
+- Android 10 (API 29) or newer. Android 8 introduced Wi-Fi Aware, but the peer
+  IPv6 endpoint needed by LocalSend is exposed through `WifiAwareNetworkInfo`
+  starting with Android 10.
+- Hardware advertising `android.hardware.wifi.aware`.
+- Location permission through Android 12L, or Nearby Wi-Fi Devices permission
+  on Android 13 and newer. On older releases the system may also require
+  Location services to be enabled before Wi-Fi Aware is reported available.
+
+Both LocalSend devices publish and subscribe to the `localsend` service. The
+publisher advertises a versioned, bounded service-info record containing its
+HTTP server port, HTTP/HTTPS mode, and an ephemeral Wi-Fi Aware passphrase.
+After discovery, the subscriber requests a data path and reports the peer's
+scoped link-local IPv6 address to Dart. The Rust discovery layer then performs
+the normal LocalSend register request. A peer is not shown until that request
+succeeds, and HTTPS continues to use LocalSend's mutual-certificate identity.
+
+Wi-Fi Aware therefore changes only how a reachable IP path is obtained. File
+transfer, authentication, pins, protocol negotiation, and the LAN path are not
+duplicated in the platform integration.
+
+Physical devices are required for end-to-end validation; Android emulators do
+not provide a Wi-Fi Aware radio.
+
+## Apple platforms
+
+Apple's Wi-Fi Aware framework is not an interchangeable implementation of
+Android's open publish/subscribe flow. The public API requires:
+
+- the Apple-granted `com.apple.developer.wifi-aware` entitlement;
+- services declared in `WiFiAwareServices`;
+- `WAPairedDevice` identities created through the system accessory-pairing
+  flow before a browser or listener can connect.
+
+LocalSend currently has no accessory identity or pairing enrollment, and the
+entitlement cannot be enabled or tested by an unaffiliated fork. Adding the
+entitlement or `Info.plist` declarations alone would either fail signing or
+leave the app without eligible peers. For that reason this change does not
+claim iOS peer support. An Apple implementation needs an approved entitlement
+and a product decision for a user-visible pairing flow before it can share the
+transport abstraction described above.
+
+Relevant platform documentation:
+
+- <https://developer.android.com/develop/connectivity/wifi/wifi-aware>
+- <https://developer.apple.com/documentation/wifiaware/adopting-wi-fi-aware>
+- <https://developer.apple.com/documentation/wifiaware/connecting-paired-devices>


### PR DESCRIPTION
## Summary

Adds Android Wi-Fi Aware (NAN) as an additional LocalSend discovery and network path while preserving LAN, multicast, and subnet discovery as fallback.

- publishes and subscribes to the RFC 6763 `_localsend._tcp` service
- uses standards-based Wi-Fi Aware Pairing with PIN display/keypad bootstrapping when the radio and OS support it
- uses the API 37 paired data-path APIs needed for interoperable peers such as iOS 26
- falls back to an encrypted ephemeral-passphrase Aware data path on older/non-pairing Android hardware
- passes the peer's scoped IPv6 endpoint into the existing Rust discovery stack
- reuses LocalSend's normal registration, HTTPS identity, transfer, and device-store logic
- keeps existing LAN discovery active and unchanged

Relates to #2523.

## Architecture

The native Android layer establishes only the Wi-Fi Aware network and reports a reachable endpoint. Dart forwards that endpoint to a targeted Rust discovery probe. A device is surfaced only after the regular LocalSend registration request succeeds.

For pairing-capable radios, the subscriber negotiates PIN display/keypad bootstrapping, establishes or verifies the cached Aware pairing, and requests a paired TCP data path. Pairing/data-path failures retry the existing passphrase path, and devices without Wi-Fi Aware continue entirely over LAN.

## Validation

- Flutter analyzer: passed with no issues (base transport change)
- Rust `cargo check`: passed (base transport change)
- Rust core tests with `full` features: passed (base transport change)
- Android `:app:testDebugUnitTest`: passed
- Android `:app:compileDebugKotlin`: passed against API 37
- full Flutter `build apk --debug`: passed
- APK installed on a Pixel 8 Pro / Android API 37
- physical-device smoke test confirmed attach plus active publisher and subscriber sessions in `dumpsys wifiaware`
- ordinary LocalSend LAN server/discovery remained active alongside Aware

The attached Pixel reports `isNanPairingSupported=false` and `supportedPairingCipherSuites=0`. It therefore validates the secure passphrase fallback, but cannot validate the new pairing callbacks over the air. Cross-platform pairing still needs two devices whose firmware exposes Wi-Fi Aware Pairing.

## Platform scope and constraints

The fallback transport requires Android 10/API 29+ and `android.hardware.wifi.aware`. Standards-based pairing is hardware/firmware dependent; paired TCP data paths require API 37. Unsupported devices, denied permissions, and Aware failures retain the existing LAN path.

The corresponding iOS 26 listener/browser, system pairing UI, entitlement, and transport bridge are in draft PR #3306. Older iPhones retain LAN fallback.

## Review status

This remains a draft because the standards-pairing path cannot be exercised on the available Pixel and needs a second pairing-capable Android or iOS 26 device before merge.
