### PR TITLE
fix(linux): set StartupWMClass in the deb desktop entry

### DIFF
--- a/app/linux/packaging/deb/make_config.yaml
+++ b/app/linux/packaging/deb/make_config.yaml
@@ -39,3 +39,7 @@ categories:
   - Utility
 
 startup_notify: true
+
+# Must match the GTK application id set in linux/CMakeLists.txt, otherwise the
+# desktop environment cannot map the running window back to this desktop entry.
+startup_wm_class: org.localsend.localsend_app


### PR DESCRIPTION
### Problem

The dock and alt-tab show a generic icon for the running window instead of the
LocalSend logo.

### Cause

The Linux app sets its GTK application id to `org.localsend.localsend_app`:

```cmake
set(APPLICATION_ID "org.localsend.localsend_app")   # linux/CMakeLists.txt
```
```cpp
g_set_prgname(APPLICATION_ID);                      # linux/my_application.cc
```

The desktop entry generated for the deb is named `localsend_app.desktop` and
declares no `StartupWMClass`, so nothing maps the window back to it. GNOME
Shell tries, in order, `StartupWMClass` against the WM_CLASS instance and
class, then a desktop file named after them, and finally the GApplication id,
see `get_app_from_window_wmclass` in `shell-window-tracker.c`. Every step looks
for `org.localsend.localsend_app`, which matches nothing.

### Fix

Declaring `StartupWMClass` covers both session types. On Wayland the app id is
`org.localsend.localsend_app`, and on X11 GTK uses it verbatim as the WM_CLASS
instance part, which is the first thing GNOME Shell checks.

The rpm config has no equivalent knob, `flutter_app_packager` only emits
`StartupWMClass` for deb, so the rpm keeps the current behaviour.

### Testing

`dart format` clean, `flutter analyze` reports no issues, `flutter test` passes.

Built the package with `flutter_distributor package --platform linux --targets
deb` and read the entry back out of it with `dpkg-deb -x`:

```desktop
[Desktop Entry]
Type=Application
Name=LocalSend
GenericName=An open source cross-platform alternative to AirDrop
Icon=localsend_app
Exec=localsend_app %U
Categories=GTK;FileTransfer;Utility;
Keywords=Sharing;LAN;Files;
StartupNotify=true
StartupWMClass=org.localsend.localsend_app
```

The value matches the application id compiled into the shipped binary. The
generic icon was observed on Ubuntu 26.04, GNOME on Wayland.
