### PR TITLE
fix: do not send a 1970 timestamp when SAF does not know the file's mtime

### DIFF
--- a/app/lib/provider/selection/selected_sending_files_provider.dart
+++ b/app/lib/provider/selection/selected_sending_files_provider.dart
@@ -247,7 +247,7 @@ class AddAndroidDirectoryAction extends AsyncReduxAction<SelectedSendingFilesNot
         path: file.uri,
         bytes: null,
         // SAF only provides milliseconds, so there is no point statting in Rust.
-        lastModified: DateTime.fromMillisecondsSinceEpoch(file.lastModified, isUtc: true).toIso8601String(),
+        lastModified: safTimestampToRfc3339(file.lastModified),
         lastAccessed: null,
       );
 

--- a/app/lib/util/native/cross_file_converters.dart
+++ b/app/lib/util/native/cross_file_converters.dart
@@ -69,7 +69,7 @@ class CrossFileConverters {
       path: file.uri,
       bytes: null,
       // SAF only provides milliseconds, so there is no point statting in Rust.
-      lastModified: DateTime.fromMillisecondsSinceEpoch(file.lastModified, isUtc: true).toIso8601String(),
+      lastModified: safTimestampToRfc3339(file.lastModified),
       lastAccessed: null,
     );
   }
@@ -105,6 +105,18 @@ class CrossFileConverters {
       lastAccessed: null,
     );
   }
+}
+
+/// Converts a SAF timestamp in milliseconds to the RFC 3339 string used by the protocol.
+///
+/// `DocumentsContract.Document.COLUMN_LAST_MODIFIED` is nullable and a null column reaches
+/// Dart as 0, so a non-positive value means "unknown" rather than the epoch. Sending it
+/// anyway makes the receiver stamp the saved file with 1970.
+String? safTimestampToRfc3339(int millisecondsSinceEpoch) {
+  if (millisecondsSinceEpoch <= 0) {
+    return null;
+  }
+  return DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch, isUtc: true).toIso8601String();
 }
 
 extension CompareFile on CrossFile {

--- a/app/test/unit/util/native/cross_file_converters_test.dart
+++ b/app/test/unit/util/native/cross_file_converters_test.dart
@@ -1,0 +1,30 @@
+import 'package:localsend_app/util/native/channel/android_channel.dart';
+import 'package:localsend_app/util/native/cross_file_converters.dart';
+import 'package:test/test.dart';
+
+FileInfo fileInfo(int lastModified) {
+  return FileInfo(
+    name: 'photo.jpg',
+    size: 1234,
+    uri: 'content://com.example.provider/document/1',
+    lastModified: lastModified,
+  );
+}
+
+void main() {
+  test('safTimestampToRfc3339 should convert a SAF timestamp', () {
+    expect(safTimestampToRfc3339(1600000000123), '2020-09-13T12:26:40.123Z');
+  });
+
+  test('safTimestampToRfc3339 should treat a non-positive timestamp as unknown', () {
+    // COLUMN_LAST_MODIFIED is nullable and a null column reads back as 0,
+    // which must not be sent as a 1970 timestamp.
+    expect(safTimestampToRfc3339(0), isNull);
+    expect(safTimestampToRfc3339(-1), isNull);
+  });
+
+  test('convertFileInfo should drop an unknown timestamp', () async {
+    expect((await CrossFileConverters.convertFileInfo(fileInfo(1600000000123))).lastModified, '2020-09-13T12:26:40.123Z');
+    expect((await CrossFileConverters.convertFileInfo(fileInfo(0))).lastModified, isNull);
+  });
+}


### PR DESCRIPTION
## Problem

Both Android SAF paths read the modification time out of a cursor with `getLong`:

```kotlin
// FastDocumentFile.kt — listFiles() and fromDocumentUri()
lastModified = cursor.getLong(4)
```

`DocumentsContract.Document.COLUMN_LAST_MODIFIED` is [documented as nullable](https://developer.android.com/reference/android/provider/DocumentsContract.Document#COLUMN_LAST_MODIFIED) ("value may be `null` if unknown"), and `Cursor.getLong` returns `0` for a NULL column. Several document providers leave it empty.

Dart then converts that `0` unconditionally:

```dart
lastModified: DateTime.fromMillisecondsSinceEpoch(file.lastModified, isUtc: true).toIso8601String(),
```

So the file goes out over the wire with `lastModified: "1970-01-01T00:00:00.000Z"`. On the receiving side that parses fine and `save.rs` applies it, so the saved file gets an mtime of 1970 — worse than the no-metadata case, where the receiver would simply leave the file alone.

The same conversion is duplicated in `selected_sending_files_provider.dart` for the directory-picker path, so both the file picker and the folder picker are affected.

## Change

Extracted the conversion into `safTimestampToRfc3339` and made it return `null` for a non-positive value, which is already how the protocol expresses "no metadata" — `FileMetadata` skips absent fields and the receiver leaves the timestamp untouched. Both call sites now go through it.

## Verification

- Three unit tests in `app/test/unit/util/native/cross_file_converters_test.dart`, covering the conversion itself, the unknown case, and `convertFileInfo` end to end. The first one also pins the existing RFC 3339 output so the refactor is provably behaviour-preserving for real timestamps.
- `flutter test` — all 72 tests pass.
- `flutter analyze` — no issues.
- `dart format --set-exit-if-changed` — clean.

I do not have an Android device with a provider that omits the column, so the fix is argued from the `DocumentsContract` contract and covered by unit tests rather than reproduced on hardware. Ran against Flutter 3.44.4 rather than the pinned 3.41.9, since I don't have fvm set up here; `app/pubspec.yaml` allows `^3.41.0`.

I did not find an issue that pins this down exactly, though it is a plausible contributor to the scattered "transferred file shows 1970 / wrong date modified" reports (#3060, #2940).

---

This fix was written with Claude Code. Per `CONTRIBUTING.md`, AI-assisted contributions are allowed for bug fixes; flagging it explicitly so you can weigh it as you see fit.