### PR TITLE
Fix Android system name resolving to localhost

### DIFF
--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/config/theme.dart';
@@ -386,6 +387,11 @@ class SettingsTab extends StatelessWidget {
                             if (Platform.isMacOS) {
                               final result = await Process.run('scutil', ['--get', 'ComputerName']);
                               newAlias = result.stdout.toString().trim();
+                            } else if (Platform.isAndroid) {
+                              final deviceInfo = await DeviceInfoPlugin().androidInfo;
+                              final brand = deviceInfo.brand;
+                              final model = deviceInfo.model;
+                              newAlias = model.toLowerCase().startsWith(brand.toLowerCase()) ? model : '$brand $model';
                             } else {
                               newAlias = Platform.localHostname;
                             }


### PR DESCRIPTION
## Summary

Fixes #3357.

On Android, `Platform.localHostname` can resolve to `localhost` instead of the device's actual name.

This change uses Android's device information to generate the system name from the device brand and model, while avoiding duplicate brand names when the model already includes it.

## Testing

Tested the "Use System Name" action on:

- A Nothing Phone (2)
- An Android emulator

The "Use System Name" action now uses the Android device's brand and model instead of resolving to `localhost`.