### PR TITLE
fix: keep sending list scrollable when Advanced is open

### DIFF
--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -32,6 +32,9 @@ import 'package:routerino/routerino.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
+/// Extra space needed below the file list while the progress details are expanded.
+const _advancedProgressPanelExtraPadding = 100.0;
+
 class ProgressPage extends StatefulWidget {
   final bool showAppBar;
   final bool closeSessionOnClose;
@@ -271,7 +274,7 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
             ListView.builder(
               padding: EdgeInsets.only(
                 top: MediaQuery.of(context).padding.top + 20,
-                bottom: 150 + getNavBarPadding(context),
+                bottom: 150 + (_advanced ? _advancedProgressPanelExtraPadding : 0) + getNavBarPadding(context),
                 left: 15,
                 right: 30,
               ),


### PR DESCRIPTION
Fixes #3308.

Opening Advanced expands the progress card without changing the sending list's scroll extent, so the last file can stay hidden behind it.

Reserve the extra panel height while Advanced is open so the list can scroll clear of the card.

Validated with flutter test (69 tests passed).
