### PR TITLE
fix: do not crash at startup when the executable path cannot be resolved

### DIFF
--- a/app/lib/util/shared_preferences/shared_preferences_portable.dart
+++ b/app/lib/util/shared_preferences/shared_preferences_portable.dart
@@ -1,7 +1,10 @@
 import 'dart:io';
 
 import 'package:localsend_app/util/shared_preferences/shared_preferences_file.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+
+final _logger = Logger('SharedPreferencesPortable');
 
 /// Custom implementation of SharedPreferencesStorePlatform
 /// that uses a file named settings.json located next to the executable.
@@ -12,7 +15,33 @@ class SharedPreferencesPortable extends SharedPreferencesFile {
 
 /// Returns the absolute path to the settings.json file next to the executable.
 String _getSettingsPathFromExecutable() {
-  final executablePath = Platform.resolvedExecutable;
-  final executableParentPath = File(executablePath).parent.path;
-  return path.join(executableParentPath, 'settings.json');
+  return buildSettingsPath(
+    executablePath: _resolveExecutable(),
+    fallbackDirectory: Directory.current.path,
+  );
+}
+
+/// Returns [Platform.resolvedExecutable], or null when the VM cannot resolve it.
+/// The getter throws a [TypeError] on some virtual disks (e.g. an ImDisk RAM disk),
+/// where reading it would crash the app before it even starts.
+/// See https://github.com/localsend/localsend/issues/3021
+/// and https://github.com/dart-lang/sdk/issues/53424
+String? _resolveExecutable() {
+  try {
+    final executablePath = Platform.resolvedExecutable;
+    return executablePath.isEmpty ? null : executablePath;
+  } catch (e) {
+    _logger.warning('Could not resolve the executable path', e);
+    return null;
+  }
+}
+
+/// Returns the absolute path to the settings.json file next to [executablePath],
+/// falling back to [fallbackDirectory] when the executable path is unknown.
+String buildSettingsPath({
+  required String? executablePath,
+  required String fallbackDirectory,
+}) {
+  final directory = executablePath == null ? fallbackDirectory : File(executablePath).parent.path;
+  return path.join(directory, 'settings.json');
 }

--- a/app/test/unit/util/shared_preferences/shared_preferences_portable_test.dart
+++ b/app/test/unit/util/shared_preferences/shared_preferences_portable_test.dart
@@ -1,0 +1,26 @@
+import 'package:localsend_app/util/shared_preferences/shared_preferences_portable.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  test('should put settings.json next to the executable', () {
+    expect(
+      buildSettingsPath(
+        executablePath: path.join('opt', 'localsend', 'localsend_app'),
+        fallbackDirectory: path.join('home', 'user'),
+      ),
+      path.join('opt', 'localsend', 'settings.json'),
+    );
+  });
+
+  test('should fall back to the working directory when the executable is unknown', () {
+    // https://github.com/localsend/localsend/issues/3021
+    expect(
+      buildSettingsPath(
+        executablePath: null,
+        fallbackDirectory: path.join('home', 'user'),
+      ),
+      path.join('home', 'user', 'settings.json'),
+    );
+  });
+}


### PR DESCRIPTION
Closes #3021

## Problem

`PersistenceService.initialize` constructs a `SharedPreferencesPortable` unconditionally, before it knows whether portable mode is even in use:

```dart
final portableStore = SharedPreferencesPortable();
if (checkPlatform(const [...]) && portableStore.exists()) {
```

That constructor reads `Platform.resolvedExecutable`. On some virtual disks — reported for an ImDisk RAM disk on Windows — the VM cannot resolve the executable and the getter itself throws, so the app dies inside `preInit` before any UI exists:

```
type 'Null' is not a subtype of type 'String'
#0  _Platform.resolvedExecutable (dart:io/platform_impl.dart:37)
#1  _getSettingsPathFromExecutable (package:localsend_app/util/shared_preferences/shared_preferences_portable.dart)
#2  new SharedPreferencesPortable (...:10)
#3  PersistenceService.initialize (package:localsend_app/provider/persistence_provider.dart:105)
#4  preInit (package:localsend_app/config/init.dart:66)
```

Upstream: dart-lang/sdk#53424, dart-lang/sdk#48427. There is no user-side workaround.

## Change

Treat an unresolvable executable as "unknown" rather than fatal, and fall back to the working directory — which is where a portable install is started from anyway. The empty-string case is folded in too, since it would otherwise resolve `settings.json` against the current directory implicitly rather than deliberately.

Path construction is split into a plain `buildSettingsPath` function so the fallback is actually testable without a virtual disk.

The other `Platform.resolvedExecutable` call sites are left alone: `enableContextMenu` and `disableContextMenu` already wrap it in a `try`/`catch`, `autostart_helper` runs on user action rather than at startup, and the debug page only displays it.

## Verification

- Two unit tests cover both branches (`app/test/unit/util/shared_preferences/shared_preferences_portable_test.dart`).
- `flutter test` — all 71 tests pass.
- `flutter analyze` — no issues.
- `dart format --set-exit-if-changed` — clean.

I do not have access to a machine that reproduces the crash, so the fallback path is covered by the unit test rather than on real hardware. Ran against Flutter 3.44.4 rather than the pinned 3.41.9, since I don't have fvm set up here; `app/pubspec.yaml` allows `^3.41.0`.

---

This fix was written with Claude Code. Per `CONTRIBUTING.md`, AI-assisted contributions are allowed for bug fixes; flagging it explicitly so you can weigh it as you see fit.