### PR TITLE
Fix non-media file transfers with gallery saving enabled

### DIFF
--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -113,7 +113,10 @@ class ReceiveController {
           endTime: null,
           destinationDirectory: destinationDir,
           cacheDirectory: cacheDir,
-          saveToGallery: checkPlatformWithGallery() && settings.saveToGallery && files.values.every((f) => !f.fileName.contains('/')),
+          saveToGallery:
+              checkPlatformWithGallery() &&
+              settings.saveToGallery &&
+              files.values.every((f) => !f.fileName.contains('/') && (f.fileType == FileType.image || f.fileType == FileType.video)),
           createdDirectories: {},
         ),
       ),

--- a/packages/localsend_isolates/lib/src/task/server/file_saver.dart
+++ b/packages/localsend_isolates/lib/src/task/server/file_saver.dart
@@ -145,7 +145,9 @@ Future<(bool, String?)> saveCachedFileToGallery({
     );
 
     _logger.info('Moving file from $cachedPath to $fallbackPath');
-    await File(cachedPath).rename(fallbackPath);
+    final sourceFile = File(cachedPath);
+    await sourceFile.copy(fallbackPath);
+    await sourceFile.delete();
     return (false, fallbackPath);
   }
 


### PR DESCRIPTION
## Summary

Fixes #3350.

- Only enable gallery saving when all received files are images or videos.
- Use `copy()` + `delete()` instead of `rename()` when falling back from gallery saving to the destination directory, avoiding Android's cross-device link (`errno = 18`) error.

## Testing

Tested on Android with **Save media to gallery** enabled:

- Successfully transferred media files.
- Successfully transferred a non-media `.dwg` file.

Both media and non-media file transfers now complete successfully.