### PR TITLE
fix(ci): use the app version in the AppImage metadata

### DIFF
--- a/.github/workflows/build_appimage.yml
+++ b/.github/workflows/build_appimage.yml
@@ -74,28 +74,33 @@ jobs:
         run: flutter build linux
 
       - name: Copy compiled linux files
-        working-directory: app
         run: |
           mkdir AppDir
-          cp -r build/linux/x64/release/bundle/* AppDir/
+          cp -r app/build/linux/x64/release/bundle/* AppDir/
 
       - name: Copy logo to AppDir
-        working-directory: app
         run: |
           mkdir -p AppDir/usr/share/icons/hicolor/32x32/apps
-          cp assets/img/logo-32.png AppDir/usr/share/icons/hicolor/32x32/apps/localsend.png
+          cp app/assets/img/logo-32.png AppDir/usr/share/icons/hicolor/32x32/apps/localsend.png
           mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
-          cp assets/img/logo-128.png AppDir/usr/share/icons/hicolor/128x128/apps/localsend.png
+          cp app/assets/img/logo-128.png AppDir/usr/share/icons/hicolor/128x128/apps/localsend.png
           mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
-          cp assets/img/logo-256.png AppDir/usr/share/icons/hicolor/256x256/apps/localsend.png
+          cp app/assets/img/logo-256.png AppDir/usr/share/icons/hicolor/256x256/apps/localsend.png
+
+      - name: Copy Recipe to correct location
+        env:
+          APP_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          sed "s/^\( *\)version: latest$/\1version: ${APP_VERSION}/" support/build/appimage/AppImageBuilder_x86_64.yml > AppImageBuilder.yml
+          grep -q "version: ${APP_VERSION}$" AppImageBuilder.yml
 
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage@57c3bc6963f870ce3be103117de5b5e33ffbaeb6
         with:
-          recipe: ./app/AppImageBuilder.yml
+          recipe: ./AppImageBuilder.yml
 
       - name: Upload AppImage file
         uses: actions/upload-artifact@v6
         with:
           name: appimage-result
-          path: ./app/*.AppImage
+          path: ./*.AppImage

--- a/.github/workflows/build_arm64_appimage.yml
+++ b/.github/workflows/build_arm64_appimage.yml
@@ -72,7 +72,11 @@ jobs:
           cp app/assets/img/logo-256.png AppDir/usr/share/icons/hicolor/256x256/apps/localsend.png
 
       - name: Copy Recipe to correct location
-        run: cp support/build/appimage/AppImageBuilder_arm_64.yml AppImageBuilder.yml
+        env:
+          APP_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          sed "s/^\( *\)version: latest$/\1version: ${APP_VERSION}/" support/build/appimage/AppImageBuilder_arm_64.yml > AppImageBuilder.yml
+          grep -q "version: ${APP_VERSION}$" AppImageBuilder.yml
 
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage@57c3bc6963f870ce3be103117de5b5e33ffbaeb6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,7 +341,11 @@ jobs:
           cp app/assets/img/logo-256.png AppDir/usr/share/icons/hicolor/256x256/apps/localsend.png
 
       - name: Copy Recipe to correct location
-        run: cp support/build/appimage/AppImageBuilder_x86_64.yml AppImageBuilder.yml
+        env:
+          APP_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          sed "s/^\( *\)version: latest$/\1version: ${APP_VERSION}/" support/build/appimage/AppImageBuilder_x86_64.yml > AppImageBuilder.yml
+          grep -q "version: ${APP_VERSION}$" AppImageBuilder.yml
 
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage@57c3bc6963f870ce3be103117de5b5e33ffbaeb6


### PR DESCRIPTION
Closes #2978

## Problem

Both AppImage recipes hardcode the app version:

```yaml
AppDir:
  app_info:
    version: latest
```

So every AppImage we ship advertises `latest` as its own version. AppImage managers such as Gear Lever compare that field against the newest release to decide whether an update is available, and `latest` never compares as older than a real version number — so LocalSend can't be updated through them.

The release workflow already resolves the real version from `app/pubspec.yaml` into `needs.build.outputs.version`, but never passes it to the recipe.

## Change

Substitute that version into the recipe in the step that copies it into place, in `release.yml` and `build_arm64_appimage.yml`. The `grep -q` afterwards fails the step if the `version: latest` line is ever renamed or removed, so this can't silently regress back to `latest`.

The x86_64 dev workflow (`build_appimage.yml`) needed a bit more: it pointed at `./app/AppImageBuilder.yml`, a file that is never created anywhere in the repo, and built its `AppDir` under `app/` while the recipe resolves `AppDir` relative to the working directory. I aligned it with the release and arm64 workflows, which both build `AppDir` at the repository root and copy the recipe there.

## Verification

I could not run `appimage-builder` itself (no Linux box), so I verified the substitution and the guard directly:

- With `APP_VERSION=1.18.2` (the current `app/pubspec.yaml`), both recipes come out with `app_info.version: 1.18.2`, and the recipe-format `version: 1` on line 2 is untouched — the `^\( *\)` anchor only matches the indented key.
- Negative test: after replacing `version: latest` with anything else in the recipe, the `grep -q` guard exits non-zero, so the build step fails loudly instead of shipping `latest` again.
- All three workflow files and the substituted recipes still parse as YAML.

The released asset name is unaffected: the release job copies `*.AppImage` to `result.AppImage` before uploading it under its own name.

## Note

`support/scripts/compile_linux_appimage.sh` also refers to `LocalSend-latest-x86_64.AppImage`, but that script looks stale for other reasons (it runs `appimage-builder` without copying a recipe into place at all), so I left it out of this PR.

---

This fix was written with Claude Code. Per `CONTRIBUTING.md`, AI-assisted contributions are allowed for bug fixes; flagging it explicitly so you can weigh it as you see fit.