### PR TITLE
fix(linux): honour XDG_CONFIG_HOME and harden the autostart helper

### DIFF
--- a/app/lib/util/native/autostart_helper.dart
+++ b/app/lib/util/native/autostart_helper.dart
@@ -21,6 +21,7 @@ Future<bool> enableAutoStart({required bool startHidden}) async {
 Type=Application
 Name=${packageInfo.appName}
 Comment=${packageInfo.appName} startup script
+Icon=${packageInfo.packageName}
 Exec=${Platform.resolvedExecutable}${startHidden ? ' $startHiddenFlag' : ''}
 StartupNotify=false
 Terminal=false
@@ -57,7 +58,10 @@ Future<bool> disableAutoStart() async {
     final packageInfo = await PackageInfo.fromPlatform();
     switch (defaultTargetPlatform) {
       case TargetPlatform.linux:
-        File(_getLinuxFilePath(packageInfo.packageName)).deleteSync();
+        final file = File(_getLinuxFilePath(packageInfo.packageName));
+        if (file.existsSync()) {
+          file.deleteSync();
+        }
         break;
       case TargetPlatform.macOS:
         await setLaunchAtLogin(false);
@@ -118,5 +122,9 @@ RegistryKey _getWindowsRegistryKey() {
 }
 
 String _getLinuxFilePath(String appName) {
-  return '${Platform.environment['HOME']}/.config/autostart/$appName.desktop';
+  // An unset or empty XDG_CONFIG_HOME falls back to $HOME/.config.
+  // https://specifications.freedesktop.org/basedir-spec/latest/
+  final configHome = Platform.environment['XDG_CONFIG_HOME'];
+  final base = configHome == null || configHome.isEmpty ? '${Platform.environment['HOME']}/.config' : configHome;
+  return '$base/autostart/$appName.desktop';
 }


### PR DESCRIPTION
Three small independent defects in the Linux branch of the autostart helper.

### `XDG_CONFIG_HOME` is ignored

`_getLinuxFilePath` hardcodes `$HOME/.config`, so on a setup with a custom
`XDG_CONFIG_HOME` the desktop entry is written to a directory the session never
reads and "Autostart after login" silently does nothing. The base directory
spec treats an unset or empty value as `$HOME/.config`, which keeps the current
path for everyone else.

### Disabling autostart can get stuck

`disableAutoStart` calls `deleteSync()` unconditionally, which throws when the
entry is already gone. The exception is swallowed and `false` is returned, and
`onToggleAutoStart` only updates the state when the call reports success:

```dart
if (state.autoStart) {
  success = await disableAutoStart();
} else {
  success = await enableAutoStart(startHidden: state.autoStartLaunchHidden);
}

if (success) {
  redux.dispatch(_SetAutoStartAction(!state.autoStart));
}
```

So if the file was removed behind the app's back, the switch springs back on
and can never be turned off. Deleting only when the file exists makes it
idempotent.

### The generated entry has no icon

It therefore shows up without one in tools that list startup applications. The
deb and rpm entries use the package name as the icon name, so reuse it here.

### Testing

`dart format` clean, `flutter analyze` reports no issues, `flutter test` passes.

Note this does not address the Flatpak side of #1927, where `$HOME` points
inside the sandbox and the entry never reaches the host session at all.
