### PR TITLE
fix(linux): do not fail the build on the appindicator deprecation

### DIFF
--- a/app/linux/CMakeLists.txt
+++ b/app/linux/CMakeLists.txt
@@ -91,6 +91,15 @@ set_target_properties(${BINARY_NAME}
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# tray_manager calls app_indicator_new, which libayatana-appindicator 0.5.94
+# annotates with G_GNUC_DEPRECATED. apply_standard_settings passes -Werror to
+# every plugin, so that deprecation fails the build on distributions shipping
+# such a version. Exempt the single warning on the single target that needs it
+# rather than relaxing -Werror for everything.
+if(TARGET tray_manager_plugin)
+  target_compile_options(tray_manager_plugin PRIVATE -Wno-error=deprecated-declarations)
+endif()
+
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build


### PR DESCRIPTION
### Problem

The Linux app does not build on distributions shipping
libayatana-appindicator 0.5.94:

```
tray_manager_plugin.cc:118:17: error: 'app_indicator_new' is deprecated [-Werror,-Wdeprecated-declarations]
Build process failed
```

Reproduced on Ubuntu 26.04 with clang 21 and Flutter 3.41.9, on a clean
checkout of `main`.

### Cause

That release annotates the function the plugin calls:

```c
AppIndicator *app_indicator_new (const gchar          *id,
                                 const gchar          *icon_name,
                                 AppIndicatorCategory  category) G_GNUC_DEPRECATED;
```

`apply_standard_settings` passes `-Werror` to every target that uses it, and
`tray_manager` does, so the deprecation warning becomes a hard error.

### Fix

Exempt that one warning on that one target. The function carries a warning in
its own file about not relaxing settings for every plugin at once:

```cmake
# Be cautious about adding new options here, as plugins use this function by
# default. In most cases, you should add new options to specific targets instead
# of modifying this function.
```

So `-Werror` stays in force everywhere else, including for the app's own
sources, and real deprecations in other plugins keep failing the build. The
`if(TARGET ...)` guard makes it a no-op if the plugin is ever dropped or
renamed.

The durable fix belongs in `tray_manager`, which should stop calling the
deprecated entry point, but that does not unblock building LocalSend today.

### Testing

`flutter_distributor package --platform linux --targets deb` now completes and
produces the package. The deprecation is still reported, just no longer fatal:

```
tray_manager_plugin.cc:118:17: warning: 'app_indicator_new' is deprecated [-Wdeprecated-declarations]
```
