### PR TITLE
fix: handle mixed files and directories in drag-and-drop

### DIFF
--- a/app/lib/pages/home_page.dart
+++ b/app/lib/pages/home_page.dart
@@ -83,20 +83,34 @@ class _HomePageState extends State<HomePage> with Refena {
         });
       },
       onDragDone: (event) async {
-        if (event.files.length == 1 && Directory(event.files.first.path).existsSync()) {
-          // user dropped a directory
-          await ref.redux(selectedSendingFilesProvider).dispatchAsync(AddDirectoryAction(event.files.first.path));
-        } else {
-          // user dropped one or more files
+        // the drop may contain a mix of files and directories
+        final droppedFiles = <XFile>[];
+        final droppedDirectories = <String>[];
+        for (final file in event.files) {
+          if (Directory(file.path).existsSync()) {
+            droppedDirectories.add(file.path);
+          } else {
+            droppedFiles.add(file);
+          }
+        }
+
+        // expand directories recursively
+        for (final directory in droppedDirectories) {
+          await ref.redux(selectedSendingFilesProvider).dispatchAsync(AddDirectoryAction(directory));
+        }
+
+        // add files directly
+        if (droppedFiles.isNotEmpty) {
           await ref
               .redux(selectedSendingFilesProvider)
               .dispatchAsync(
                 AddFilesAction(
-                  files: event.files,
+                  files: droppedFiles,
                   converter: CrossFileConverters.convertXFile,
                 ),
               );
         }
+
         vm.changeTab(HomeTab.send);
       },
       child: ResponsiveBuilder(


### PR DESCRIPTION
## PR Summary

### Problem
When dragging and dropping a mix of files and directories onto the home page at the same time, the app did not accept them correctly. The old code only handled the directory case when a **single** item was dropped and that item was a directory; otherwise it treated **all** dropped items as files. This meant:

- 1 directory + 1 or more files dropped together → the directory was processed as a file and failed
- Multiple directories dropped together → all were treated as files
- Mixed drops were never expanded correctly

### Fix
Rewrote the `onDragDone` handler to split dropped items into **files** and **directories**, then process both groups correctly:

1. For each dropped `XFile`, check `Directory(path).existsSync()`
2. Directories are added via `AddDirectoryAction` (expanded recursively)
3. Files are added directly via `AddFilesAction`
4. Finally, the user is switched to the `Send` tab