### PR TITLE
fix(linux): resolve the tray icon to an absolute path on Snap

### DIFF
--- a/app/lib/util/native/tray_helper.dart
+++ b/app/lib/util/native/tray_helper.dart
@@ -6,6 +6,7 @@ import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/provider/animation_provider.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:tray_manager/tray_manager.dart' as tm;
 import 'package:window_manager/window_manager.dart';
@@ -32,6 +33,11 @@ Future<void> initTray() async {
       if (await File('/.flatpak-info').exists()) {
         // Icon for Flatpak, which must exist in /app/share/icons/hicolor/*x*/apps.
         icon = 'org.localsend.localsend_app-tray';
+      } else if (Platform.environment.containsKey('SNAP')) {
+        // tray_manager only resolves the asset path against the executable directory when it does not detect a sandbox,
+        // and it treats $SNAP as one. The relative path would then reach libayatana-appindicator, which interprets
+        // anything that is not absolute as an icon theme name. A snap sees the same paths as the host, so resolve it here.
+        icon = p.join(p.dirname(Platform.resolvedExecutable), 'data', 'flutter_assets', Assets.img.logo32White.path);
       } else {
         icon = Assets.img.logo32White.path;
       }


### PR DESCRIPTION
### Problem

On the Snap package the system tray icon is not the LocalSend logo but three
dots. Those three dots are `image-loading-symbolic`, the fallback icon of the
GNOME appindicator extension.

<img width="52" height="44" alt="image" src="https://github.com/user-attachments/assets/e3cc30dc-fb30-4788-90be-81ea430545c6" />

### Cause

`initTray` passes the relative asset path `assets/img/logo-32-white.png`.
`tray_manager` normally turns that into an absolute path, but only when it does
not detect a sandbox, and its `runningInSandbox()` returns true because Snap
sets `$SNAP`:

```dart
if (runningInSandbox()) {
  // Pass the icon name as specified if running in a sandbox.
  arguments['iconPath'] = iconPath;
}
```

The relative path then reaches `app_indicator_set_icon_full()`, which treats
anything that is not absolute as an icon theme name. The shell extension makes
the same distinction and only loads the icon from disk when the name starts
with a slash:

```js
if (name[0] === '/') { ... return {file, iconInfo: null, name: null}; }
```

The theme lookup fails, so the fallback icon is drawn instead.

### Fix

That guard exists because a Flatpak sees different paths than the host, but a
Snap does not, so resolving the asset in the app is enough. Flatpak keeps using
its themed icon name and unsandboxed installs are untouched.

### Testing

`dart format` clean, `flutter analyze` reports no issues, `flutter test` passes.
Checked on Ubuntu 26.04, GNOME on Wayland, `localsend` snap revision 35, that
the resolved path exists inside the snap:

```
/snap/localsend/current/opt/localsend_app/data/flutter_assets/assets/img/logo-32-white.png
```
