### PR TITLE
fix: expose settings controls to screen readers

### DIFF
--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -29,6 +29,7 @@ import 'package:localsend_app/widget/dialogs/text_field_with_actions.dart';
 import 'package:localsend_app/widget/labeled_checkbox.dart';
 import 'package:localsend_app/widget/local_send_logo.dart';
 import 'package:localsend_app/widget/responsive_list_view.dart';
+import 'package:localsend_app/widget/settings_entry.dart';
 import 'package:localsend_isolates/constants.dart';
 import 'package:localsend_isolates/model/device.dart';
 import 'package:refena_flutter/refena_flutter.dart';
@@ -47,15 +48,18 @@ class SettingsTab extends StatelessWidget {
         return ResponsiveListView(
           padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 40),
           children: [
-            Padding(
-              padding: const EdgeInsets.only(left: 8),
-              child: Text(t.settingsTab.title, style: Theme.of(context).textTheme.titleLarge, textAlign: TextAlign.center),
+            Semantics(
+              header: true,
+              child: Padding(
+                padding: const EdgeInsets.only(left: 8),
+                child: Text(t.settingsTab.title, style: Theme.of(context).textTheme.titleLarge, textAlign: TextAlign.center),
+              ),
             ),
             const SizedBox(height: 30),
             _SettingsSection(
               title: t.settingsTab.general.title,
               children: [
-                _SettingsEntry(
+                SettingsEntry(
                   label: t.settingsTab.general.brightness,
                   child: CustomDropdownButton<ThemeMode>(
                     value: vm.settings.theme,
@@ -69,7 +73,7 @@ class SettingsTab extends StatelessWidget {
                     onChanged: (theme) => vm.onChangeTheme(context, theme),
                   ),
                 ),
-                _SettingsEntry(
+                SettingsEntry(
                   label: t.settingsTab.general.color,
                   child: CustomDropdownButton<ColorMode>(
                     value: vm.settings.colorMode,
@@ -206,7 +210,7 @@ class SettingsTab extends StatelessWidget {
                   },
                 ),
                 if (checkPlatformWithFileSystem())
-                  _SettingsEntry(
+                  SettingsEntry(
                     label: t.settingsTab.receive.destination,
                     child: TextButton(
                       style: TextButton.styleFrom(
@@ -313,8 +317,9 @@ class SettingsTab extends StatelessWidget {
                     child: Text(t.settingsTab.network.needRestart, style: TextStyle(color: Theme.of(context).colorScheme.warning)),
                   ),
                 ),
-                _SettingsEntry(
+                SettingsEntry(
                   label: '${t.settingsTab.network.server}${vm.serverState == null ? ' (${t.general.offline})' : ''}',
+                  mergeSemantics: false,
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       color: Theme.of(context).inputDecorationTheme.fillColor,
@@ -329,7 +334,7 @@ class SettingsTab extends StatelessWidget {
                             child: TextButton(
                               style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface, iconSize: 24),
                               onPressed: () => vm.onTapStartServer(context),
-                              child: const Icon(Icons.play_arrow),
+                              child: Icon(Icons.play_arrow, semanticLabel: t.general.start),
                             ),
                           )
                         else
@@ -338,7 +343,7 @@ class SettingsTab extends StatelessWidget {
                             child: TextButton(
                               style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface, iconSize: 24),
                               onPressed: () => vm.onTapRestartServer(context),
-                              child: const Icon(Icons.refresh),
+                              child: Icon(Icons.refresh, semanticLabel: t.general.restart),
                             ),
                           ),
                         Tooltip(
@@ -346,14 +351,14 @@ class SettingsTab extends StatelessWidget {
                           child: TextButton(
                             style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.onSurface, iconSize: 24),
                             onPressed: vm.serverState == null ? null : vm.onTapStopServer,
-                            child: const Icon(Icons.stop),
+                            child: Icon(Icons.stop, semanticLabel: t.general.stop),
                           ),
                         ),
                       ],
                     ),
                   ),
                 ),
-                _SettingsEntry(
+                SettingsEntry(
                   label: t.settingsTab.network.alias,
                   child: TextFieldWithActions(
                     name: t.settingsTab.network.alias,
@@ -400,7 +405,7 @@ class SettingsTab extends StatelessWidget {
                   ),
                 ),
                 if (vm.advanced)
-                  _SettingsEntry(
+                  SettingsEntry(
                     label: t.settingsTab.network.deviceType,
                     child: CustomDropdownButton<DeviceType>(
                       value: vm.deviceInfo.deviceType,
@@ -408,7 +413,7 @@ class SettingsTab extends StatelessWidget {
                         return DropdownMenuItem(
                           value: type,
                           alignment: Alignment.center,
-                          child: Icon(type.icon),
+                          child: Icon(type.icon, semanticLabel: type.name),
                         );
                       }).toList(),
                       onChanged: (type) async {
@@ -417,7 +422,7 @@ class SettingsTab extends StatelessWidget {
                     ),
                   ),
                 if (vm.advanced)
-                  _SettingsEntry(
+                  SettingsEntry(
                     label: t.settingsTab.network.deviceModel,
                     child: TextFieldTv(
                       name: t.settingsTab.network.deviceModel,
@@ -428,7 +433,7 @@ class SettingsTab extends StatelessWidget {
                     ),
                   ),
                 if (vm.advanced)
-                  _SettingsEntry(
+                  SettingsEntry(
                     label: t.settingsTab.network.port,
                     child: TextFieldTv(
                       name: t.settingsTab.network.port,
@@ -453,7 +458,7 @@ class SettingsTab extends StatelessWidget {
                     },
                   ),
                 if (vm.advanced)
-                  _SettingsEntry(
+                  SettingsEntry(
                     label: t.settingsTab.network.discoveryTimeout,
                     child: TextFieldTv(
                       name: t.settingsTab.network.discoveryTimeout,
@@ -479,7 +484,7 @@ class SettingsTab extends StatelessWidget {
                     },
                   ),
                 if (vm.advanced)
-                  _SettingsEntry(
+                  SettingsEntry(
                     label: t.settingsTab.network.multicastGroup,
                     child: TextFieldTv(
                       name: t.settingsTab.network.multicastGroup,
@@ -609,33 +614,7 @@ class SettingsTab extends StatelessWidget {
   }
 }
 
-class _SettingsEntry extends StatelessWidget {
-  final String label;
-  final Widget child;
-
-  const _SettingsEntry({required this.label, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 15),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(label),
-          ),
-          const SizedBox(width: 10),
-          SizedBox(
-            width: 150,
-            child: child,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// A specialized version of [_SettingsEntry].
+/// A specialized version of [SettingsEntry].
 class _BooleanEntry extends StatelessWidget {
   final String label;
   final bool value;
@@ -650,7 +629,7 @@ class _BooleanEntry extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return _SettingsEntry(
+    return SettingsEntry(
       label: label,
       child: Stack(
         children: [
@@ -680,7 +659,7 @@ class _BooleanEntry extends StatelessWidget {
   }
 }
 
-/// A specialized version of [_SettingsEntry].
+/// A specialized version of [SettingsEntry].
 class _ButtonEntry extends StatelessWidget {
   final String label;
   final String buttonLabel;
@@ -694,7 +673,7 @@ class _ButtonEntry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _SettingsEntry(
+    return SettingsEntry(
       label: label,
       child: TextButton(
         style: TextButton.styleFrom(
@@ -737,7 +716,10 @@ class _SettingsSection extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(title, style: Theme.of(context).textTheme.titleMedium),
+              Semantics(
+                header: true,
+                child: Text(title, style: Theme.of(context).textTheme.titleMedium),
+              ),
               const SizedBox(height: 10),
               ...children,
             ],

--- a/app/lib/widget/labeled_checkbox.dart
+++ b/app/lib/widget/labeled_checkbox.dart
@@ -15,24 +15,26 @@ class LabeledCheckbox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: labelFirst
-          ? [
-              Text(label),
-              const SizedBox(width: 5),
-              Checkbox(
-                value: value,
-                onChanged: onChanged,
-              ),
-            ]
-          : [
-              Checkbox(
-                value: value,
-                onChanged: onChanged,
-              ),
-              const SizedBox(width: 5),
-              Text(label),
-            ],
+    return MergeSemantics(
+      child: Row(
+        children: labelFirst
+            ? [
+                Text(label),
+                const SizedBox(width: 5),
+                Checkbox(
+                  value: value,
+                  onChanged: onChanged,
+                ),
+              ]
+            : [
+                Checkbox(
+                  value: value,
+                  onChanged: onChanged,
+                ),
+                const SizedBox(width: 5),
+                Text(label),
+              ],
+      ),
     );
   }
 }

--- a/app/lib/widget/settings_entry.dart
+++ b/app/lib/widget/settings_entry.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+/// A settings row that associates its visible label with its control in the
+/// accessibility tree.
+///
+/// Most settings have one control, so their semantics are merged into a single
+/// node. Screen readers can then announce the setting name together with the
+/// control's role, value, state, and actions.
+///
+/// Set [mergeSemantics] to false when [child] contains multiple independently
+/// actionable controls. In that mode, the row is exposed as a named group and
+/// each child keeps its own semantics and actions.
+class SettingsEntry extends StatelessWidget {
+  final String label;
+  final Widget child;
+  final bool mergeSemantics;
+
+  const SettingsEntry({
+    required this.label,
+    required this.child,
+    this.mergeSemantics = true,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final row = _buildRow(excludeLabelSemantics: !mergeSemantics);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 15),
+      child: mergeSemantics
+          ? MergeSemantics(child: row)
+          : Semantics(
+              container: true,
+              explicitChildNodes: true,
+              label: label,
+              child: row,
+            ),
+    );
+  }
+
+  Widget _buildRow({required bool excludeLabelSemantics}) {
+    final labelWidget = Text(label);
+
+    return Row(
+      children: [
+        Expanded(
+          child: excludeLabelSemantics ? ExcludeSemantics(child: labelWidget) : labelWidget,
+        ),
+        const SizedBox(width: 10),
+        SizedBox(
+          width: 150,
+          child: child,
+        ),
+      ],
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -77,6 +77,8 @@ dev_dependencies:
   dart_mappable_builder: 4.8.0
   flutter_gen_runner: 5.15.0
   flutter_lints: 6.0.0
+  flutter_test:
+    sdk: flutter
   freezed: 3.2.5
   mockito: any
   refena_inspector: 2.1.1

--- a/app/test/widget/settings_accessibility_test.dart
+++ b/app/test/widget/settings_accessibility_test.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localsend_app/widget/custom_dropdown_button.dart';
+import 'package:localsend_app/widget/labeled_checkbox.dart';
+import 'package:localsend_app/widget/settings_entry.dart';
+
+void main() {
+  group('SettingsEntry semantics', () {
+    testWidgets('combines a setting name with its switch state and action', (tester) async {
+      final handle = tester.ensureSemantics();
+      var value = false;
+
+      await tester.pumpWidget(
+        _testApp(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return SettingsEntry(
+                label: 'Allow uploads',
+                child: Switch(
+                  value: value,
+                  onChanged: (newValue) => setState(() => value = newValue),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      var node = _semanticsNode('Allow uploads');
+      expect(
+        node,
+        isSemantics(
+          label: 'Allow uploads',
+          hasToggledState: true,
+          isToggled: false,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasFocusAction: true,
+          hasTapAction: true,
+        ),
+      );
+
+      tester.semantics.tap(find.semantics.byLabel('Allow uploads'));
+      await tester.pump();
+
+      expect(value, isTrue);
+      node = _semanticsNode('Allow uploads');
+      expect(node, isSemantics(hasToggledState: true, isToggled: true));
+      handle.dispose();
+    });
+
+    testWidgets('combines a setting name with a button value and role', (tester) async {
+      final handle = tester.ensureSemantics();
+      var activations = 0;
+
+      await tester.pumpWidget(
+        _testApp(
+          SettingsEntry(
+            label: 'Language',
+            child: TextButton(
+              onPressed: () => activations++,
+              child: const Text('English'),
+            ),
+          ),
+        ),
+      );
+
+      final node = _semanticsNode('Language');
+      expect(
+        node,
+        isSemantics(
+          label: 'Language\nEnglish',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasFocusAction: true,
+          hasTapAction: true,
+        ),
+      );
+
+      tester.semantics.tap(find.semantics.byLabel('English'));
+      await tester.pump();
+
+      expect(activations, 1);
+      handle.dispose();
+    });
+
+    testWidgets('keeps a text field label, current value, role, and actions together', (tester) async {
+      final handle = tester.ensureSemantics();
+      final controller = TextEditingController(text: '53317');
+
+      await tester.pumpWidget(
+        _testApp(
+          SettingsEntry(
+            label: 'Port',
+            child: TextFormField(controller: controller),
+          ),
+        ),
+      );
+
+      expect(
+        _semanticsNode('Port'),
+        isSemantics(
+          label: 'Port',
+          value: '53317',
+          isTextField: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasFocusAction: true,
+          hasTapAction: true,
+        ),
+      );
+      controller.dispose();
+      handle.dispose();
+    });
+
+    testWidgets('announces an icon-only dropdown current value', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _testApp(
+          SettingsEntry(
+            label: 'Device type',
+            child: CustomDropdownButton<String>(
+              value: 'mobile',
+              items: const [
+                DropdownMenuItem(
+                  value: 'mobile',
+                  child: Icon(Icons.smartphone, semanticLabel: 'mobile'),
+                ),
+              ],
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        _semanticsNode('Device type\nmobile'),
+        isSemantics(
+          label: 'Device type\nmobile',
+          isButton: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          isExpanded: false,
+          hasFocusAction: true,
+          hasTapAction: true,
+        ),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('preserves every action in a setting with multiple controls', (tester) async {
+      final handle = tester.ensureSemantics();
+      var starts = 0;
+      var stops = 0;
+
+      await tester.pumpWidget(
+        _testApp(
+          SettingsEntry(
+            label: 'Server (offline)',
+            mergeSemantics: false,
+            child: Row(
+              children: [
+                IconButton(
+                  tooltip: 'Start',
+                  onPressed: () => starts++,
+                  icon: const Icon(Icons.play_arrow, semanticLabel: 'Start'),
+                ),
+                IconButton(
+                  tooltip: 'Stop',
+                  onPressed: () => stops++,
+                  icon: const Icon(Icons.stop, semanticLabel: 'Stop'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final groupNode = _semanticsNode('Server (offline)');
+      expect(groupNode, isSemantics(label: 'Server (offline)', hasTapAction: false));
+
+      final startNode = _semanticsNode('Start');
+      final stopNode = _semanticsNode('Stop');
+      expect(startNode, isSemantics(label: 'Start', isButton: true, hasTapAction: true));
+      expect(stopNode, isSemantics(label: 'Stop', isButton: true, hasTapAction: true));
+
+      tester.semantics.tap(find.semantics.byLabel('Start'));
+      tester.semantics.tap(find.semantics.byLabel('Stop'));
+      await tester.pump();
+
+      expect(starts, 1);
+      expect(stops, 1);
+      handle.dispose();
+    });
+  });
+
+  group('LabeledCheckbox semantics', () {
+    for (final labelFirst in [false, true]) {
+      testWidgets('associates the label when labelFirst is $labelFirst', (tester) async {
+        final handle = tester.ensureSemantics();
+        bool? changedValue;
+
+        await tester.pumpWidget(
+          _testApp(
+            LabeledCheckbox(
+              label: 'Advanced settings',
+              value: true,
+              labelFirst: labelFirst,
+              onChanged: (value) => changedValue = value,
+            ),
+          ),
+        );
+
+        final node = _semanticsNode('Advanced settings');
+        expect(
+          node,
+          isSemantics(
+            label: 'Advanced settings',
+            hasCheckedState: true,
+            isChecked: true,
+            hasEnabledState: true,
+            isEnabled: true,
+            isFocusable: true,
+            hasFocusAction: true,
+            hasTapAction: true,
+          ),
+        );
+
+        tester.semantics.tap(find.semantics.byLabel('Advanced settings'));
+        await tester.pump();
+
+        expect(changedValue, isFalse);
+        handle.dispose();
+      });
+    }
+  });
+}
+
+SemanticsNode _semanticsNode(Pattern label) {
+  return find.semantics.byLabel(label).evaluate().single;
+}
+
+Widget _testApp(Widget child) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 400,
+          child: child,
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- associate each visible settings label with its control in the accessibility tree
- preserve independent actions for multi-control rows and name icon-only controls
- expose the settings page and section titles as headings
- add widget tests for roles, values, states, actions, and callback behavior

## Problem

The settings layout rendered labels and controls as separate semantics nodes. As a result, screen readers could encounter generic switches, buttons, text fields, and dropdowns without the setting name that gives the control meaning. Icon-only device and server controls also lacked reliable accessible names.

## Implementation

`SettingsEntry` now expresses the relationship between the existing visible label and its control without changing the visual layout:

- rows with one control use `MergeSemantics`, retaining the control role, current value or state, focusability, and actions in one named node
- rows with several controls use a named semantics container with explicit child nodes, so each action remains independently reachable
- the server actions and device-type icons receive accessible names
- `LabeledCheckbox` merges its text and checkbox for both supported label positions

The regression tests inspect the resulting semantics tree and invoke its actions. They cover a switch, text button, text field, icon-only dropdown, the multi-action server layout, and both checkbox orders.

## Tests

- `flutter test --no-pub` (76 tests passed)
- `dart analyze` (`No issues found`)
- `dart format --output=none --set-exit-if-changed lib/pages/tabs/settings_tab.dart lib/widget/labeled_checkbox.dart lib/widget/settings_entry.dart test/widget/settings_accessibility_test.dart`

Fixes #3296
