### PR TITLE
Add iOS Wi-Fi Aware transport with LAN fallback

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -1,8 +1,16 @@
 import UIKit
 import Flutter
+#if canImport(WiFiAware) && canImport(DeviceDiscoveryUI)
+import DeviceDiscoveryUI
+import Network
+import SwiftUI
+import WiFiAware
+#endif
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  private var wifiAwareController: WifiAwareController?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -15,13 +23,301 @@ import Flutter
         name: "ios-delegate-channel",
         binaryMessenger: engineBridge.applicationRegistrar.messenger()
     )
+    wifiAwareController = WifiAwareController(channel: channel)
     channel.setMethodCallHandler { (call: FlutterMethodCall, result: @escaping FlutterResult) in
-        if call.method == "isReduceMotionEnabled" {
+        switch call.method {
+        case "isReduceMotionEnabled":
           result(UIAccessibility.isReduceMotionEnabled)
-        } else {
+        case "isWifiAwareSupported":
+          result(self.wifiAwareController?.isSupported ?? false)
+        case "showWifiAwarePairing":
+          self.wifiAwareController?.showPairing()
+          result(nil)
+        case "startWifiAware":
+          guard
+            let arguments = call.arguments as? [String: Any],
+            let port = arguments["port"] as? Int,
+            let https = arguments["https"] as? Bool,
+            (1...65535).contains(port)
+          else {
+            result(FlutterError(code: "INVALID_ARGUMENT", message: "Missing port or https", details: nil))
+            return
+          }
+          self.wifiAwareController?.start(port: UInt16(port), https: https)
+          result(nil)
+        case "stopWifiAware":
+          self.wifiAwareController?.stop()
+          result(nil)
+        default:
           result(FlutterMethodNotImplemented)
         }
     }
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+  }
+}
+
+#if canImport(WiFiAware) && canImport(DeviceDiscoveryUI)
+@available(iOS 26.0, *)
+private extension WAPublishableService {
+  static var localSend: WAPublishableService { allServices["_localsend._tcp"]! }
+}
+
+@available(iOS 26.0, *)
+private extension WASubscribableService {
+  static var localSend: WASubscribableService { allServices["_localsend._tcp"]! }
+}
+
+@available(iOS 26.0, *)
+private struct LocalSendPairingView: View {
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    NavigationStack {
+      VStack(spacing: 24) {
+        Text("Pair two nearby devices before using Wi-Fi Aware. One device should advertise while the other chooses it.")
+          .multilineTextAlignment(.center)
+
+        DevicePairingView(
+          .wifiAware(.connecting(to: .localSend, from: .selected([])))
+        ) {
+          Label("Advertise this iPhone", systemImage: "dot.radiowaves.left.and.right")
+        } fallback: {
+          Text("Wi-Fi Aware pairing is unavailable on this device.")
+        }
+
+        DevicePicker(
+          .wifiAware(.connecting(to: .userSpecifiedDevices, from: .localSend)),
+          onSelect: { _ in dismiss() }
+        ) {
+          Label("Choose another device", systemImage: "iphone.gen3.radiowaves.left.and.right")
+        } fallback: {
+          Text("No compatible nearby-device picker is available.")
+        }
+
+        Spacer()
+      }
+      .padding()
+      .navigationTitle("Wi-Fi Aware")
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Done") { dismiss() }
+        }
+      }
+    }
+  }
+}
+
+@available(iOS 26.0, *)
+private final class IOS26WifiAwareTransport {
+  private let channel: FlutterMethodChannel
+  private let queue = DispatchQueue(label: "org.localsend.wifi-aware")
+  private var publishTask: Task<Void, Never>?
+  private var browseTask: Task<Void, Never>?
+  private var proxyListeners: [String: NWListener] = [:]
+  private var serverPort: UInt16 = 0
+  private var https = true
+
+  init(channel: FlutterMethodChannel) {
+    self.channel = channel
+  }
+
+  func start(port: UInt16, https: Bool) {
+    guard WACapabilities.supportedFeatures.contains(.wifiAware) else { return }
+    if serverPort == port && self.https == https && publishTask != nil { return }
+    stop()
+    serverPort = port
+    self.https = https
+    startPublisher()
+    startBrowser()
+  }
+
+  func stop() {
+    publishTask?.cancel()
+    browseTask?.cancel()
+    publishTask = nil
+    browseTask = nil
+    proxyListeners.values.forEach { $0.cancel() }
+    proxyListeners.removeAll()
+  }
+
+  private func startPublisher() {
+    let localPort = serverPort
+    publishTask = Task { [weak self] in
+      do {
+        let listener = try NetworkListener(
+          for: .wifiAware(.connecting(to: .localSend, from: .allPairedDevices)),
+          using: { TCP() }
+        )
+        try await listener.run { connection in
+          guard let self else { return }
+          try await self.bridgeToLocalServer(connection, port: localPort)
+        }
+      } catch is CancellationError {
+      } catch {
+        NSLog("LocalSend Wi-Fi Aware publisher failed: %@", String(describing: error))
+      }
+    }
+  }
+
+  private func startBrowser() {
+    browseTask = Task { [weak self] in
+      guard let self else { return }
+      do {
+        let browser = NetworkBrowser(
+          for: .wifiAware(.connecting(to: .allPairedDevices, from: .localSend))
+        )
+        try await browser.run { endpoints in
+          for endpoint in endpoints {
+            self.addLoopbackProxy(for: endpoint)
+          }
+          return .continue
+        }
+      } catch is CancellationError {
+      } catch {
+        NSLog("LocalSend Wi-Fi Aware browser failed: %@", String(describing: error))
+      }
+    }
+  }
+
+  private func addLoopbackProxy(for endpoint: NWEndpoint) {
+    let key = String(describing: endpoint)
+    guard proxyListeners[key] == nil else { return }
+    do {
+      let parameters = NWParameters.tcp
+      parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
+      let listener = try NWListener(using: parameters)
+      listener.newConnectionHandler = { [weak self] localConnection in
+        guard let self else { return }
+        let awareConnection = NetworkConnection(to: endpoint, using: { TCP() }).start()
+        Task {
+          do {
+            try await self.bridge(localConnection, awareConnection)
+          } catch {
+            localConnection.cancel()
+          }
+        }
+      }
+      listener.stateUpdateHandler = { [weak self] state in
+        guard let self, case .ready = state, let port = listener.port else { return }
+        DispatchQueue.main.async {
+          self.channel.invokeMethod(
+            "wifiAwareEndpoint",
+            arguments: ["host": "127.0.0.1", "port": Int(port.rawValue), "https": self.https]
+          )
+        }
+      }
+      proxyListeners[key] = listener
+      listener.start(queue: queue)
+    } catch {
+      NSLog("LocalSend Wi-Fi Aware proxy failed: %@", String(describing: error))
+    }
+  }
+
+  private func bridgeToLocalServer(_ awareConnection: NetworkConnection<TCP>, port: UInt16) async throws {
+    guard let endpointPort = NWEndpoint.Port(rawValue: port) else { return }
+    let localConnection = NWConnection(host: "127.0.0.1", port: endpointPort, using: .tcp)
+    try await bridge(localConnection, awareConnection)
+  }
+
+  private func bridge(_ localConnection: NWConnection, _ awareConnection: NetworkConnection<TCP>) async throws {
+    localConnection.start(queue: queue)
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        while !Task.isCancelled {
+          let message = try await awareConnection.receive(atLeast: 1, atMost: 64 * 1024)
+          try await self.send(message.content, to: localConnection)
+        }
+      }
+      group.addTask {
+        while !Task.isCancelled {
+          let data = try await self.receive(from: localConnection)
+          try await awareConnection.send(data, endOfStream: false)
+        }
+      }
+      _ = try await group.next()
+      group.cancelAll()
+    }
+    localConnection.cancel()
+  }
+
+  private func receive(from connection: NWConnection) async throws -> Data {
+    try await withCheckedThrowingContinuation { continuation in
+      connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, complete, error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else if let data, !data.isEmpty {
+          continuation.resume(returning: data)
+        } else if complete {
+          continuation.resume(throwing: CancellationError())
+        } else {
+          continuation.resume(throwing: CancellationError())
+        }
+      }
+    }
+  }
+
+  private func send(_ data: Data, to connection: NWConnection) async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      connection.send(content: data, completion: .contentProcessed { error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume(returning: ())
+        }
+      })
+    }
+  }
+}
+#endif
+
+private final class WifiAwareController {
+  private let channel: FlutterMethodChannel
+#if canImport(WiFiAware) && canImport(DeviceDiscoveryUI)
+  private var transport: Any?
+#endif
+
+  init(channel: FlutterMethodChannel) {
+    self.channel = channel
+  }
+
+  var isSupported: Bool {
+#if canImport(WiFiAware) && canImport(DeviceDiscoveryUI)
+    if #available(iOS 26.0, *) {
+      return WACapabilities.supportedFeatures.contains(.wifiAware)
+    }
+#endif
+    return false
+  }
+
+  func start(port: UInt16, https: Bool) {
+#if canImport(WiFiAware) && canImport(DeviceDiscoveryUI)
+    if #available(iOS 26.0, *) {
+      let value = (transport as? IOS26WifiAwareTransport) ?? IOS26WifiAwareTransport(channel: channel)
+      transport = value
+      value.start(port: port, https: https)
+    }
+#endif
+  }
+
+  func stop() {
+#if canImport(WiFiAware) && canImport(DeviceDiscoveryUI)
+    if #available(iOS 26.0, *) {
+      (transport as? IOS26WifiAwareTransport)?.stop()
+      transport = nil
+    }
+#endif
+  }
+
+  func showPairing() {
+#if canImport(WiFiAware) && canImport(DeviceDiscoveryUI)
+    if #available(iOS 26.0, *), isSupported {
+      guard let presenter = UIApplication.shared.connectedScenes
+        .compactMap({ $0 as? UIWindowScene })
+        .flatMap({ $0.windows })
+        .first(where: { $0.isKeyWindow })?
+        .rootViewController else { return }
+      presenter.present(UIHostingController(rootView: LocalSendPairingView()), animated: true)
+    }
+#endif
   }
 }

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -145,12 +145,22 @@
     <string>The app requires the local IP to communicate.</string>
     <key>NSLocalNetworkUsageDescription</key>
     <string>The app uses the local network to find and connect to nearby devices.</string>
-    <key>NSBonjourServices</key>
+	<key>NSBonjourServices</key>
     <array>
         <string>_http._tcp</string>
         <string>_bonjour._tcp</string>
         <string>_lnp._tcp.</string>
-    </array>
+	</array>
+	<key>WiFiAwareServices</key>
+	<dict>
+		<key>_localsend._tcp</key>
+		<dict>
+			<key>Publishable</key>
+			<dict/>
+			<key>Subscribable</key>
+			<dict/>
+		</dict>
+	</dict>
 
     <!-- share_handler -->
     <key>CFBundleURLTypes</key>

--- a/app/ios/Runner/Runner.entitlements
+++ b/app/ios/Runner/Runner.entitlements
@@ -6,6 +6,11 @@
 	<string>development</string>
 	<key>com.apple.developer.networking.multicast</key>
 	<true/>
+	<key>com.apple.developer.wifi-aware</key>
+	<array>
+		<string>Publish</string>
+		<string>Subscribe</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.localsend.localsendApp</string>

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -33,6 +33,7 @@ import 'package:localsend_app/util/native/channel/android_channel.dart';
 import 'package:localsend_app/util/native/context_menu_helper.dart';
 import 'package:localsend_app/util/native/cross_file_converters.dart';
 import 'package:localsend_app/util/native/device_info_helper.dart';
+import 'package:localsend_app/util/native/ios_wifi_aware_helper.dart';
 import 'package:localsend_app/util/native/macos_channel.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
@@ -217,6 +218,8 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
   } catch (e) {
     _logger.warning('Starting discovery listener failed', e);
   }
+
+  await setupIOSWifiAwareDiscovery(ref);
 
   // ignore: dead_code
   if (webRTCEnabled) {

--- a/app/lib/pages/tabs/receive_tab.dart
+++ b/app/lib/pages/tabs/receive_tab.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/state/server/server_state.dart';
@@ -9,6 +12,7 @@ import 'package:localsend_app/provider/animation_provider.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
 import 'package:localsend_app/provider/network/server/server_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/util/native/ios_wifi_aware_helper.dart';
 import 'package:localsend_app/widget/animations/initial_fade_transition.dart';
 import 'package:localsend_app/widget/column_list_view.dart';
 import 'package:localsend_app/widget/custom_icon_button.dart';
@@ -28,6 +32,20 @@ class ReceiveTab extends StatefulWidget {
 }
 
 class _ReceiveTabState extends State<ReceiveTab> {
+  bool _wifiAwareSupported = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      unawaited(
+        isIOSWifiAwareSupported().then((supported) {
+          if (mounted) setState(() => _wifiAwareSupported = supported);
+        }),
+      );
+    }
+  }
+
   /// Whether the advanced network info is shown
   bool _showAdvanced = false;
 
@@ -131,6 +149,7 @@ class _ReceiveTabState extends State<ReceiveTab> {
           showAdvanced: _showAdvanced,
         ),
         _CornerButtons(
+          wifiAwareSupported: _wifiAwareSupported,
           showAdvanced: _showAdvanced,
           showHistoryButton: _showHistoryButton,
           toggleAdvanced: _toggleAdvanced,
@@ -141,11 +160,13 @@ class _ReceiveTabState extends State<ReceiveTab> {
 }
 
 class _CornerButtons extends StatelessWidget {
+  final bool wifiAwareSupported;
   final bool showAdvanced;
   final bool showHistoryButton;
   final Future<void> Function() toggleAdvanced;
 
   const _CornerButtons({
+    required this.wifiAwareSupported,
     required this.showAdvanced,
     required this.showHistoryButton,
     required this.toggleAdvanced,
@@ -160,6 +181,14 @@ class _CornerButtons extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
+            if (wifiAwareSupported)
+              Tooltip(
+                message: 'Pair a nearby device',
+                child: CustomIconButton(
+                  onPressed: showIOSWifiAwarePairing,
+                  child: const Icon(Icons.wifi_tethering),
+                ),
+              ),
             if (!showAdvanced)
               AnimatedOpacity(
                 opacity: showHistoryButton ? 1 : 0,

--- a/app/lib/util/native/ios_wifi_aware_helper.dart
+++ b/app/lib/util/native/ios_wifi_aware_helper.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:localsend_app/model/state/server/server_state.dart';
+import 'package:localsend_app/provider/network/server/server_provider.dart';
+import 'package:localsend_isolates/isolate.dart';
+import 'package:logging/logging.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+
+const _methodChannel = MethodChannel('ios-delegate-channel');
+final _logger = Logger('WifiAware');
+StreamSubscription? _serverSubscription;
+(int, bool)? _configuration;
+
+Future<bool> isIOSWifiAwareSupported() async {
+  if (defaultTargetPlatform != TargetPlatform.iOS) return false;
+  return await _methodChannel.invokeMethod<bool>('isWifiAwareSupported') ?? false;
+}
+
+Future<void> showIOSWifiAwarePairing() => _methodChannel.invokeMethod<void>('showWifiAwarePairing');
+
+Future<void> setupIOSWifiAwareDiscovery(Ref ref) async {
+  if (!await isIOSWifiAwareSupported()) return;
+
+  _methodChannel.setMethodCallHandler((call) async {
+    if (call.method != 'wifiAwareEndpoint') {
+      throw MissingPluginException('Unknown native method ${call.method}');
+    }
+    final arguments = (call.arguments as Map).cast<String, dynamic>();
+    final host = arguments['host'] as String?;
+    final port = arguments['port'] as int?;
+    final https = arguments['https'] as bool?;
+    if (host == null || port == null || https == null) {
+      _logger.warning('Ignoring an invalid Wi-Fi Aware endpoint: $arguments');
+      return;
+    }
+    try {
+      await ref.redux(parentIsolateProvider).dispatchTakeResult(IsolateDiscoveryProbeAction(host: host, port: port, https: https)).drain<void>();
+    } catch (e, stackTrace) {
+      _logger.warning('Wi-Fi Aware endpoint probe failed ($host:$port)', e, stackTrace);
+    }
+  });
+
+  await _serverSubscription?.cancel();
+  _serverSubscription = ref.stream(serverProvider).listen((event) {
+    unawaited(_configureIOSWifiAware(event.next));
+  });
+  await _configureIOSWifiAware(ref.read(serverProvider));
+}
+
+Future<void> _configureIOSWifiAware(ServerState? server) async {
+  try {
+    if (server == null) {
+      _configuration = null;
+      await _methodChannel.invokeMethod<void>('stopWifiAware');
+      return;
+    }
+    final next = (server.port, server.https);
+    if (_configuration == next) return;
+    _configuration = next;
+    await _methodChannel.invokeMethod<void>('startWifiAware', {'port': server.port, 'https': server.https});
+  } catch (e, stackTrace) {
+    _configuration = null;
+    _logger.warning('Could not configure Wi-Fi Aware', e, stackTrace);
+  }
+}

--- a/packages/localsend_isolates/lib/rust/api/discovery.dart
+++ b/packages/localsend_isolates/lib/rust/api/discovery.dart
@@ -83,6 +83,12 @@ abstract class RsDiscovery implements RustOpaqueInterface {
   /// the store's log limit. Empty when the fingerprint is unknown.
   Future<List<RsDeviceLog>> deviceLogs({required String fingerprint});
 
+  /// Probes one endpoint that was discovered by a platform transport, such
+  /// as an Android Wi-Fi Aware data path. A successful LocalSend register
+  /// response is merged into the regular discovery store and emitted on
+  /// [RsDiscovery::listen].
+  Future<void> discover({required String host, required int port, required ProtocolType protocol});
+
   /// Discovers devices in stages, cheapest first: announces this device to
   /// the network and probes [channels] (e.g. the favorites), then falls
   /// back to scanning the `/24` subnets of the local interface addresses

--- a/packages/localsend_isolates/lib/rust/frb_generated.dart
+++ b/packages/localsend_isolates/lib/rust/frb_generated.dart
@@ -76,7 +76,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1979579466;
+  int get rustContentHash => -454181894;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'rust_lib_localsend_app',
@@ -119,6 +119,13 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiDiscoveryRsDiscoveryAnnounce({required RsDiscovery that});
 
   Future<List<RsDeviceLog>> crateApiDiscoveryRsDiscoveryDeviceLogs({required RsDiscovery that, required String fingerprint});
+
+  Future<void> crateApiDiscoveryRsDiscoveryDiscover({
+    required RsDiscovery that,
+    required String host,
+    required int port,
+    required ProtocolType protocol,
+  });
 
   Future<void> crateApiDiscoveryRsDiscoveryDiscoverStaged({
     required RsDiscovery that,
@@ -647,6 +654,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<void> crateApiDiscoveryRsDiscoveryDiscover({
+    required RsDiscovery that,
+    required String host,
+    required int port,
+    required ProtocolType protocol,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
+          sse_encode_String(host, serializer);
+          sse_encode_u_16(port, serializer);
+          sse_encode_protocol_type(protocol, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10, port: port_);
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiDiscoveryRsDiscoveryDiscoverConstMeta,
+        argValues: [that, host, port, protocol],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiDiscoveryRsDiscoveryDiscoverConstMeta => const TaskConstMeta(
+    debugName: 'RsDiscovery_discover',
+    argNames: ['that', 'host', 'port', 'protocol'],
+  );
+
+  @override
   Future<void> crateApiDiscoveryRsDiscoveryDiscoverStaged({
     required RsDiscovery that,
     required List<RsDeviceChannel> channels,
@@ -665,7 +705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_16(port, serializer);
           sse_encode_protocol_type(protocol, serializer);
           sse_encode_u_64(graceMs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -693,7 +733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
             sse_encode_StreamSink_rs_stored_device_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -720,7 +760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -753,7 +793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(interfaceIp, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_protocol_type(protocol, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -779,7 +819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
           sse_encode_bool(answer, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -804,7 +844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -839,7 +879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ip, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_String(sessionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -880,7 +920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_String(publicKey, serializer);
           sse_encode_opt_String(pin, serializer);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_prepare_upload_result,
@@ -915,7 +955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ip, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_box_autoadd_register_dto(payload, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_result_with_public_key_register_response_dto,
@@ -972,7 +1012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(contentLength, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1015,7 +1055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1042,7 +1082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1069,7 +1109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1097,7 +1137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
             sse_encode_StreamSink_rs_server_event_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1134,7 +1174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(fileId, serializer);
           sse_encode_opt_String(path, serializer);
           sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1174,7 +1214,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_String(path, serializer);
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(fileSize, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1203,7 +1243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_bool(accept, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1229,7 +1269,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_opt_list_String(acceptedFileIds, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1254,7 +1294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1279,7 +1319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1307,7 +1347,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
             sse_encode_StreamSink_list_prim_u_8_strict_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1335,7 +1375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender(that, serializer);
           sse_encode_list_prim_u_8_loose(data, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1360,7 +1400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1388,7 +1428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1415,7 +1455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_file_dto,
@@ -1443,7 +1483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1473,7 +1513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1501,7 +1541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_box_autoadd_rtc_send_file_response(status, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1527,7 +1567,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1553,7 +1593,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_Set_String_None(selection, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1581,7 +1621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1608,7 +1648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Set_String_None,
@@ -1636,7 +1676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1664,7 +1704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender,
@@ -1690,7 +1730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1729,7 +1769,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               onConnection,
               serializer,
             );
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1755,7 +1795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken,
@@ -1790,7 +1830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_ls_http_client_version(version, serializer);
           sse_encode_opt_String(expectedFingerprint, serializer);
           sse_encode_opt_box_autoadd_u_32(timeoutMs, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpClient,
@@ -1814,7 +1854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1839,7 +1879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1863,7 +1903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_key_pair,
@@ -1887,7 +1927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_security_context,
@@ -1918,7 +1958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_opt_list_prim_u_8_strict(bytes, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1945,7 +1985,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1970,7 +2010,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(path, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_file_metadata,
@@ -1995,7 +2035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2048,7 +2088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(certPem, serializer);
           sse_encode_String(privateKeyPem, serializer);
           sse_encode_u_64(timeoutMs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery,
@@ -2125,7 +2165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_bool(verifyChecksums, serializer);
           sse_encode_opt_box_autoadd_web_params(web, serializer);
           sse_encode_opt_String(showToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer,
@@ -2151,7 +2191,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cert, serializer);
           sse_encode_String(publicKey, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -6362,6 +6402,13 @@ class RsDiscoveryImpl extends RustOpaque implements RsDiscovery {
   /// the store's log limit. Empty when the fingerprint is unknown.
   Future<List<RsDeviceLog>> deviceLogs({required String fingerprint}) =>
       RustLib.instance.api.crateApiDiscoveryRsDiscoveryDeviceLogs(that: this, fingerprint: fingerprint);
+
+  /// Probes one endpoint that was discovered by a platform transport, such
+  /// as an Android Wi-Fi Aware data path. A successful LocalSend register
+  /// response is merged into the regular discovery store and emitted on
+  /// [RsDiscovery::listen].
+  Future<void> discover({required String host, required int port, required ProtocolType protocol}) =>
+      RustLib.instance.api.crateApiDiscoveryRsDiscoveryDiscover(that: this, host: host, port: port, protocol: protocol);
 
   /// Discovers devices in stages, cheapest first: announces this device to
   /// the network and probes [channels] (e.g. the favorites), then falls

--- a/packages/localsend_isolates/lib/src/isolate/child/discovery_isolate.dart
+++ b/packages/localsend_isolates/lib/src/isolate/child/discovery_isolate.dart
@@ -76,6 +76,21 @@ class DiscoveryStagedScanTask implements DiscoveryTask {
   });
 }
 
+/// Probes a single endpoint discovered through a native platform transport.
+/// Completes when the endpoint answered or the probe failed; successful
+/// devices arrive on the [DiscoveryListenTask] stream.
+class DiscoveryProbeTask implements DiscoveryTask {
+  final String host;
+  final int port;
+  final bool https;
+
+  DiscoveryProbeTask({
+    required this.host,
+    required this.port,
+    required this.https,
+  });
+}
+
 /// Feeds a device confirmed outside of the discovery into the store, e.g. one
 /// that registered with this device's HTTP server. The device comes back on
 /// the [DiscoveryListenTask] stream.
@@ -145,6 +160,9 @@ Future<void> setupDiscoveryIsolate(
                 https: data.https,
                 grace: data.grace,
               );
+          break;
+        case DiscoveryProbeTask data:
+          await ref.read(discoveryProvider).probe(host: data.host, port: data.port, https: data.https);
           break;
         case DiscoveryAddDeviceTask data:
           await ref.read(discoveryProvider).addDevice(data.device);

--- a/packages/localsend_isolates/lib/src/isolate/parent/actions.dart
+++ b/packages/localsend_isolates/lib/src/isolate/parent/actions.dart
@@ -116,6 +116,38 @@ class IsolateDiscoveryStagedScanAction extends ReduxActionWithResult<IsolateCont
   }
 }
 
+/// Probes a single endpoint discovered by a native platform transport.
+/// The returned stream completes when the probe finishes; a successful device
+/// arrives on the [IsolateDiscoveryListenAction] stream.
+class IsolateDiscoveryProbeAction extends ReduxActionWithResult<IsolateController, ParentIsolateState, Stream<Device>> {
+  final String host;
+  final int port;
+  final bool https;
+
+  IsolateDiscoveryProbeAction({
+    required this.host,
+    required this.port,
+    required this.https,
+  });
+
+  @override
+  (ParentIsolateState, Stream<Device>) reduce() {
+    final connection = state.discovery;
+    if (connection == null) {
+      throw StateError('discovery is not initialized');
+    }
+
+    return (
+      state,
+      connection
+          .sendWrappedTaskAndListenStream(
+            task: DiscoveryProbeTask(host: host, port: port, https: https),
+          )
+          .toDeviceStream(),
+    );
+  }
+}
+
 /// Fetches the retained confirmations of a stored device, oldest first.
 /// The logs are empty when the fingerprint is unknown or the discovery is
 /// not running.

--- a/packages/localsend_isolates/lib/src/task/discovery/discovery.dart
+++ b/packages/localsend_isolates/lib/src/task/discovery/discovery.dart
@@ -24,6 +24,7 @@ class DiscoveryService {
 
   final Ref _ref;
   RsDiscovery? _discovery;
+  Completer<void> _readyCompleter = Completer<void>();
   Completer<void> _retryCompleter = Completer();
   bool _listening = false;
 
@@ -91,6 +92,9 @@ class DiscoveryService {
       }
 
       _discovery = discovery;
+      if (!_readyCompleter.isCompleted) {
+        _readyCompleter.complete();
+      }
 
       // Tell everyone in the network that I am online.
       unawaited(discovery.announce());
@@ -103,6 +107,7 @@ class DiscoveryService {
 
       // The stream ended because [restartListener] stopped the discovery.
       _discovery = null;
+      _readyCompleter = Completer<void>();
     }
   }
 
@@ -179,6 +184,29 @@ class DiscoveryService {
     );
   }
 
+  /// Probes one endpoint found by a native transport such as Wi-Fi Aware.
+  /// Successful devices are emitted by [startListener].
+  Future<void> probe({required String host, required int port, required bool https}) async {
+    if (_discovery == null) {
+      try {
+        await _readyCompleter.future.timeout(const Duration(seconds: 5));
+      } on TimeoutException {
+        _logger.info('Discovery did not become ready, skipping endpoint $host:$port');
+        return;
+      }
+    }
+    final discovery = _discovery;
+    if (discovery == null) {
+      _logger.info('Discovery is not running, skipping endpoint $host:$port');
+      return;
+    }
+
+    await discovery.discover(
+      host: host,
+      port: port,
+      protocol: https ? rust_model.ProtocolType.https : rust_model.ProtocolType.http,
+    );
+  }
 
   /// The retained confirmations of a stored device, oldest first.
   /// Empty when the fingerprint is unknown or the discovery is not running.

--- a/packages/localsend_isolates/rust/src/api/discovery.rs
+++ b/packages/localsend_isolates/rust/src/api/discovery.rs
@@ -335,6 +335,23 @@ impl RsDiscovery {
         Ok(())
     }
 
+    /// Probes one endpoint that was discovered by a platform transport, such
+    /// as an Android Wi-Fi Aware data path. A successful LocalSend register
+    /// response is merged into the regular discovery store and emitted on
+    /// [RsDiscovery::listen].
+    pub async fn discover(
+        &self,
+        host: String,
+        port: u16,
+        protocol: ProtocolType,
+    ) -> anyhow::Result<()> {
+        self.instance
+            .handle
+            .discover(&host, port, protocol)
+            .await?;
+        Ok(())
+    }
+
     /// Scans the `/24` subnet of the local interface address [interface_ip]
     /// by sending every other host a register request, for networks that do
     /// not carry multicast.

--- a/packages/localsend_isolates/rust/src/frb_generated.rs
+++ b/packages/localsend_isolates/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1979579466;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -454181894;
 
 // Section: executor
 
@@ -578,6 +578,70 @@ fn wire__crate__api__discovery__RsDiscovery_device_logs_impl(
                         ))?;
                     Ok(output_ok)
                 })())
+            }
+        },
+    )
+}
+fn wire__crate__api__discovery__RsDiscovery_discover_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "RsDiscovery_discover",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsDiscovery>,
+            >>::sse_decode(&mut deserializer);
+            let api_host = <String>::sse_decode(&mut deserializer);
+            let api_port = <u16>::sse_decode(&mut deserializer);
+            let api_protocol = <crate::api::model::ProtocolType>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::api::discovery::RsDiscovery::discover(
+                            &*api_that_guard,
+                            api_host,
+                            api_port,
+                            api_protocol,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
             }
         },
     )
@@ -5156,197 +5220,203 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__discovery__RsDiscovery_discover_staged_impl(
+        10 => wire__crate__api__discovery__RsDiscovery_discover_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => {
+        11 => wire__crate__api__discovery__RsDiscovery_discover_staged_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        12 => {
             wire__crate__api__discovery__RsDiscovery_listen_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__discovery__RsDiscovery_multicast_error_impl(
+        13 => wire__crate__api__discovery__RsDiscovery_multicast_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        13 => wire__crate__api__discovery__RsDiscovery_scan_subnet_impl(
+        14 => wire__crate__api__discovery__RsDiscovery_scan_subnet_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        14 => wire__crate__api__discovery__RsDiscovery_set_answer_announcements_impl(
+        15 => wire__crate__api__discovery__RsDiscovery_set_answer_announcements_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__api__discovery__RsDiscovery_stop_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__http__RsHttpClient_cancel_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
+        16 => wire__crate__api__discovery__RsDiscovery_stop_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__http__RsHttpClient_cancel_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        18 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
+        19 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        21 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
+        22 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        22 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
+        23 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
+        24 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        25 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
+        26 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        26 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
+        27 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        27 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
+        28 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
+        29 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
+        31 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
+        32 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
+        34 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
+        35 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
+        36 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
+        37 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
+        38 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
+        39 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
+        40 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
+        41 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
+        42 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
+        43 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
+        44 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
+        45 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        46 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
+        50 => {
             wire__crate__api__logging__enable_debug_logging_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__crypto__generate_security_context_impl(
+        51 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__crypto__generate_security_context_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
-        54 => {
+        53 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
+        55 => {
             wire__crate__api__metadata__read_file_metadata_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5361,10 +5431,10 @@ fn pde_ffi_dispatcher_sync_impl(
     match func_id {
         2 => wire__crate__api__stream__Dart2RustStreamSink_close_impl(ptr, rust_vec_len, data_len),
         6 => wire__crate__api__cancel__RsCancellationToken_cancel_impl(ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/support/docs/wifi-aware-ios.md
+++ b/support/docs/wifi-aware-ios.md
@@ -1,0 +1,51 @@
+# iOS Wi-Fi Aware transport
+
+LocalSend can use the iOS 26 Wi-Fi Aware framework as an additional paired
+transport. Existing LAN discovery remains active and is the fallback on older
+iOS releases, unsupported iPhones, missing entitlements, or transport errors.
+
+## Requirements
+
+- iOS 26 and a device for which
+  `WACapabilities.supportedFeatures` contains `wifiAware`.
+- The `com.apple.developer.wifi-aware` signing entitlement with both `Publish`
+  and `Subscribe` capabilities.
+- The `_localsend._tcp` service declared as both `Publishable` and
+  `Subscribable` in `WiFiAwareServices`.
+- A peer paired through Apple's DeviceDiscoveryUI. The Receive screen exposes
+  a Wi-Fi Aware button on supported devices; one device advertises and the
+  other chooses it in the system UI.
+
+## Architecture
+
+The native listener and browser use Apple's paired Wi-Fi Aware service. They do
+not duplicate the LocalSend protocol. Each Wi-Fi Aware TCP connection is
+bridged byte-for-byte to a loopback TCP connection:
+
+- Incoming publisher connections are forwarded to the existing LocalSend
+  server.
+- Discovered subscriber endpoints receive a stable local loopback listener.
+  Dart sends that endpoint to the normal targeted discovery probe, and later
+  LocalSend connections to the same endpoint create fresh Wi-Fi Aware streams.
+
+Consequently, LocalSend's existing HTTPS identity, registration, PIN handling,
+transfer protocol, and device store remain unchanged.
+
+## Validation limits
+
+The code is conditionally compiled when the iOS 26 WiFiAware and
+DeviceDiscoveryUI SDKs are present, so older Xcode toolchains continue to build
+the LAN-only application. The iOS transport must still be compiled with Xcode
+26, signed by the LocalSend team with the entitlement, and tested between two
+supported physical devices before it can leave draft status.
+
+Android interoperability additionally requires an Android radio/firmware that
+advertises standards-based Wi-Fi Aware Pairing and the API 37 paired data path.
+Android devices without that support cannot pair with iOS, but continue using
+their Android passphrase path and LAN fallback.
+
+References:
+
+- <https://developer.apple.com/documentation/wifiaware/adopting-wi-fi-aware>
+- <https://developer.apple.com/documentation/wifiaware/connecting-paired-devices>
+- <https://developer.apple.com/documentation/devicediscoveryui>


### PR DESCRIPTION
## Summary

Adds an iOS 26 Wi-Fi Aware transport for paired nearby devices while preserving LocalSend's existing LAN behavior for older/unsupported iPhones and every failure path.

- declares `_localsend._tcp` as a publishable and subscribable Wi-Fi Aware service
- adds the `Publish` and `Subscribe` Wi-Fi Aware entitlement capabilities
- exposes Apple's DeviceDiscoveryUI publisher/picker flow from the Receive screen
- publishes to and browses all paired LocalSend devices
- tunnels Wi-Fi Aware TCP streams byte-for-byte through loopback listeners to the existing LocalSend server/client
- forwards discovered loopback endpoints to the normal targeted Rust discovery probe
- reuses LocalSend HTTPS identity, registration, PIN, transfer, and device-store logic
- conditionally compiles the new native code only when the iOS 26 frameworks are present

Relates to #2523.

The Android standards-pairing counterpart is draft PR #3304. iPhone ↔ Android requires that PR plus Android hardware/firmware exposing Wi-Fi Aware Pairing and API 37 paired data paths.

## Architecture

Wi-Fi Aware is an additional transport, not a second LocalSend protocol implementation:

- Publisher: each incoming Apple `NetworkConnection<TCP>` is bridged to LocalSend's existing loopback server port.
- Subscriber: each discovered Wi-Fi Aware endpoint receives a stable loopback `NWListener`. LocalSend probes and later transfers connect to that listener; each connection opens and bridges a fresh Wi-Fi Aware TCP stream.
- Discovery: the loopback endpoint is authenticated by the existing LocalSend registration request before a device is shown.

LAN multicast and subnet discovery remain active and unchanged. On iOS <26, unsupported devices, or unavailable framework/transport state, the Wi-Fi Aware button is absent and LAN remains the only path.

## Validation completed here

- changed Dart files: analyzer passed with no issues
- Rust bridge crate: tests passed
- LocalSend core with `full` features: 78 unit tests and all integration suites passed
- targeted discovery loopback and HTTPS fingerprint integration tests passed
- `Info.plist` and entitlements XML validation passed
- `git diff --check` passed
- Apple DocC metadata/signatures were checked for the iOS 26 Wi-Fi Aware, DeviceDiscoveryUI, and Network APIs used by the implementation

## Required before merge

This Linux environment cannot run Xcode or sign an iOS build. This PR must remain draft until a maintainer can:

1. Compile it with Xcode 26 and resolve any SDK/Swift concurrency diagnostics.
2. Sign with a LocalSend provisioning profile that contains `com.apple.developer.wifi-aware` for `Publish` and `Subscribe`.
3. Validate iPhone ↔ iPhone pairing, discovery, registration, and bidirectional file transfer on two supported physical devices.
4. Validate iPhone ↔ Android against PR #3304 on Android hardware that reports standards-pairing support.
5. Localize the small pairing surface if maintainers want it exposed in the first iteration.

## Platform constraints

Apple requires iOS 26, supported hardware, the entitlement, a valid `WiFiAwareServices` declaration, and system-managed pairing before a listener/browser can connect. Those constraints cannot be bypassed in LocalSend. Older iPhones continue using LAN fallback.
