### PR TITLE
docs: add CLI usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,7 @@ Read more about [distribution channels][].
 ### Command Line Interface (CLI)
 
 Since v1.18.0, LocalSend provides a standalone Command Line Interface.
-It is available on Windows via Winget:
-
-```bash
-winget install LocalSend.CLI
-```
-
-For other platforms, you can download the binaries directly from the [latest release][latest] (look for `LocalSend-CLI-...`).
+You can download the binaries directly from the [latest release][latest] (look for `LocalSend-CLI-...`).
 
 *(Note: The main desktop app also supports command line arguments, such as `--text` or `-t` to start a text share from the terminal).*
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ It is recommended to download the app either from an app store or from a package
 
 Read more about [distribution channels][].
 
+### Command Line Interface (CLI)
+
+Since v1.18.0, LocalSend provides a standalone Command Line Interface.
+It is available on Windows via Winget:
+
+```bash
+winget install LocalSend.CLI
+```
+
+For other platforms, you can download the binaries directly from the [latest release][latest] (look for `LocalSend-CLI-...`).
+
+*(Note: The main desktop app also supports command line arguments, such as `--text` or `-t` to start a text share from the terminal).*
+
 Windows binaries are signed. Read more about the [Code signing policy][].
 
 > [!CAUTION]


### PR DESCRIPTION
## Description

This PR adds a small section to the \README.md\ (under the Download table) to mention the newly released CLI (Command Line Interface).

Currently, while the CLI was recently published (and available via Winget / GitHub releases), there was no mention of it in the main README, causing users to potentially miss this feature. It also adds a small note about the existing command-line arguments (like \--text\) for the main GUI app.