### PR TITLE
feat: allow drag-and-drop on the web send upload page

### DIFF
--- a/app/assets/i18n/_missing_translations_ar.json
+++ b/app/assets/i18n/_missing_translations_ar.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ar>.",
     "After editing this file, you can run 'dart run slang apply --locale=ar' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_az.json
+++ b/app/assets/i18n/_missing_translations_az.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <az>.",
     "After editing this file, you can run 'dart run slang apply --locale=az' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_be.json
+++ b/app/assets/i18n/_missing_translations_be.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <be>.",
     "After editing this file, you can run 'dart run slang apply --locale=be' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_bg.json
+++ b/app/assets/i18n/_missing_translations_bg.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <bg>.",
     "After editing this file, you can run 'dart run slang apply --locale=bg' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_bn.json
+++ b/app/assets/i18n/_missing_translations_bn.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <bn>.",
     "After editing this file, you can run 'dart run slang apply --locale=bn' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ca.json
+++ b/app/assets/i18n/_missing_translations_ca.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ca>.",
     "After editing this file, you can run 'dart run slang apply --locale=ca' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_cs.json
+++ b/app/assets/i18n/_missing_translations_cs.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <cs>.",
     "After editing this file, you can run 'dart run slang apply --locale=cs' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_da.json
+++ b/app/assets/i18n/_missing_translations_da.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <da>.",
     "After editing this file, you can run 'dart run slang apply --locale=da' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_de.json
+++ b/app/assets/i18n/_missing_translations_de.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <de>.",
     "After editing this file, you can run 'dart run slang apply --locale=de' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_el.json
+++ b/app/assets/i18n/_missing_translations_el.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <el>.",
     "After editing this file, you can run 'dart run slang apply --locale=el' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_en_IN.json
+++ b/app/assets/i18n/_missing_translations_en_IN.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <en-IN>.",
     "After editing this file, you can run 'dart run slang apply --locale=en-IN' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_es_ES.json
+++ b/app/assets/i18n/_missing_translations_es_ES.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <es-ES>.",
     "After editing this file, you can run 'dart run slang apply --locale=es-ES' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_et.json
+++ b/app/assets/i18n/_missing_translations_et.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <et>.",
     "After editing this file, you can run 'dart run slang apply --locale=et' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_eu.json
+++ b/app/assets/i18n/_missing_translations_eu.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <eu>.",
     "After editing this file, you can run 'dart run slang apply --locale=eu' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_fa.json
+++ b/app/assets/i18n/_missing_translations_fa.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <fa>.",
     "After editing this file, you can run 'dart run slang apply --locale=fa' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_fi.json
+++ b/app/assets/i18n/_missing_translations_fi.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <fi>.",
     "After editing this file, you can run 'dart run slang apply --locale=fi' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_fil_PH.json
+++ b/app/assets/i18n/_missing_translations_fil_PH.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <fil-PH>.",
     "After editing this file, you can run 'dart run slang apply --locale=fil-PH' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_fr.json
+++ b/app/assets/i18n/_missing_translations_fr.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <fr>.",
     "After editing this file, you can run 'dart run slang apply --locale=fr' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ga.json
+++ b/app/assets/i18n/_missing_translations_ga.json
@@ -71,5 +71,8 @@
         ]
       }
     }
+  },
+  "web": {
+    "dropHint": "Or drop files here"
   }
 }

--- a/app/assets/i18n/_missing_translations_gl.json
+++ b/app/assets/i18n/_missing_translations_gl.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <gl>.",
     "After editing this file, you can run 'dart run slang apply --locale=gl' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_gu.json
+++ b/app/assets/i18n/_missing_translations_gu.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <gu>.",
     "After editing this file, you can run 'dart run slang apply --locale=gu' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_he.json
+++ b/app/assets/i18n/_missing_translations_he.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <he>.",
     "After editing this file, you can run 'dart run slang apply --locale=he' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_hi.json
+++ b/app/assets/i18n/_missing_translations_hi.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <hi>.",
     "After editing this file, you can run 'dart run slang apply --locale=hi' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_hu.json
+++ b/app/assets/i18n/_missing_translations_hu.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <hu>.",
     "After editing this file, you can run 'dart run slang apply --locale=hu' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_id.json
+++ b/app/assets/i18n/_missing_translations_id.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <id>.",
     "After editing this file, you can run 'dart run slang apply --locale=id' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_it.json
+++ b/app/assets/i18n/_missing_translations_it.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <it>.",
     "After editing this file, you can run 'dart run slang apply --locale=it' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ja.json
+++ b/app/assets/i18n/_missing_translations_ja.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ja>.",
     "After editing this file, you can run 'dart run slang apply --locale=ja' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_km.json
+++ b/app/assets/i18n/_missing_translations_km.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <km>.",
     "After editing this file, you can run 'dart run slang apply --locale=km' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ko.json
+++ b/app/assets/i18n/_missing_translations_ko.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ko>.",
     "After editing this file, you can run 'dart run slang apply --locale=ko' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_lo.json
+++ b/app/assets/i18n/_missing_translations_lo.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <lo>.",
     "After editing this file, you can run 'dart run slang apply --locale=lo' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ml.json
+++ b/app/assets/i18n/_missing_translations_ml.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ml>.",
     "After editing this file, you can run 'dart run slang apply --locale=ml' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_mn.json
+++ b/app/assets/i18n/_missing_translations_mn.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <mn>.",
     "After editing this file, you can run 'dart run slang apply --locale=mn' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ms.json
+++ b/app/assets/i18n/_missing_translations_ms.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ms>.",
     "After editing this file, you can run 'dart run slang apply --locale=ms' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ne.json
+++ b/app/assets/i18n/_missing_translations_ne.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ne>.",
     "After editing this file, you can run 'dart run slang apply --locale=ne' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_nl.json
+++ b/app/assets/i18n/_missing_translations_nl.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <nl>.",
     "After editing this file, you can run 'dart run slang apply --locale=nl' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_pl.json
+++ b/app/assets/i18n/_missing_translations_pl.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <pl>.",
     "After editing this file, you can run 'dart run slang apply --locale=pl' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_pt_BR.json
+++ b/app/assets/i18n/_missing_translations_pt_BR.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <pt-BR>.",
     "After editing this file, you can run 'dart run slang apply --locale=pt-BR' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_pt_PT.json
+++ b/app/assets/i18n/_missing_translations_pt_PT.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <pt-PT>.",
     "After editing this file, you can run 'dart run slang apply --locale=pt-PT' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ro.json
+++ b/app/assets/i18n/_missing_translations_ro.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ro>.",
     "After editing this file, you can run 'dart run slang apply --locale=ro' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ru.json
+++ b/app/assets/i18n/_missing_translations_ru.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ru>.",
     "After editing this file, you can run 'dart run slang apply --locale=ru' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_si.json
+++ b/app/assets/i18n/_missing_translations_si.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <si>.",
     "After editing this file, you can run 'dart run slang apply --locale=si' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_sk.json
+++ b/app/assets/i18n/_missing_translations_sk.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <sk>.",
     "After editing this file, you can run 'dart run slang apply --locale=sk' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_sl.json
+++ b/app/assets/i18n/_missing_translations_sl.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <sl>.",
     "After editing this file, you can run 'dart run slang apply --locale=sl' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_sr.json
+++ b/app/assets/i18n/_missing_translations_sr.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <sr>.",
     "After editing this file, you can run 'dart run slang apply --locale=sr' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_sr_Cyrl.json
+++ b/app/assets/i18n/_missing_translations_sr_Cyrl.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <sr-Cyrl>.",
     "After editing this file, you can run 'dart run slang apply --locale=sr-Cyrl' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_sv.json
+++ b/app/assets/i18n/_missing_translations_sv.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <sv>.",
     "After editing this file, you can run 'dart run slang apply --locale=sv' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ta.json
+++ b/app/assets/i18n/_missing_translations_ta.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ta>.",
     "After editing this file, you can run 'dart run slang apply --locale=ta' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_th.json
+++ b/app/assets/i18n/_missing_translations_th.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <th>.",
     "After editing this file, you can run 'dart run slang apply --locale=th' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_tr.json
+++ b/app/assets/i18n/_missing_translations_tr.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <tr>.",
     "After editing this file, you can run 'dart run slang apply --locale=tr' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_uk.json
+++ b/app/assets/i18n/_missing_translations_uk.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <uk>.",
     "After editing this file, you can run 'dart run slang apply --locale=uk' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_ur.json
+++ b/app/assets/i18n/_missing_translations_ur.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <ur>.",
     "After editing this file, you can run 'dart run slang apply --locale=ur' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_uz.json
+++ b/app/assets/i18n/_missing_translations_uz.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <uz>.",
     "After editing this file, you can run 'dart run slang apply --locale=uz' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_vi.json
+++ b/app/assets/i18n/_missing_translations_vi.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <vi>.",
     "After editing this file, you can run 'dart run slang apply --locale=vi' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_zh_CN.json
+++ b/app/assets/i18n/_missing_translations_zh_CN.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <zh-CN>.",
     "After editing this file, you can run 'dart run slang apply --locale=zh-CN' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_zh_HK.json
+++ b/app/assets/i18n/_missing_translations_zh_HK.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <zh-HK>.",
     "After editing this file, you can run 'dart run slang apply --locale=zh-HK' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/_missing_translations_zh_TW.json
+++ b/app/assets/i18n/_missing_translations_zh_TW.json
@@ -2,5 +2,8 @@
   "@@info": [
     "Here are translations that exist in <en> but not in <zh-TW>.",
     "After editing this file, you can run 'dart run slang apply --locale=zh-TW' to quickly apply the newly added translations."
-  ]
+  ],
+  "web": {
+    "dropHint": "Or drop files here"
+  }
 }

--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -539,7 +539,8 @@
     "rejected": "Rejected",
     "files": "Files",
     "fileName": "File name",
-    "size": "Size"
+    "size": "Size",
+    "dropHint": "Or drop files here"
   },
   "assetPicker": {
     "@info": "Translations for the Media selection tool for Android and iPhone",

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 57
-/// Strings: 20623 (361 per locale)
+/// Strings: 20624 (361 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
@@ -136,8 +136,7 @@ enum AppLocale with BaseAppLocale<AppLocale, Translations> {
   srCyrl(languageCode: 'sr', scriptCode: 'Cyrl'),
   zhCn(languageCode: 'zh', countryCode: 'CN'),
   zhHk(languageCode: 'zh', countryCode: 'HK'),
-  zhTw(languageCode: 'zh', countryCode: 'TW')
-  ;
+  zhTw(languageCode: 'zh', countryCode: 'TW');
 
   const AppLocale({
     required this.languageCode,

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -851,6 +851,9 @@ class Translations$web$en {
 
   /// en: 'Size'
   String get size => 'Size';
+
+  /// en: 'Or drop files here'
+  String get dropHint => 'Or drop files here';
 }
 
 // Path: assetPicker

--- a/app/lib/provider/network/server/server_provider.dart
+++ b/app/lib/provider/network/server/server_provider.dart
@@ -168,6 +168,7 @@ class ServerService extends Notifier<ServerState?> {
                       files: t.web.files,
                       fileName: t.web.fileName,
                       size: t.web.size,
+                      dropHint: t.web.dropHint,
                     ),
                   )
                 : null,

--- a/packages/core/assets/web/upload.html
+++ b/packages/core/assets/web/upload.html
@@ -17,7 +17,14 @@
             width: 100%;
             max-width: 400px;
             margin: 15vh auto 0;
-            padding: 0 1em;
+            padding: 1em;
+            border: 2px dashed transparent;
+            border-radius: 0.5em;
+        }
+
+        #content.drag-over {
+            border-color: #00796B;
+            background-color: #E0F2F1;
         }
 
         #upload-button {
@@ -49,6 +56,12 @@
             display: none;
             font-size: 1.5em;
         }
+
+        #drop-hint {
+            margin-top: 0.75em;
+            font-size: 1em;
+            color: #616161;
+        }
     </style>
 </head>
 <body>
@@ -59,6 +72,7 @@
 <h1 style="padding: 0.5em">LocalSend</h1>
 <div id="content">
     <button id="upload-button" type="button">Upload</button>
+    <p id="drop-hint">Or drop files here</p>
     <input id="file-input" type="file" multiple style="display: none">
     <p id="status-text"></p>
     <p id="progress-text"></p>
@@ -70,6 +84,8 @@
     var i18n = {};
     var queryParams = location.search.slice(1).split('&');
     var pin = null;
+    var uploading = false;
+    var dragDepth = 0;
 
     // Parse query parameters manually for IE
     for (var i = 0; i < queryParams.length; i++) {
@@ -95,13 +111,31 @@
       makeRequest('/i18n.json', 'GET', null, function (response) {
         if (response.status === 200) {
           i18n = JSON.parse(response.responseText);
+          if (i18n.dropHint) {
+            document.getElementById('drop-hint').innerText = i18n.dropHint;
+          }
           then();
         }
       });
     }
 
+    function setHintVisible(visible) {
+      document.getElementById('drop-hint').style.display = visible ? 'block' : 'none';
+    }
+
     function setButtonVisible(visible) {
       document.getElementById('upload-button').style.display = visible ? 'block' : 'none';
+      setHintVisible(visible);
+    }
+
+    function setDragOver(active) {
+      var content = document.getElementById('content');
+      if (active) {
+        content.className = 'drag-over';
+      } else {
+        content.className = '';
+        dragDepth = 0;
+      }
     }
 
     function showStatus(text, isError) {
@@ -123,17 +157,21 @@
 
     // Ends the upload flow: keeps the error visible and lets the user try again.
     function finishWithError(text) {
+      uploading = false;
       showStatus(text, true);
       setButtonVisible(true);
     }
 
     // Ends the upload flow after all files have been sent.
     function finishWithSuccess() {
+      uploading = false;
       showStatus('');
       setButtonVisible(true);
     }
 
     function startUpload(fileList) {
+      uploading = true;
+      setDragOver(false);
       setButtonVisible(false);
       hideProgress();
       showStatus(i18n.waiting);
@@ -287,6 +325,34 @@
           fileInput.value = '';
         }
       };
+
+      document.addEventListener('dragenter', function (e) {
+        e.preventDefault();
+        if (uploading) {
+          return;
+        }
+        dragDepth++;
+        setDragOver(true);
+      });
+      document.addEventListener('dragover', function (e) {
+        e.preventDefault();
+      });
+      document.addEventListener('dragleave', function (e) {
+        e.preventDefault();
+        dragDepth--;
+        if (dragDepth <= 0) {
+          setDragOver(false);
+        }
+      });
+      document.addEventListener('drop', function (e) {
+        e.preventDefault();
+        setDragOver(false);
+        if (uploading || !e.dataTransfer || !e.dataTransfer.files.length) {
+          return;
+        }
+        startUpload(e.dataTransfer.files);
+      });
+
       fetchI18n(function () {});
     }
 

--- a/packages/core/src/http/server/web.rs
+++ b/packages/core/src/http/server/web.rs
@@ -130,6 +130,7 @@ pub struct WebI18n {
     pub files: String,
     pub file_name: String,
     pub size: String,
+    pub drop_hint: String,
 }
 
 impl Default for WebI18n {
@@ -145,6 +146,7 @@ impl Default for WebI18n {
             files: "Files".to_string(),
             file_name: "File name".to_string(),
             size: "Size".to_string(),
+            drop_hint: "Or drop files here".to_string(),
         }
     }
 }

--- a/packages/core/tests/v2_web_send.rs
+++ b/packages/core/tests/v2_web_send.rs
@@ -344,6 +344,7 @@ async fn test_upload_page() {
     let i18n = response.json::<HashMap<String, String>>().await.unwrap();
     assert!(i18n.contains_key("busy"));
     assert!(i18n.contains_key("uploadRejected"));
+    assert!(i18n.contains_key("dropHint"));
 }
 
 #[tokio::test]

--- a/packages/localsend_isolates/lib/rust/api/server.dart
+++ b/packages/localsend_isolates/lib/rust/api/server.dart
@@ -287,6 +287,7 @@ class WebI18n {
   final String files;
   final String fileName;
   final String size;
+  final String dropHint;
 
   const WebI18n({
     required this.waiting,
@@ -299,6 +300,7 @@ class WebI18n {
     required this.files,
     required this.fileName,
     required this.size,
+    required this.dropHint,
   });
 
   @override
@@ -312,7 +314,8 @@ class WebI18n {
       busy.hashCode ^
       files.hashCode ^
       fileName.hashCode ^
-      size.hashCode;
+      size.hashCode ^
+      dropHint.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -328,7 +331,8 @@ class WebI18n {
           busy == other.busy &&
           files == other.files &&
           fileName == other.fileName &&
-          size == other.size;
+          size == other.size &&
+          dropHint == other.dropHint;
 }
 
 /// Configuration for the web pages served to browsers. When omitted, the web

--- a/packages/localsend_isolates/lib/rust/frb_generated.dart
+++ b/packages/localsend_isolates/lib/rust/frb_generated.dart
@@ -3436,7 +3436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WebI18n dco_decode_web_i_18_n(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return WebI18n(
       waiting: dco_decode_String(arr[0]),
       enterPin: dco_decode_String(arr[1]),
@@ -3448,6 +3448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       files: dco_decode_String(arr[7]),
       fileName: dco_decode_String(arr[8]),
       size: dco_decode_String(arr[9]),
+      dropHint: dco_decode_String(arr[10]),
     );
   }
 
@@ -4810,6 +4811,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_files = sse_decode_String(deserializer);
     var var_fileName = sse_decode_String(deserializer);
     var var_size = sse_decode_String(deserializer);
+    var var_dropHint = sse_decode_String(deserializer);
     return WebI18n(
       waiting: var_waiting,
       enterPin: var_enterPin,
@@ -4821,6 +4823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       files: var_files,
       fileName: var_fileName,
       size: var_size,
+      dropHint: var_dropHint,
     );
   }
 
@@ -6160,6 +6163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.files, serializer);
     sse_encode_String(self.fileName, serializer);
     sse_encode_String(self.size, serializer);
+    sse_encode_String(self.dropHint, serializer);
   }
 
   @protected

--- a/packages/localsend_isolates/rust/src/api/server.rs
+++ b/packages/localsend_isolates/rust/src/api/server.rs
@@ -749,6 +749,7 @@ pub struct _WebI18n {
     pub files: String,
     pub file_name: String,
     pub size: String,
+    pub drop_hint: String,
 }
 
 #[frb(mirror(TlsConfig))]

--- a/packages/localsend_isolates/rust/src/frb_generated.rs
+++ b/packages/localsend_isolates/rust/src/frb_generated.rs
@@ -3496,6 +3496,7 @@ const _: fn() = || {
         let _: String = WebI18n.files;
         let _: String = WebI18n.file_name;
         let _: String = WebI18n.size;
+        let _: String = WebI18n.drop_hint;
     }
     match None::<crate::api::webrtc::WsServerMessage>.unwrap() {
         crate::api::webrtc::WsServerMessage::Hello { client, peers } => {
@@ -4999,6 +5000,7 @@ impl SseDecode for crate::api::server::WebI18n {
         let mut var_files = <String>::sse_decode(deserializer);
         let mut var_fileName = <String>::sse_decode(deserializer);
         let mut var_size = <String>::sse_decode(deserializer);
+        let mut var_dropHint = <String>::sse_decode(deserializer);
         return crate::api::server::WebI18n {
             waiting: var_waiting,
             enter_pin: var_enterPin,
@@ -5010,6 +5012,7 @@ impl SseDecode for crate::api::server::WebI18n {
             files: var_files,
             file_name: var_fileName,
             size: var_size,
+            drop_hint: var_dropHint,
         };
     }
 }
@@ -6421,6 +6424,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::api::server::WebI18n> {
             self.0.files.into_into_dart().into_dart(),
             self.0.file_name.into_into_dart().into_dart(),
             self.0.size.into_into_dart().into_dart(),
+            self.0.drop_hint.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -7742,6 +7746,7 @@ impl SseEncode for crate::api::server::WebI18n {
         <String>::sse_encode(self.files, serializer);
         <String>::sse_encode(self.file_name, serializer);
         <String>::sse_encode(self.size, serializer);
+        <String>::sse_encode(self.drop_hint, serializer);
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds file drag-and-drop on the browser **Receive via link** upload page (`upload.html`), including a drop hint and ignore-empty / ignore-in-progress drops.
- Wires `web.dropHint` through `WebI18n`, FRB, slang (`en.json` + missing-translation placeholders), and `server_provider`.
- Covers the new i18n key in the core web-send test.

Fixes #3320

A screen recording of this working will be attached on GitHub after the PR is opened.

## Test plan
- [ ] Build and run the **native** LocalSend app (not `flutter run -d chrome`).
- [ ] On Receive, enable **Receive via link** and open the URL in Safari or Chrome (not Send → Share via link).
- [ ] Drop one or more files onto the page; they should upload like the file picker.
- [ ] Dropping while an upload is in progress should be ignored.
- [ ] Folder / empty drops should not start an upload.
- [ ] Drop target should highlight while dragging files over the page.
- [ ] `cargo test --features full` in `packages/core` (web-send i18n assertion).
