### PR TITLE
use app clip to allow tap to share with iPhone without installing app

### DIFF
--- a/.github/workflows/ios_app_clip.yml
+++ b/.github/workflows/ios_app_clip.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/ios_app_clip.yml
+++ b/.github/workflows/ios_app_clip.yml
@@ -1,0 +1,54 @@
+name: iOS App Clip
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/ios_app_clip.yml'
+      - 'app/ios/AppClip/**'
+      - 'app/ios/AppClipTests/**'
+      - 'app/ios/Flutter/AppClip.xcconfig'
+      - 'app/ios/Runner/Runner.entitlements'
+      - 'app/ios/Runner/**'
+      - 'app/ios/Runner.xcodeproj/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/ios_app_clip.yml'
+      - 'app/ios/AppClip/**'
+      - 'app/ios/AppClipTests/**'
+      - 'app/ios/Flutter/AppClip.xcconfig'
+      - 'app/ios/Runner/Runner.entitlements'
+      - 'app/ios/Runner/**'
+      - 'app/ios/Runner.xcodeproj/**'
+
+env:
+  FLUTTER_VERSION: '3.41.9'
+
+jobs:
+  test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+      - name: Generate Flutter build settings
+        working-directory: app
+        run: flutter pub get
+      - name: Select an available iPhone simulator
+        run: |
+          SIMULATOR_ID=$(xcrun simctl list devices available -j | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(device["udid"] for runtime in data["devices"].values() for device in runtime if device["name"].startswith("iPhone")))')
+          echo "SIMULATOR_ID=$SIMULATOR_ID" >> "$GITHUB_ENV"
+      - name: Build and test the native App Clip
+        run: |
+          xcodebuild test \
+            -project app/ios/Runner.xcodeproj \
+            -scheme LocalSendClip \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
+            CODE_SIGNING_ALLOWED=NO \
+            APP_CLIP_ASSOCIATED_DOMAIN=appclips:localsend.org \
+            APP_CLIP_INVOCATION_BASE_URL=https://localsend.org/clip
+      - name: Compile the installed-app invocation fallback
+        working-directory: app
+        run: flutter build ios --simulator --debug --no-codesign

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -22,6 +22,8 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def appClipInvocationBaseUrl = project.findProperty('appClipInvocationBaseUrl') ?: 'https://localsend.org/clip'
+
 android {
     namespace "org.localsend.localsend_app"
     compileSdkVersion 36
@@ -48,6 +50,7 @@ android {
         targetSdkVersion 37
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        resValue "string", "app_clip_invocation_base_url", appClipInvocationBaseUrl
     }
 
     signingConfigs {
@@ -85,6 +88,10 @@ android {
 
 flutter {
     source '../..'
+}
+
+dependencies {
+    testImplementation "junit:junit:4.13.2"
 }
 
 // To comply with F-Droid version code schema

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,16 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
@@ -25,6 +35,7 @@
     <!-- Android TV -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.hardware.nfc.hce" android:required="false" />
 
     <application
         android:label="LocalSend"
@@ -94,6 +105,24 @@
             android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
             android:foregroundServiceType="dataSync"
             android:exported="false" />
+
+        <service
+            android:name=".appclip.AppClipHostService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+
+        <service
+            android:name=".appclip.AppClipNdefService"
+            android:enabled="false"
+            android:exported="true"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/app_clip_apdu_service" />
+        </service>
 
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -16,6 +16,7 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import org.localsend.localsend_app.appclip.AppClipHostBridge
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -75,6 +76,7 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        AppClipHostBridge.configureEvents(flutterEngine.dartExecutor.binaryMessenger)
         MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             CHANNEL
@@ -133,6 +135,33 @@ class MainActivity : FlutterActivity() {
                         pendingPermissionResult = result
                         requestPermissions(arrayOf(PERMISSION_ACCESS_LOCAL_NETWORK), REQUEST_CODE_LOCAL_NETWORK)
                     }
+                }
+
+                "getAppClipHostPrerequisites" -> result.success(AppClipHostBridge.getPrerequisites(this))
+
+                "getAppClipHostState" -> result.success(AppClipHostBridge.getState())
+
+                "startAppClipHost" -> result.success(
+                    AppClipHostBridge.start(
+                        this,
+                        call.argument<String>("deviceName") ?: "",
+                    ),
+                )
+
+                "getAppClipInvocationUrl" -> result.success(AppClipHostBridge.getInvocationUrl())
+
+                "getAppClipBootstrap" -> result.success(AppClipHostBridge.getBootstrap())
+
+                "acknowledgeAppClipBootstrap" -> result.success(
+                    AppClipHostBridge.acknowledgeBootstrap(
+                        this,
+                        call.argument<String>("sessionId") ?: "",
+                    ),
+                )
+
+                "stopAppClipHost" -> {
+                    AppClipHostBridge.stop(this)
+                    result.success(null)
                 }
 
                 else -> result.notImplemented()

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipBootstrapServer.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipBootstrapServer.kt
@@ -1,0 +1,180 @@
+package org.localsend.localsend_app.appclip
+
+import java.io.BufferedInputStream
+import java.io.Closeable
+import java.io.IOException
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+internal data class AppClipBootstrapResult(
+    val sessionId: String,
+    val peerIp: String,
+    val peerPort: Int,
+    val downloadToken: String,
+) {
+    fun toMap(): Map<String, Any> = mapOf(
+        "sessionId" to sessionId,
+        "peerIp" to peerIp,
+        "peerPort" to peerPort,
+        "downloadToken" to downloadToken,
+    )
+}
+
+/** Bounded one-shot HTTP bootstrap listener; it never receives or persists transfer bytes. */
+internal class AppClipBootstrapServer(
+    private val sessionId: ByteArray,
+    private val sessionKey: ByteArray,
+    private val clock: () -> Long = System::currentTimeMillis,
+    private val onAccepted: (AppClipBootstrapResult) -> Unit,
+    private val onFatalError: () -> Unit,
+) : Closeable {
+    private val closed = AtomicBoolean(false)
+    private val accepted = AtomicReference<AppClipBootstrapResult?>(null)
+    private val socket = ServerSocket().apply {
+        reuseAddress = false
+        bind(InetSocketAddress(InetAddress.getByName("0.0.0.0"), 0), 4)
+    }
+    private val worker = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "localsend-app-clip-bootstrap").apply { isDaemon = true }
+    }
+
+    val port: Int = socket.localPort
+
+    init {
+        worker.execute(::acceptLoop)
+    }
+
+    fun result(): AppClipBootstrapResult? = accepted.get()
+
+    private fun acceptLoop() {
+        while (!closed.get()) {
+            try {
+                socket.accept().use(::handle)
+            } catch (_: IOException) {
+                if (!closed.get()) onFatalError()
+                return
+            } catch (_: RuntimeException) {
+                if (!closed.get()) onFatalError()
+                return
+            }
+        }
+    }
+
+    private fun handle(client: Socket) {
+        client.soTimeout = 5_000
+        if (accepted.get() != null) {
+            respond(client, 409, "Conflict")
+            return
+        }
+        try {
+            val body = readRequest(client)
+            val remote = client.inetAddress
+            val peerIp = remote.hostAddress ?: throw HttpFailure(400, "Bad Request")
+            if (remote !is Inet4Address || !AppClipProtocol.isCanonicalPrivateIpv4(peerIp)) {
+                throw HttpFailure(403, "Forbidden")
+            }
+            val bootstrap = try {
+                AppClipProtocol.authenticateBootstrap(body, sessionId, sessionKey, clock())
+            } catch (error: BootstrapException) {
+                when (error.failure) {
+                    BootstrapFailure.INVALID_SHAPE -> throw HttpFailure(400, "Bad Request")
+                    BootstrapFailure.AUTHENTICATION -> throw HttpFailure(403, "Forbidden")
+                }
+            }
+            val result = AppClipBootstrapResult(
+                sessionId = AppClipProtocol.encodeSessionId(sessionId),
+                peerIp = peerIp,
+                peerPort = bootstrap.listenerPort,
+                downloadToken = AppClipProtocol.deriveDownloadToken(sessionKey),
+            )
+            if (!accepted.compareAndSet(null, result)) {
+                throw HttpFailure(409, "Conflict")
+            }
+            respond(client, 202, "Accepted")
+            onAccepted(result)
+        } catch (failure: HttpFailure) {
+            respond(client, failure.status, failure.reason)
+        } catch (_: IOException) {
+            // A disconnected or malformed client has no effect on the active one-shot listener.
+        }
+    }
+
+    private fun readRequest(client: Socket): ByteArray {
+        val input = BufferedInputStream(client.getInputStream())
+        var headerBytes = 0
+        fun line(): String {
+            val bytes = ArrayList<Byte>()
+            while (true) {
+                val next = input.read()
+                if (next < 0) throw HttpFailure(400, "Bad Request")
+                headerBytes++
+                if (headerBytes > MAX_HEADER_BYTES) throw HttpFailure(400, "Bad Request")
+                if (next == '\r'.code) {
+                    if (input.read() != '\n'.code) throw HttpFailure(400, "Bad Request")
+                    headerBytes++
+                    return bytes.toByteArray().toString(StandardCharsets.US_ASCII)
+                }
+                if (next == '\n'.code || next > 0x7f) throw HttpFailure(400, "Bad Request")
+                bytes.add(next.toByte())
+            }
+        }
+
+        if (line() != "POST $APP_CLIP_BOOTSTRAP_PATH HTTP/1.1") throw HttpFailure(400, "Bad Request")
+        val headers = mutableMapOf<String, String>()
+        while (true) {
+            val value = line()
+            if (value.isEmpty()) break
+            val separator = value.indexOf(':')
+            if (separator <= 0) throw HttpFailure(400, "Bad Request")
+            val name = value.substring(0, separator).trim().lowercase()
+            if (headers.put(name, value.substring(separator + 1).trim()) != null) throw HttpFailure(400, "Bad Request")
+        }
+        if (headers["content-type"] != "application/octet-stream") throw HttpFailure(400, "Bad Request")
+        if (headers["transfer-encoding"] != null) throw HttpFailure(400, "Bad Request")
+        if (headers["content-length"]?.toIntOrNull() != APP_CLIP_BOOTSTRAP_SIZE) throw HttpFailure(400, "Bad Request")
+
+        val body = ByteArray(APP_CLIP_BOOTSTRAP_SIZE)
+        var offset = 0
+        while (offset < body.size) {
+            val count = input.read(body, offset, body.size - offset)
+            if (count < 0) throw HttpFailure(400, "Bad Request")
+            offset += count
+        }
+        return body
+    }
+
+    private fun respond(client: Socket, status: Int, reason: String) {
+        try {
+            client.getOutputStream().write(
+                "HTTP/1.1 $status $reason\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .toByteArray(StandardCharsets.US_ASCII),
+            )
+            client.getOutputStream().flush()
+        } catch (_: IOException) {
+            // The state transition remains valid even if the client closes before reading the response.
+        }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        try {
+            socket.close()
+        } catch (_: IOException) {
+            // Already closed.
+        }
+        worker.shutdownNow()
+    }
+
+    private class HttpFailure(val status: Int, val reason: String) : Exception()
+
+    companion object {
+        private const val MAX_HEADER_BYTES = 4_096
+    }
+}

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipHostBridge.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipHostBridge.kt
@@ -1,0 +1,41 @@
+package org.localsend.localsend_app.appclip
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+
+/** Keeps App Clip host lifecycle calls on LocalSend's existing native bridge and emits redacted state events. */
+object AppClipHostBridge {
+    private const val EVENT_CHANNEL = "org.localsend.localsend_app/localsend/app-clip-events"
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var eventSink: EventChannel.EventSink? = null
+    private val listener: (Map<String, Any?>) -> Unit = { state ->
+        mainHandler.post { eventSink?.success(state) }
+    }
+
+    fun configureEvents(messenger: BinaryMessenger) {
+        EventChannel(messenger, EVENT_CHANNEL).setStreamHandler(
+            object : EventChannel.StreamHandler {
+                override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+                    eventSink = events
+                    AppClipHostStateBus.add(listener)
+                }
+
+                override fun onCancel(arguments: Any?) {
+                    AppClipHostStateBus.remove(listener)
+                    eventSink = null
+                }
+            },
+        )
+    }
+
+    fun getPrerequisites(context: Context): Map<String, Any> = AppClipHostService.prerequisites(context)
+    fun getState(): Map<String, Any?> = AppClipHostStateBus.snapshot()
+    fun start(context: Context, deviceName: String): Map<String, Any?> = AppClipHostService.start(context, deviceName)
+    fun stop(context: Context) = AppClipHostService.stop(context)
+    fun getInvocationUrl(): String? = AppClipHostService.invocationUrl()
+    fun getBootstrap(): Map<String, Any>? = AppClipHostService.bootstrap()
+    fun acknowledgeBootstrap(context: Context, sessionId: String): Boolean = AppClipHostService.acknowledge(context, sessionId)
+}

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipHostService.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipHostService.kt
@@ -1,0 +1,443 @@
+package org.localsend.localsend_app.appclip
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import org.localsend.localsend_app.MainActivity
+import org.localsend.localsend_app.R
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.security.SecureRandom
+import java.util.Collections
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal data class AppClipHostState(
+    val state: String,
+    val message: String? = null,
+    val hceAvailable: Boolean = false,
+    val sessionId: String? = null,
+) {
+    fun toMap(): Map<String, Any?> = mapOf(
+        "state" to state,
+        "message" to message,
+        "hceAvailable" to hceAvailable,
+        "sessionId" to sessionId,
+    )
+}
+
+internal object AppClipHostStateBus {
+    @Volatile
+    private var state = AppClipHostState("idle")
+    private val listeners = CopyOnWriteArraySet<(Map<String, Any?>) -> Unit>()
+
+    fun snapshot(): Map<String, Any?> = state.toMap()
+
+    fun publish(value: AppClipHostState) {
+        state = value
+        val map = value.toMap()
+        listeners.forEach { it(map) }
+    }
+
+    fun add(listener: (Map<String, Any?>) -> Unit) {
+        listeners.add(listener)
+        listener(snapshot())
+    }
+
+    fun remove(listener: (Map<String, Any?>) -> Unit) {
+        listeners.remove(listener)
+    }
+}
+
+/** Owns the local-only hotspot and authenticated callback until Flutter completes or cancels the transfer. */
+class AppClipHostService : Service() {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "localsend-app-clip-host").apply { isDaemon = true }
+    }
+    private val closed = AtomicBoolean(false)
+    private var reservation: WifiManager.LocalOnlyHotspotReservation? = null
+    private var bootstrapServer: AppClipBootstrapServer? = null
+    private var sessionId: String? = null
+    private var beforeAddresses: Set<String> = emptySet()
+    private var hotspotSsid: String? = null
+    private var hotspotPassphrase: String? = null
+    private var readyTimeout: ScheduledFuture<*>? = null
+    private var approvalTimeout: ScheduledFuture<*>? = null
+    private lateinit var sessionIdBytes: ByteArray
+    private lateinit var sessionKey: ByteArray
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> startHosting(intent.getStringExtra(EXTRA_DEVICE_NAME) ?: "")
+            ACTION_ACKNOWLEDGE -> acknowledge(intent.getStringExtra(EXTRA_SESSION_ID) ?: "")
+            ACTION_STOP -> finish(AppClipHostState("idle"))
+            else -> finish(AppClipHostState("idle"))
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun startHosting(deviceName: String) {
+        if (bootstrapServer != null || reservation != null) return
+        createNotificationChannel()
+        startForegroundCompat(notification(R.string.app_clip_notification_starting))
+
+        val baseUrl = getString(R.string.app_clip_invocation_base_url).trim()
+        try {
+            AppClipProtocol.validateInvocationBaseUrl(baseUrl)
+        } catch (_: RuntimeException) {
+            fail("APP_CLIP_URL_NOT_CONFIGURED")
+            return
+        }
+        if (deviceName.toByteArray(Charsets.UTF_8).size !in 1..80) {
+            fail("INVALID_DEVICE_NAME")
+            return
+        }
+
+        sessionIdBytes = ByteArray(16).also(SecureRandom()::nextBytes)
+        sessionKey = ByteArray(32).also(SecureRandom()::nextBytes)
+        sessionId = AppClipProtocol.encodeSessionId(sessionIdBytes)
+        beforeAddresses = currentPrivateAddresses()
+        try {
+            bootstrapServer = AppClipBootstrapServer(
+                sessionId = sessionIdBytes,
+                sessionKey = sessionKey,
+                onAccepted = ::onBootstrapAccepted,
+                onFatalError = { mainHandler.post { fail("BOOTSTRAP_LISTENER_FAILED") } },
+            )
+        } catch (_: Exception) {
+            fail("BOOTSTRAP_LISTENER_FAILED")
+            return
+        }
+
+        AppClipHostStateBus.publish(AppClipHostState("startingHotspot", sessionId = sessionId))
+        val wifi = getSystemService(WifiManager::class.java)
+        try {
+            wifi.startLocalOnlyHotspot(
+                object : WifiManager.LocalOnlyHotspotCallback() {
+                    override fun onStarted(value: WifiManager.LocalOnlyHotspotReservation) {
+                        if (closed.get()) {
+                            value.close()
+                            return
+                        }
+                        reservation = value
+                        try {
+                            val credentials = readHotspotCredentials(value)
+                            hotspotSsid = credentials.first
+                            hotspotPassphrase = credentials.second
+                            qualifyHotspotAddresses(deviceName, 0)
+                        } catch (_: RuntimeException) {
+                            fail("HOTSPOT_CREDENTIALS_UNAVAILABLE")
+                        }
+                    }
+
+                    override fun onFailed(reason: Int) {
+                        fail("HOTSPOT_FAILED_$reason")
+                    }
+
+                    override fun onStopped() {
+                        if (!closed.get()) fail("HOTSPOT_STOPPED")
+                    }
+                },
+                mainHandler,
+            )
+        } catch (_: SecurityException) {
+            fail("HOTSPOT_PERMISSION_DENIED")
+        } catch (_: RuntimeException) {
+            fail("HOTSPOT_START_FAILED")
+        }
+    }
+
+    private fun qualifyHotspotAddresses(deviceName: String, attempt: Int) {
+        if (closed.get()) return
+        val candidates = (currentPrivateAddresses() - beforeAddresses).sorted().take(4)
+        if (candidates.isNotEmpty()) {
+            makeReady(deviceName, candidates)
+            return
+        }
+        if (attempt >= ADDRESS_ATTEMPTS) {
+            fail("HOTSPOT_ADDRESS_UNAVAILABLE")
+            return
+        }
+        scheduler.schedule(
+            { mainHandler.post { qualifyHotspotAddresses(deviceName, attempt + 1) } },
+            ADDRESS_RETRY_MILLIS,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    private fun makeReady(deviceName: String, hosts: List<String>) {
+        val server = bootstrapServer ?: return fail("BOOTSTRAP_LISTENER_FAILED")
+        val ssid = hotspotSsid ?: return fail("HOTSPOT_CREDENTIALS_UNAVAILABLE")
+        val passphrase = hotspotPassphrase ?: return fail("HOTSPOT_CREDENTIALS_UNAVAILABLE")
+        val url = try {
+            AppClipProtocol.buildInvocationUrl(
+                baseUrl = getString(R.string.app_clip_invocation_base_url).trim(),
+                sessionId = sessionIdBytes,
+                sessionKey = sessionKey,
+                ssid = ssid,
+                passphrase = passphrase,
+                hosts = hosts,
+                bootstrapPort = server.port,
+                deviceName = deviceName,
+            )
+        } catch (_: RuntimeException) {
+            fail("INVOCATION_URL_INVALID")
+            return
+        }
+        publishInvocationUrl(url)
+        val hce = AppClipHceRegistry.arm(this, url)
+        AppClipHostStateBus.publish(AppClipHostState("readyForTap", hceAvailable = hce, sessionId = sessionId))
+        updateNotification(R.string.app_clip_notification_ready)
+        readyTimeout = scheduler.schedule({ mainHandler.post { fail("SESSION_TIMED_OUT") } }, READY_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+    }
+
+    private fun onBootstrapAccepted(result: AppClipBootstrapResult) {
+        mainHandler.post {
+            if (closed.get()) return@post
+            readyTimeout?.cancel(false)
+            pendingBootstrap.set(result)
+            publishInvocationUrl(null)
+            AppClipHceRegistry.clear(this)
+            AppClipHostStateBus.publish(AppClipHostState("waitingForApproval", sessionId = result.sessionId))
+            updateNotification(R.string.app_clip_notification_connected)
+            approvalTimeout = scheduler.schedule({ mainHandler.post { fail("APPROVAL_TIMED_OUT") } }, APPROVAL_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+        }
+    }
+
+    private fun acknowledge(value: String) {
+        val result = pendingBootstrap.get()
+        if (result == null || result.sessionId != value) return
+        approvalTimeout?.cancel(false)
+        pendingBootstrap.compareAndSet(result, null)
+        bootstrapServer?.close()
+        bootstrapServer = null
+        AppClipHostStateBus.publish(AppClipHostState("receiving", sessionId = value))
+        updateNotification(R.string.app_clip_notification_receiving)
+    }
+
+    private fun fail(code: String) {
+        if (closed.get()) return
+        finish(AppClipHostState("failed", message = code, sessionId = sessionId))
+    }
+
+    private fun finish(finalState: AppClipHostState) {
+        if (!closed.compareAndSet(false, true)) return
+        readyTimeout?.cancel(false)
+        approvalTimeout?.cancel(false)
+        publishInvocationUrl(null)
+        pendingBootstrap.set(null)
+        AppClipHceRegistry.clear(this)
+        bootstrapServer?.close()
+        bootstrapServer = null
+        try {
+            reservation?.close()
+        } catch (_: RuntimeException) {
+            // Reservation teardown is idempotent from the host's perspective.
+        }
+        reservation = null
+        if (this::sessionIdBytes.isInitialized) sessionIdBytes.fill(0)
+        if (this::sessionKey.isInitialized) sessionKey.fill(0)
+        scheduler.shutdownNow()
+        AppClipHostStateBus.publish(finalState)
+        if (finalState.state == "failed") updateNotification(R.string.app_clip_notification_failed)
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        if (!closed.get()) finish(AppClipHostState("idle"))
+        super.onDestroy()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun readHotspotCredentials(value: WifiManager.LocalOnlyHotspotReservation): Pair<String, String> {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val config = value.softApConfiguration
+            val ssid = config.ssid ?: ""
+            val passphrase = config.passphrase ?: ""
+            if (ssid.isNotEmpty() && passphrase.isNotEmpty()) return ssid to passphrase
+        }
+        val config = value.wifiConfiguration ?: throw IllegalStateException("Hotspot credentials unavailable")
+        val ssid = config.SSID?.removeSurrounding("\"") ?: ""
+        val passphrase = config.preSharedKey?.removeSurrounding("\"") ?: ""
+        if (ssid.isEmpty() || passphrase.isEmpty()) throw IllegalStateException("Hotspot credentials unavailable")
+        return ssid to passphrase
+    }
+
+    private fun currentPrivateAddresses(): Set<String> = try {
+        Collections.list(NetworkInterface.getNetworkInterfaces())
+            .asSequence()
+            .filter { it.isUp && !it.isLoopback }
+            .flatMap { Collections.list(it.inetAddresses).asSequence() }
+            .filterIsInstance<Inet4Address>()
+            .mapNotNull { it.hostAddress }
+            .filter(AppClipProtocol::isCanonicalPrivateIpv4)
+            .toSet()
+    } catch (_: Exception) {
+        emptySet()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            getSystemService(NotificationManager::class.java).createNotificationChannel(
+                NotificationChannel(
+                    NOTIFICATION_CHANNEL,
+                    getString(R.string.app_clip_notification_channel),
+                    NotificationManager.IMPORTANCE_LOW,
+                ),
+            )
+        }
+    }
+
+    private fun notification(text: Int): Notification {
+        val launch = PendingIntent.getActivity(
+            this,
+            0,
+            MainActivity.createDefaultIntent(this),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val stop = PendingIntent.getService(
+            this,
+            1,
+            Intent(this, AppClipHostService::class.java).setAction(ACTION_STOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, NOTIFICATION_CHANNEL)
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+        }
+        return builder
+            .setContentTitle(getString(R.string.app_clip_notification_title))
+            .setContentText(getString(text))
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentIntent(launch)
+            .setOngoing(true)
+            .addAction(0, getString(R.string.app_clip_notification_stop), stop)
+            .build()
+    }
+
+    private fun startForegroundCompat(value: Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID, value, ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)
+        } else {
+            startForeground(NOTIFICATION_ID, value)
+        }
+    }
+
+    private fun updateNotification(text: Int) {
+        getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, notification(text))
+    }
+
+    companion object {
+        private const val ACTION_START = "org.localsend.appclip.START"
+        private const val ACTION_STOP = "org.localsend.appclip.STOP"
+        private const val ACTION_ACKNOWLEDGE = "org.localsend.appclip.ACKNOWLEDGE"
+        private const val EXTRA_DEVICE_NAME = "deviceName"
+        private const val EXTRA_SESSION_ID = "sessionId"
+        private const val NOTIFICATION_CHANNEL = "app_clip_receive"
+        private const val NOTIFICATION_ID = 4_721
+        private const val ADDRESS_ATTEMPTS = 50
+        private const val ADDRESS_RETRY_MILLIS = 100L
+        private const val READY_TIMEOUT_MINUTES = 10L
+        private const val APPROVAL_TIMEOUT_MINUTES = 2L
+        private val pendingBootstrap = java.util.concurrent.atomic.AtomicReference<AppClipBootstrapResult?>(null)
+        @Volatile private var activeInvocationUrl: String? = null
+
+        fun prerequisites(context: Context): Map<String, Any> {
+            val missing = mutableListOf<String>()
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) missing += "ANDROID_8_REQUIRED"
+            if (context.getSystemService(WifiManager::class.java) == null) missing += "WIFI_UNAVAILABLE"
+            val runtimePermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                Manifest.permission.NEARBY_WIFI_DEVICES
+            } else {
+                Manifest.permission.ACCESS_FINE_LOCATION
+            }
+            if (context.checkSelfPermission(runtimePermission) != PackageManager.PERMISSION_GRANTED) missing += runtimePermission
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+            ) {
+                missing += Manifest.permission.POST_NOTIFICATIONS
+            }
+            val baseUrl = context.getString(R.string.app_clip_invocation_base_url).trim()
+            try {
+                AppClipProtocol.validateInvocationBaseUrl(baseUrl)
+            } catch (_: RuntimeException) {
+                missing += "APP_CLIP_URL_NOT_CONFIGURED"
+            }
+            return mapOf(
+                "available" to missing.isEmpty(),
+                "missing" to missing,
+                "hceAvailable" to context.packageManager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION),
+            )
+        }
+
+        @Synchronized
+        fun start(context: Context, deviceName: String): Map<String, Any?> {
+            val current = AppClipHostStateBus.snapshot()
+            if (current["state"] !in setOf("idle", "failed", "unavailable")) return current
+            val check = prerequisites(context)
+            if (check["available"] != true) return check + ("state" to "unavailable")
+            pendingBootstrap.set(null)
+            activeInvocationUrl = null
+            AppClipHostStateBus.publish(AppClipHostState("startingHotspot"))
+            val intent = Intent(context, AppClipHostService::class.java)
+                .setAction(ACTION_START)
+                .putExtra(EXTRA_DEVICE_NAME, deviceName)
+            try {
+                context.startForegroundService(intent)
+            } catch (_: RuntimeException) {
+                AppClipHostStateBus.publish(AppClipHostState("failed", message = "FOREGROUND_SERVICE_START_FAILED"))
+            }
+            return AppClipHostStateBus.snapshot()
+        }
+
+        fun stop(context: Context) {
+            if (AppClipHostStateBus.snapshot()["state"] in setOf("idle", "failed", "unavailable")) {
+                pendingBootstrap.set(null)
+                activeInvocationUrl = null
+                AppClipHostStateBus.publish(AppClipHostState("idle"))
+                return
+            }
+            context.startService(Intent(context, AppClipHostService::class.java).setAction(ACTION_STOP))
+        }
+
+        fun acknowledge(context: Context, sessionId: String): Boolean {
+            val result = pendingBootstrap.get() ?: return false
+            if (result.sessionId != sessionId) return false
+            context.startService(
+                Intent(context, AppClipHostService::class.java)
+                    .setAction(ACTION_ACKNOWLEDGE)
+                    .putExtra(EXTRA_SESSION_ID, sessionId),
+            )
+            return true
+        }
+
+        fun bootstrap(): Map<String, Any>? = pendingBootstrap.get()?.toMap()
+        fun invocationUrl(): String? = activeInvocationUrl
+    }
+
+    private fun publishInvocationUrl(value: String?) {
+        activeInvocationUrl = value
+    }
+}

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipNdefService.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipNdefService.kt
@@ -1,0 +1,57 @@
+package org.localsend.localsend_app.appclip
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+
+internal object AppClipHceRegistry {
+    @Volatile
+    private var tag: Type4NdefTag? = null
+
+    fun arm(context: Context, invocationUrl: String): Boolean {
+        if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION)) return false
+        return try {
+            tag = Type4NdefTag(invocationUrl)
+            context.packageManager.setComponentEnabledSetting(
+                ComponentName(context, AppClipNdefService::class.java),
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                PackageManager.DONT_KILL_APP,
+            )
+            true
+        } catch (_: RuntimeException) {
+            tag = null
+            false
+        }
+    }
+
+    fun process(command: ByteArray): ByteArray = tag?.process(command) ?: byteArrayOf(0x69, 0x85.toByte())
+
+    fun reset() {
+        tag?.reset()
+    }
+
+    fun clear(context: Context) {
+        tag = null
+        try {
+            context.packageManager.setComponentEnabledSetting(
+                ComponentName(context, AppClipNdefService::class.java),
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                PackageManager.DONT_KILL_APP,
+            )
+        } catch (_: RuntimeException) {
+            // An absent HCE implementation is handled by the QR fallback.
+        }
+    }
+}
+
+/** Thin Android adapter around the pure Type-4 state machine. */
+class AppClipNdefService : HostApduService() {
+    override fun processCommandApdu(commandApdu: ByteArray?, extras: Bundle?): ByteArray =
+        if (commandApdu == null) byteArrayOf(0x67, 0x00) else AppClipHceRegistry.process(commandApdu)
+
+    override fun onDeactivated(reason: Int) {
+        AppClipHceRegistry.reset()
+    }
+}

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipProtocol.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/AppClipProtocol.kt
@@ -1,0 +1,148 @@
+package org.localsend.localsend_app.appclip
+
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+internal const val APP_CLIP_BOOTSTRAP_PATH = "/api/localsend/app-clip/v1/bootstrap"
+internal const val APP_CLIP_BOOTSTRAP_SIZE = 75
+private const val APP_CLIP_INVOCATION_MAX_BYTES = 1_024
+private const val APP_CLIP_BOOTSTRAP_TTL_MILLIS = 120_000L
+private const val DOWNLOAD_TOKEN_LABEL = "localsend-app-clip-download-v1"
+
+/** Builds and authenticates the short-lived values shared by the Android host and App Clip. */
+internal object AppClipProtocol {
+    fun validateInvocationBaseUrl(baseUrl: String) {
+        val base = URI(baseUrl)
+        require(base.scheme == "https" && base.host != null) { "App Clip URL must use HTTPS" }
+        require(base.userInfo == null && base.query == null && base.fragment == null) { "App Clip URL must not contain credentials, query, or fragment" }
+        require(base.port == -1 || base.port == 443) { "App Clip URL must use the default HTTPS port" }
+    }
+
+    fun buildInvocationUrl(
+        baseUrl: String,
+        sessionId: ByteArray,
+        sessionKey: ByteArray,
+        ssid: String,
+        passphrase: String,
+        hosts: List<String>,
+        bootstrapPort: Int,
+        deviceName: String,
+    ): String {
+        require(sessionId.size == 16) { "Session ID must be 16 bytes" }
+        require(sessionKey.size == 32) { "Session key must be 32 bytes" }
+        require(ssid.toByteArray(StandardCharsets.UTF_8).size in 1..32) { "Invalid hotspot SSID" }
+        require(passphrase.toByteArray(StandardCharsets.UTF_8).size in 8..63) { "Invalid hotspot passphrase" }
+        require(hosts.isNotEmpty() && hosts.size <= 4 && hosts.distinct().size == hosts.size) { "Invalid host list" }
+        require(hosts.all(::isCanonicalPrivateIpv4)) { "Host list must contain canonical private IPv4 addresses" }
+        require(bootstrapPort in 1..65_535) { "Invalid bootstrap port" }
+        require(deviceName.toByteArray(StandardCharsets.UTF_8).size in 1..80) { "Invalid device name" }
+
+        validateInvocationBaseUrl(baseUrl)
+        val base = URI(baseUrl)
+
+        val query = listOf(
+            "v" to "1",
+            "sid" to base64Url(sessionId),
+            "k" to base64Url(sessionKey),
+            "ssid" to ssid,
+            "pass" to passphrase,
+            "hosts" to hosts.joinToString(","),
+            "bp" to bootstrapPort.toString(),
+            "name" to deviceName,
+        ).joinToString("&") { (key, value) -> "$key=${encodeQueryValue(value)}" }
+        val invocation = "${base.toASCIIString()}?$query"
+        require(invocation.toByteArray(StandardCharsets.UTF_8).size <= APP_CLIP_INVOCATION_MAX_BYTES) { "App Clip URL is too long" }
+        return invocation
+    }
+
+    fun authenticateBootstrap(
+        body: ByteArray,
+        expectedSessionId: ByteArray,
+        sessionKey: ByteArray,
+        nowMillis: Long,
+    ): AuthenticatedBootstrap {
+        if (body.size != APP_CLIP_BOOTSTRAP_SIZE || expectedSessionId.size != 16 || sessionKey.size != 32) {
+            throw BootstrapException(BootstrapFailure.INVALID_SHAPE)
+        }
+        if (body[0] != 1.toByte()) {
+            throw BootstrapException(BootstrapFailure.INVALID_SHAPE)
+        }
+
+        val sessionId = body.copyOfRange(1, 17)
+        if (!MessageDigest.isEqual(sessionId, expectedSessionId)) {
+            throw BootstrapException(BootstrapFailure.AUTHENTICATION)
+        }
+        val signed = body.copyOfRange(0, 43)
+        val suppliedMac = body.copyOfRange(43, APP_CLIP_BOOTSTRAP_SIZE)
+        if (!MessageDigest.isEqual(hmacSha256(sessionKey, signed), suppliedMac)) {
+            throw BootstrapException(BootstrapFailure.AUTHENTICATION)
+        }
+
+        val values = ByteBuffer.wrap(body).order(ByteOrder.BIG_ENDIAN)
+        values.position(17)
+        val listenerPort = values.short.toInt() and 0xffff
+        val issuedAtMillis = values.long
+        val nonce = ByteArray(16).also(values::get)
+        if (listenerPort == 0 || issuedAtMillis < nowMillis - APP_CLIP_BOOTSTRAP_TTL_MILLIS || issuedAtMillis > nowMillis + APP_CLIP_BOOTSTRAP_TTL_MILLIS) {
+            throw BootstrapException(BootstrapFailure.INVALID_SHAPE)
+        }
+        return AuthenticatedBootstrap(listenerPort, issuedAtMillis, nonce)
+    }
+
+    fun deriveDownloadToken(sessionKey: ByteArray): String {
+        require(sessionKey.size == 32) { "Session key must be 32 bytes" }
+        return base64Url(hmacSha256(sessionKey, DOWNLOAD_TOKEN_LABEL.toByteArray(StandardCharsets.US_ASCII)))
+    }
+
+    fun encodeSessionId(sessionId: ByteArray): String {
+        require(sessionId.size == 16) { "Session ID must be 16 bytes" }
+        return base64Url(sessionId)
+    }
+
+    fun isCanonicalPrivateIpv4(value: String): Boolean {
+        val parts = value.split('.')
+        if (parts.size != 4) return false
+        val octets = IntArray(4)
+        for (index in parts.indices) {
+            val part = parts[index]
+            if (part.isEmpty() || (part.length > 1 && part.startsWith('0')) || part.any { !it.isDigit() }) return false
+            val octet = part.toIntOrNull() ?: return false
+            if (octet !in 0..255) return false
+            octets[index] = octet
+        }
+        return octets[0] == 10 ||
+            (octets[0] == 172 && octets[1] in 16..31) ||
+            (octets[0] == 192 && octets[1] == 168)
+    }
+
+    private fun hmacSha256(key: ByteArray, value: ByteArray): ByteArray =
+        Mac.getInstance("HmacSHA256").run {
+            init(SecretKeySpec(key, "HmacSHA256"))
+            doFinal(value)
+        }
+
+    private fun base64Url(value: ByteArray): String = Base64.getUrlEncoder().withoutPadding().encodeToString(value)
+
+    private fun encodeQueryValue(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8.name()).replace("+", "%20")
+}
+
+internal data class AuthenticatedBootstrap(
+    val listenerPort: Int,
+    val issuedAtMillis: Long,
+    val nonce: ByteArray,
+)
+
+internal enum class BootstrapFailure {
+    INVALID_SHAPE,
+    AUTHENTICATION,
+}
+
+internal class BootstrapException(val failure: BootstrapFailure) : IllegalArgumentException(failure.name)

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/Type4NdefTag.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/appclip/Type4NdefTag.kt
@@ -1,0 +1,108 @@
+package org.localsend.localsend_app.appclip
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+
+/** In-memory, read-only NFC Forum Type-4 tag containing exactly one HTTPS URI record. */
+internal class Type4NdefTag(invocationUrl: String) {
+    private enum class SelectedFile { CAPABILITY_CONTAINER, NDEF }
+
+    private var selectedFile: SelectedFile? = null
+    private val ndefFile = buildNdefFile(invocationUrl)
+
+    fun process(command: ByteArray): ByteArray {
+        if (command.size < 4) return WRONG_LENGTH.copyOf()
+        if (command[0] != 0.toByte()) return CLASS_NOT_SUPPORTED.copyOf()
+        return when (command[1].toInt() and 0xff) {
+            0xA4 -> select(command)
+            0xB0 -> readBinary(command)
+            else -> INSTRUCTION_NOT_SUPPORTED.copyOf()
+        }
+    }
+
+    fun reset() {
+        selectedFile = null
+    }
+
+    private fun select(command: ByteArray): ByteArray {
+        return when (command[2].toInt() and 0xff) {
+            0x04 -> {
+                if (!isSelectByName(command, NDEF_APPLICATION_AID)) return FILE_NOT_FOUND.copyOf()
+                selectedFile = null
+                OK.copyOf()
+            }
+            0x00 -> {
+                if (command.size != 7 || (command[3] != 0.toByte() && command[3] != 0x0c.toByte()) || command[4] != 2.toByte()) {
+                    return WRONG_LENGTH.copyOf()
+                }
+                selectedFile = when {
+                    command[5] == 0xe1.toByte() && command[6] == 0x03.toByte() -> SelectedFile.CAPABILITY_CONTAINER
+                    command[5] == 0xe1.toByte() && command[6] == 0x04.toByte() -> SelectedFile.NDEF
+                    else -> return FILE_NOT_FOUND.copyOf()
+                }
+                OK.copyOf()
+            }
+            else -> FILE_NOT_FOUND.copyOf()
+        }
+    }
+
+    private fun readBinary(command: ByteArray): ByteArray {
+        if (command.size != 5) return WRONG_LENGTH.copyOf()
+        val source = when (selectedFile) {
+            SelectedFile.CAPABILITY_CONTAINER -> CAPABILITY_CONTAINER
+            SelectedFile.NDEF -> ndefFile
+            null -> return CONDITIONS_NOT_SATISFIED.copyOf()
+        }
+        val offset = ((command[2].toInt() and 0xff) shl 8) or (command[3].toInt() and 0xff)
+        if (offset > source.size) return WRONG_OFFSET.copyOf()
+        val requested = (command[4].toInt() and 0xff).let { if (it == 0) 256 else it }
+        val length = minOf(requested, source.size - offset)
+        return source.copyOfRange(offset, offset + length) + OK
+    }
+
+    private fun isSelectByName(command: ByteArray, aid: ByteArray): Boolean {
+        if (command.size < 5 || command[3] != 0.toByte()) return false
+        val length = command[4].toInt() and 0xff
+        if (length != aid.size || (command.size != 5 + length && command.size != 6 + length)) return false
+        return command.copyOfRange(5, 5 + length).contentEquals(aid)
+    }
+
+    companion object {
+        private val NDEF_APPLICATION_AID = byteArrayOf(0xd2.toByte(), 0x76, 0x00, 0x00, 0x85.toByte(), 0x01, 0x01)
+        internal val CAPABILITY_CONTAINER = byteArrayOf(
+            0x00, 0x0f, 0x20, 0x00, 0x3b, 0x00, 0x34, 0x04, 0x06,
+            0xe1.toByte(), 0x04, 0x7f, 0xff.toByte(), 0x00, 0xff.toByte(),
+        )
+        private val OK = byteArrayOf(0x90.toByte(), 0x00)
+        private val FILE_NOT_FOUND = byteArrayOf(0x6a, 0x82.toByte())
+        private val WRONG_LENGTH = byteArrayOf(0x67, 0x00)
+        private val WRONG_OFFSET = byteArrayOf(0x6b, 0x00)
+        private val CONDITIONS_NOT_SATISFIED = byteArrayOf(0x69, 0x85.toByte())
+        private val CLASS_NOT_SUPPORTED = byteArrayOf(0x6e, 0x00)
+        private val INSTRUCTION_NOT_SUPPORTED = byteArrayOf(0x6d, 0x00)
+
+        internal fun buildNdefFile(invocationUrl: String): ByteArray {
+            require(invocationUrl.startsWith("https://")) { "NDEF invocation must use HTTPS" }
+            require(invocationUrl.toByteArray(StandardCharsets.UTF_8).size <= 1_024) { "NDEF invocation is too long" }
+            val url = invocationUrl.toByteArray(StandardCharsets.UTF_8)
+            val payload = byteArrayOf(0x00) + url
+            val message = ByteArrayOutputStream().apply {
+                val shortRecord = payload.size < 256
+                write(if (shortRecord) 0xd1 else 0xc1)
+                write(1)
+                if (shortRecord) {
+                    write(payload.size)
+                } else {
+                    write((payload.size ushr 24) and 0xff)
+                    write((payload.size ushr 16) and 0xff)
+                    write((payload.size ushr 8) and 0xff)
+                    write(payload.size and 0xff)
+                }
+                write('U'.code)
+                write(payload)
+            }.toByteArray()
+            require(message.size <= 0x7fff) { "NDEF message is too long" }
+            return byteArrayOf((message.size ushr 8).toByte(), message.size.toByte()) + message
+        }
+    }
+}

--- a/app/android/app/src/main/res/values/app_clip_strings.xml
+++ b/app/android/app/src/main/res/values/app_clip_strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_clip_hce_description">LocalSend App Clip link</string>
+    <string name="app_clip_notification_channel">Receive from iPhone</string>
+    <string name="app_clip_notification_title">LocalSend</string>
+    <string name="app_clip_notification_starting">Starting direct receive…</string>
+    <string name="app_clip_notification_ready">Ready for an iPhone</string>
+    <string name="app_clip_notification_connected">iPhone connected</string>
+    <string name="app_clip_notification_receiving">Receiving from iPhone…</string>
+    <string name="app_clip_notification_failed">Direct receive stopped</string>
+    <string name="app_clip_notification_stop">Stop</string>
+</resources>

--- a/app/android/app/src/main/res/xml/app_clip_apdu_service.xml
+++ b/app/android/app/src/main/res/xml/app_clip_apdu_service.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_clip_hce_description"
+    android:requireDeviceUnlock="true">
+    <aid-group
+        android:category="other"
+        android:description="@string/app_clip_hce_description">
+        <aid-filter android:name="D2760000850101" />
+    </aid-group>
+</host-apdu-service>

--- a/app/android/app/src/test/kotlin/org/localsend/localsend_app/appclip/AppClipProtocolTest.kt
+++ b/app/android/app/src/test/kotlin/org/localsend/localsend_app/appclip/AppClipProtocolTest.kt
@@ -1,0 +1,98 @@
+package org.localsend.localsend_app.appclip
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class AppClipProtocolTest {
+    private val sessionId = ByteArray(16) { it.toByte() }
+    private val sessionKey = ByteArray(32) { it.toByte() }
+
+    @Test
+    fun invocationRoundTripsContractValues() {
+        val url = AppClipProtocol.buildInvocationUrl(
+            baseUrl = "https://localsend.org/clip",
+            sessionId = sessionId,
+            sessionKey = sessionKey,
+            ssid = "Local Send & Café",
+            passphrase = "a/b+c d?",
+            hosts = listOf("192.168.43.1", "172.20.10.1"),
+            bootstrapPort = 45_321,
+            deviceName = "Pixel 9 Pro",
+        )
+
+        assertTrue(url.startsWith("https://localsend.org/clip?v=1&"))
+        assertTrue(url.contains("ssid=Local%20Send%20%26%20Caf%C3%A9"))
+        assertTrue(url.contains("pass=a%2Fb%2Bc%20d%3F"))
+        assertTrue(url.contains("hosts=192.168.43.1%2C172.20.10.1"))
+        assertFalse(url.contains("+"))
+    }
+
+    @Test
+    fun rejectsUnsafeInvocationInputs() {
+        assertThrows(IllegalArgumentException::class.java) {
+            AppClipProtocol.buildInvocationUrl("http://localsend.org/clip", sessionId, sessionKey, "ssid", "12345678", listOf("192.168.1.1"), 8080, "Pixel")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            AppClipProtocol.buildInvocationUrl("https://localsend.org/clip", sessionId, sessionKey, "ssid", "12345678", listOf("010.0.0.1"), 8080, "Pixel")
+        }
+        assertFalse(AppClipProtocol.isCanonicalPrivateIpv4("127.0.0.1"))
+        assertFalse(AppClipProtocol.isCanonicalPrivateIpv4("192.168.001.1"))
+        assertTrue(AppClipProtocol.isCanonicalPrivateIpv4("10.0.0.1"))
+    }
+
+    @Test
+    fun authenticatesIndependentBootstrapVector() {
+        val body = hex(
+            "01000102030405060708090a0b0c0d0e0f1f900000018bcfe56800" +
+                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf" +
+                "268b9b48e5b2564018c313fe6e41d2cb2ea801bd9b95fcc4a415f234b8d1db3c",
+        )
+
+        val result = AppClipProtocol.authenticateBootstrap(body, sessionId, sessionKey, 1_700_000_000_000L)
+
+        assertEquals(8080, result.listenerPort)
+        assertEquals(1_700_000_000_000L, result.issuedAtMillis)
+        assertArrayEquals(ByteArray(16) { (0xa0 + it).toByte() }, result.nonce)
+        assertEquals("pk1G7b8k5hTIZy-kMRJmCLYFNGHb0FdNQhB0DT_o7Pw", AppClipProtocol.deriveDownloadToken(sessionKey))
+    }
+
+    @Test
+    fun rejectsTamperingAndExpiredBodies() {
+        val valid = bootstrapBody(1_700_000_000_000L)
+        val tampered = valid.copyOf().also { it[20] = (it[20].toInt() xor 1).toByte() }
+        assertEquals(
+            BootstrapFailure.AUTHENTICATION,
+            assertThrows(BootstrapException::class.java) {
+                AppClipProtocol.authenticateBootstrap(tampered, sessionId, sessionKey, 1_700_000_000_000L)
+            }.failure,
+        )
+        assertEquals(
+            BootstrapFailure.INVALID_SHAPE,
+            assertThrows(BootstrapException::class.java) {
+                AppClipProtocol.authenticateBootstrap(valid, sessionId, sessionKey, 1_700_000_120_001L)
+            }.failure,
+        )
+    }
+
+    private fun bootstrapBody(issuedAt: Long): ByteArray {
+        val fixed = hex(
+            "01000102030405060708090a0b0c0d0e0f1f90" +
+                ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(issuedAt).array().toHex() +
+                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+        )
+        val mac = javax.crypto.Mac.getInstance("HmacSHA256").run {
+            init(javax.crypto.spec.SecretKeySpec(sessionKey, "HmacSHA256"))
+            doFinal(fixed)
+        }
+        return fixed + mac
+    }
+
+    private fun hex(value: String): ByteArray = value.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+}

--- a/app/android/app/src/test/kotlin/org/localsend/localsend_app/appclip/Type4NdefTagTest.kt
+++ b/app/android/app/src/test/kotlin/org/localsend/localsend_app/appclip/Type4NdefTagTest.kt
@@ -1,0 +1,47 @@
+package org.localsend.localsend_app.appclip
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+class Type4NdefTagTest {
+    @Test
+    fun emitsExactlyOneUriRecord() {
+        assertArrayEquals(
+            hex("001cd10118550068747470733a2f2f6c6f63616c73656e642e6f72672f63"),
+            Type4NdefTag.buildNdefFile("https://localsend.org/c"),
+        )
+    }
+
+    @Test
+    fun servesCapabilityContainerAndChunkedNdefReads() {
+        val tag = Type4NdefTag("https://localsend.org/c")
+        assertArrayEquals(hex("9000"), tag.process(hex("00a4040007d2760000850101")))
+        assertArrayEquals(hex("9000"), tag.process(hex("00a4000c02e103")))
+        assertArrayEquals(Type4NdefTag.CAPABILITY_CONTAINER + hex("9000"), tag.process(hex("00b000000f")))
+        assertArrayEquals(hex("9000"), tag.process(hex("00a4000c02e104")))
+        assertArrayEquals(hex("001cd101189000"), tag.process(hex("00b0000005")))
+        assertArrayEquals(hex("5500687474709000"), tag.process(hex("00b0000506")))
+    }
+
+    @Test
+    fun rejectsMutationUnknownFilesAndInvalidOffsets() {
+        val tag = Type4NdefTag("https://localsend.org/c")
+        assertArrayEquals(hex("6d00"), tag.process(hex("00d600000100")))
+        assertArrayEquals(hex("6a82"), tag.process(hex("00a4000c02e105")))
+        assertArrayEquals(hex("6985"), tag.process(hex("00b0000005")))
+        assertArrayEquals(hex("9000"), tag.process(hex("00a4000c02e104")))
+        assertArrayEquals(hex("6b00"), tag.process(hex("00b0ffff01")))
+    }
+
+    @Test
+    fun newTagCannotExposePreviousSession() {
+        val first = Type4NdefTag.buildNdefFile("https://localsend.org/c?sid=first")
+        val second = Type4NdefTag.buildNdefFile("https://localsend.org/c?sid=second")
+        assertFalse(first.contentEquals(second))
+        assertFalse(String(second, StandardCharsets.UTF_8).contains("first"))
+    }
+
+    private fun hex(value: String): ByteArray = value.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+}

--- a/app/assets/CHANGELOG.md
+++ b/app/assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- feat(android, ios): add an iOS App Clip sender flow with authenticated NFC/QR bootstrap, LocalSend v2 reverse downloads, installed-app fallback, and production `localsend.org/clip` deployment configuration
+
 ## 1.18.2 (2026-08-21)
 
 - feat: drag and drop files into the "Receive via link" browser page

--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -54,6 +54,24 @@
     },
     "link": "Receive via link"
   },
+  "appClip": {
+    "title": "Receive from iPhone",
+    "intro": "An iPhone can send photos and videos without installing LocalSend.",
+    "starting": "Preparing a private connection…",
+    "readyNfc": "Hold the unlocked iPhone near this phone, or scan the QR code.",
+    "readyQr": "Scan this QR code with the iPhone camera.",
+    "waiting": "Waiting for the iPhone…",
+    "preparing": "Reading the file offer…",
+    "offer": "{name} wants to send {count} file(s).",
+    "receiving": "Receiving files…",
+    "completed": "All files were received.",
+    "retryFailed": "Retry failed files",
+    "unavailable": "Receive from iPhone is unavailable on this device.",
+    "notConfigured": "The App Clip invocation URL has not been configured for this build.",
+    "permissionDenied": "Nearby Wi-Fi and notification permissions are required.",
+    "failed": "The direct connection stopped before the transfer completed.",
+    "nfcOptional": "NFC is unavailable; the QR code still works."
+  },
   "sendTab": {
     "title": "Send",
     "selection": {

--- a/app/ios/AppClip/AppClip.entitlements
+++ b/app/ios/AppClip/AppClip.entitlements
@@ -2,19 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
-	<key>com.apple.developer.networking.multicast</key>
-	<true/>
+	<key>com.apple.developer.parent-application-identifiers</key>
+	<array>
+		<string>$(AppIdentifierPrefix)org.localsend.localsendApp</string>
+	</array>
 	<key>com.apple.developer.networking.HotspotConfiguration</key>
+	<true/>
+	<key>com.apple.developer.on-demand-install-capable</key>
 	<true/>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>$(APP_CLIP_ASSOCIATED_DOMAIN)</string>
-	</array>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.org.localsend.localsendApp</string>
 	</array>
 </dict>
 </plist>

--- a/app/ios/AppClip/AppClipBootstrap.swift
+++ b/app/ios/AppClip/AppClipBootstrap.swift
@@ -1,0 +1,197 @@
+// AppClipBootstrap authenticates the App Clip's private callback to Android's "Receive from App Clip" host.
+// AppClipBootstrapClient performs the exact-origin, nonpersistent WebKit POST after joining the hotspot.
+// The byte fixture is unit-tested; WebKit-on-hotspot behavior remains signed-device-unverified.
+import CryptoKit
+import Foundation
+import Security
+import SwiftUI
+import WebKit
+
+enum AppClipBootstrap {
+    static let path = "/api/localsend/app-clip/v1/bootstrap"
+
+    static func body(
+        invocation: AppClipInvocation,
+        listenerPort: UInt16,
+        issuedAtMillis: UInt64,
+        nonce: Data
+    ) throws -> Data {
+        guard listenerPort != 0, nonce.count == 16 else { throw AppClipBootstrapError.invalidInput }
+        var signed = Data([1])
+        signed.append(invocation.sessionID)
+        signed.append(contentsOf: [UInt8(listenerPort >> 8), UInt8(listenerPort & 0xff)])
+        signed.append(contentsOf: (0..<8).reversed().map { UInt8((issuedAtMillis >> UInt64($0 * 8)) & 0xff) })
+        signed.append(nonce)
+        let mac = HMAC<SHA256>.authenticationCode(for: signed, using: SymmetricKey(data: invocation.sessionKey))
+        signed.append(contentsOf: mac)
+        return signed
+    }
+
+    static func body(invocation: AppClipInvocation, listenerPort: UInt16) throws -> Data {
+        var nonce = Data(count: 16)
+        let status = nonce.withUnsafeMutableBytes { bytes in
+            guard let address = bytes.baseAddress else { return errSecParam }
+            return SecRandomCopyBytes(kSecRandomDefault, 16, address)
+        }
+        guard status == errSecSuccess else { throw AppClipBootstrapError.randomFailure }
+        return try body(
+            invocation: invocation,
+            listenerPort: listenerPort,
+            issuedAtMillis: UInt64(Date().timeIntervalSince1970 * 1_000),
+            nonce: nonce
+        )
+    }
+
+    static func downloadToken(sessionKey: Data) -> String {
+        let label = Data("localsend-app-clip-download-v1".utf8)
+        return Data(HMAC<SHA256>.authenticationCode(for: label, using: SymmetricKey(data: sessionKey))).base64URL
+    }
+
+    static func candidates(invocation: AppClipInvocation) throws -> [URL] {
+        try invocation.hosts.map { host in
+            var components = URLComponents()
+            components.scheme = "http"
+            components.host = host
+            components.port = Int(invocation.bootstrapPort)
+            components.path = path
+            guard let url = components.url else { throw AppClipBootstrapError.invalidInput }
+            return url
+        }
+    }
+}
+
+enum AppClipBootstrapError: Error, LocalizedError {
+    case invalidInput
+    case randomFailure
+    case busy
+    case rejected
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidInput: return "The direct-connection invitation is invalid."
+        case .randomFailure: return "Secure session setup failed."
+        case .busy: return "A direct connection is already starting."
+        case .rejected: return "The Android phone did not accept the direct connection."
+        case .cancelled: return "The transfer was cancelled."
+        }
+    }
+}
+
+@MainActor
+final class AppClipBootstrapClient: NSObject, WKNavigationDelegate {
+    var onWebViewChanged: ((WKWebView?) -> Void)?
+
+    private var candidates: [URL] = []
+    private var body = Data()
+    private var index = 0
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var webView: WKWebView?
+
+    func perform(candidates: [URL], body: Data) async throws {
+        guard continuation == nil else { throw AppClipBootstrapError.busy }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.candidates = candidates
+                self.body = body
+                self.index = 0
+                self.continuation = continuation
+                self.loadCurrentCandidate()
+            }
+        } onCancel: {
+            Task { @MainActor in self.cancel() }
+        }
+    }
+
+    func cancel() {
+        finish(.failure(AppClipBootstrapError.cancelled))
+    }
+
+    private func loadCurrentCandidate() {
+        guard continuation != nil else { return }
+        guard index < candidates.count else {
+            finish(.failure(AppClipBootstrapError.rejected))
+            return
+        }
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let next = WKWebView(frame: .zero, configuration: configuration)
+        next.navigationDelegate = self
+        webView = next
+        onWebViewChanged?(next)
+
+        var request = URLRequest(url: candidates[index], cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 8)
+        request.httpMethod = "POST"
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        next.load(request)
+    }
+
+    private func advance(_ current: WKWebView) {
+        guard current === webView, continuation != nil else { return }
+        current.stopLoading()
+        current.navigationDelegate = nil
+        index += 1
+        loadCurrentCandidate()
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
+        webView = nil
+        onWebViewChanged?(nil)
+        candidates = []
+        body.removeAll(keepingCapacity: false)
+        switch result {
+        case .success: continuation.resume()
+        case .failure(let error): continuation.resume(throwing: error)
+        }
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard webView === self.webView,
+              action.targetFrame?.isMainFrame == true,
+              action.request.url == candidates[safe: index] else {
+            decisionHandler(.cancel)
+            if webView === self.webView { advance(webView) }
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor response: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        guard webView === self.webView,
+              response.isForMainFrame,
+              response.response.url == candidates[safe: index],
+              let http = response.response as? HTTPURLResponse,
+              http.statusCode == 202 else {
+            decisionHandler(.cancel)
+            if webView === self.webView { advance(webView) }
+            return
+        }
+        decisionHandler(.cancel)
+        finish(.success(()))
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) { advance(webView) }
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) { advance(webView) }
+    func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge,
+                 completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        completionHandler(.cancelAuthenticationChallenge, nil)
+        advance(webView)
+    }
+}
+
+struct AppClipBootstrapWebView: UIViewRepresentable {
+    let webView: WKWebView
+    func makeUIView(context: Context) -> WKWebView { webView }
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+}
+
+private extension Collection {
+    subscript(safe index: Index) -> Element? { indices.contains(index) ? self[index] : nil }
+}

--- a/app/ios/AppClip/AppClipHotspot.swift
+++ b/app/ios/AppClip/AppClipHotspot.swift
@@ -1,0 +1,29 @@
+// AppClipHotspot owns the ephemeral Wi-Fi join used by the "Send with LocalSend" App Clip flow.
+// The transfer coordinator joins once and always removes the configuration during teardown.
+// The API contract is source-reviewed; the approval sheet and physical join remain device-unverified.
+import Foundation
+import NetworkExtension
+
+enum AppClipHotspot {
+    static func join(ssid: String, passphrase: String) async throws {
+        let configuration = NEHotspotConfiguration(ssid: ssid, passphrase: passphrase, isWEP: false)
+        configuration.joinOnce = true
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            NEHotspotConfigurationManager.shared.apply(configuration) { error in
+                if let error = error as NSError?,
+                   error.domain == NEHotspotConfigurationErrorDomain,
+                   error.code == NEHotspotConfigurationError.alreadyAssociated.rawValue {
+                    continuation.resume()
+                } else if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    static func remove(ssid: String) {
+        NEHotspotConfigurationManager.shared.removeConfiguration(forSSID: ssid)
+    }
+}

--- a/app/ios/AppClip/AppClipInvocation.swift
+++ b/app/ios/AppClip/AppClipInvocation.swift
@@ -1,0 +1,120 @@
+// AppClipInvocation parses the short-lived "Send with LocalSend" App Clip URL emitted by Android.
+// It rejects unconfigured origins and malformed capabilities before hotspot or network work begins.
+// Protocol parsing is covered by AppClipProtocolTests; signed invocation remains device-unverified.
+import Foundation
+
+/// Strict, nonpersistent parser for the short-lived Android invocation capability.
+struct AppClipInvocation: Equatable, Hashable {
+    let sessionID: Data
+    let sessionKey: Data
+    let ssid: String
+    let passphrase: String
+    let hosts: [String]
+    let bootstrapPort: UInt16
+    let receiverName: String
+
+    static func configured(url: URL, bundle: Bundle = .main) throws -> AppClipInvocation {
+        guard let value = bundle.object(forInfoDictionaryKey: "AppClipInvocationBaseURL") as? String,
+              !value.isEmpty, let expected = URL(string: value),
+              expected.scheme == "https", expected.host != nil,
+              expected.user == nil, expected.password == nil,
+              expected.query == nil, expected.fragment == nil,
+              url.scheme == expected.scheme, url.host == expected.host,
+              url.port == expected.port, url.path == expected.path else {
+            throw AppClipInvocationError.configurationMismatch
+        }
+        return try AppClipInvocation(url: url)
+    }
+
+    init(url: URL) throws {
+        guard url.absoluteString.utf8.count <= 1_024,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            throw AppClipInvocationError.invalidURL
+        }
+
+        var values: [String: String] = [:]
+        for item in queryItems {
+            guard values[item.name] == nil, let value = item.value else {
+                throw AppClipInvocationError.duplicateOrMissingField
+            }
+            values[item.name] = value
+        }
+        let expectedFields: Set<String> = ["v", "sid", "k", "ssid", "pass", "hosts", "bp", "name"]
+        guard Set(values.keys) == expectedFields,
+              values["v"] == "1",
+              let sessionID = values["sid"].flatMap(Data.init(base64URL:)), sessionID.count == 16,
+              let sessionKey = values["k"].flatMap(Data.init(base64URL:)), sessionKey.count == 32,
+              let ssid = values["ssid"], ssid.utf8.count >= 1, ssid.utf8.count <= 32,
+              let passphrase = values["pass"], passphrase.utf8.count >= 8, passphrase.utf8.count <= 63,
+              let rawHosts = values["hosts"],
+              let rawPort = values["bp"], let port = UInt16(rawPort), port != 0,
+              let receiverName = values["name"], receiverName.utf8.count >= 1, receiverName.utf8.count <= 80,
+              !receiverName.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains) else {
+            throw AppClipInvocationError.invalidField
+        }
+        let hosts = rawHosts.split(separator: ",", omittingEmptySubsequences: false).map(String.init)
+        guard hosts.count >= 1, hosts.count <= 4,
+              Set(hosts).count == hosts.count,
+              hosts.allSatisfy(Self.isCanonicalPrivateIPv4) else {
+            throw AppClipInvocationError.invalidHost
+        }
+
+        self.sessionID = sessionID
+        self.sessionKey = sessionKey
+        self.ssid = ssid
+        self.passphrase = passphrase
+        self.hosts = hosts
+        self.bootstrapPort = port
+        self.receiverName = receiverName
+    }
+
+    static func isCanonicalPrivateIPv4(_ value: String) -> Bool {
+        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        var octets: [Int] = []
+        for part in parts {
+            guard !part.isEmpty, !(part.count > 1 && part.first == "0"),
+                  part.utf8.allSatisfy({ (48...57).contains($0) }), let octet = Int(part), (0...255).contains(octet) else {
+                return false
+            }
+            octets.append(octet)
+        }
+        return octets[0] == 10 ||
+            (octets[0] == 172 && (16...31).contains(octets[1])) ||
+            (octets[0] == 192 && octets[1] == 168)
+    }
+}
+
+enum AppClipInvocationError: Error {
+    case configurationMismatch
+    case invalidURL
+    case duplicateOrMissingField
+    case invalidField
+    case invalidHost
+}
+
+extension Data {
+    init?(base64URL value: String) {
+        guard !value.contains("="), value.utf8.allSatisfy({
+            (65...90).contains($0) || (97...122).contains($0) || (48...57).contains($0) || $0 == 45 || $0 == 95
+        }) else {
+            return nil
+        }
+        var padded = value.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        padded += String(repeating: "=", count: (4 - padded.count % 4) % 4)
+        guard let decoded = Data(base64Encoded: padded) else { return nil }
+        self = decoded
+    }
+
+    var base64URL: String {
+        base64EncodedString().replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    func constantTimeEquals(_ other: Data) -> Bool {
+        guard count == other.count else { return false }
+        return zip(self, other).reduce(UInt8(0)) { $0 | ($1.0 ^ $1.1) } == 0
+    }
+}

--- a/app/ios/AppClip/AppClipReverseDownloadServer.swift
+++ b/app/ios/AppClip/AppClipReverseDownloadServer.swift
@@ -12,6 +12,7 @@ struct AppClipStagedFile {
     let url: URL
 }
 
+@available(iOS 16.0, *)
 final class AppClipReverseDownloadServer {
     private let files: [String: AppClipStagedFile]
     private let alias: String

--- a/app/ios/AppClip/AppClipReverseDownloadServer.swift
+++ b/app/ios/AppClip/AppClipReverseDownloadServer.swift
@@ -127,19 +127,27 @@ final class AppClipReverseDownloadServer {
         connection.start(queue: queue)
         Task {
             defer {
-                self.lock.lock()
-                self.connections.removeValue(forKey: ObjectIdentifier(connection))
-                self.lock.unlock()
+                self.unregister(connection)
                 connection.cancel()
             }
             do { try await handle(connection) }
             catch {
-                self.lock.lock()
-                let canReply = !self.stopped
-                self.lock.unlock()
-                if canReply { try? await sendResponse(connection, status: 400, reason: "Bad Request", body: Data(), contentType: nil) }
+                if self.canReplyToFailure() { try? await sendResponse(connection, status: 400, reason: "Bad Request", body: Data(), contentType: nil) }
             }
         }
+    }
+
+    private func unregister(_ connection: NWConnection) {
+        lock.lock()
+        connections.removeValue(forKey: ObjectIdentifier(connection))
+        lock.unlock()
+    }
+
+    private func canReplyToFailure() -> Bool {
+        lock.lock()
+        let result = !stopped
+        lock.unlock()
+        return result
     }
 
     private func handle(_ connection: NWConnection) async throws {
@@ -292,7 +300,7 @@ final class AppClipReverseDownloadServer {
     }
 
     private func send(_ connection: NWConnection, _ data: Data, complete: Bool) async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             connection.send(content: data, contentContext: .defaultMessage, isComplete: complete, completion: .contentProcessed { error in
                 if let error { continuation.resume(throwing: error) } else { continuation.resume() }
             })

--- a/app/ios/AppClip/AppClipReverseDownloadServer.swift
+++ b/app/ios/AppClip/AppClipReverseDownloadServer.swift
@@ -1,0 +1,397 @@
+// AppClipReverseDownloadServer is the bounded, Wi-Fi-only LocalSend v2 sender used by the App Clip.
+// Android prepares and downloads staged media with a derived PIN after authenticated bootstrap.
+// Protocol structure is statically reviewed; Xcode compilation and physical transfer remain unverified.
+import Foundation
+import Network
+
+struct AppClipStagedFile {
+    let id: String
+    let name: String
+    let size: UInt64
+    let fileType: String
+    let url: URL
+}
+
+final class AppClipReverseDownloadServer {
+    private let files: [String: AppClipStagedFile]
+    private let alias: String
+    private let pin: Data
+    private let sessionID = UUID().uuidString
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "org.localsend.appclip.http")
+    private let lock = NSLock()
+    private var acceptedIP: String?
+    private var inFlight: Set<String> = []
+    private var progress: [String: UInt64] = [:]
+    private var completed: Set<String> = []
+    private var connections: [ObjectIdentifier: NWConnection] = [:]
+    private var requestCount = 0
+    private var lastProgressNotification: UInt64 = 0
+    private var stopped = false
+    private var startContinuation: CheckedContinuation<UInt16, Error>?
+    private var completionContinuation: CheckedContinuation<Void, Error>?
+    private var completionResult: Result<Void, Error>?
+    var onProgress: ((UInt64, UInt64) -> Void)?
+
+    init(files: [AppClipStagedFile], alias: String, pin: String) throws {
+        guard !files.isEmpty, files.count <= 100,
+              Set(files.map(\.id)).count == files.count else {
+            throw AppClipServerError.invalidFiles
+        }
+        self.files = Dictionary(uniqueKeysWithValues: files.map { ($0.id, $0) })
+        self.alias = alias
+        self.pin = Data(pin.utf8)
+        let parameters = NWParameters.tcp
+        parameters.requiredInterfaceType = .wifi
+        self.listener = try NWListener(using: parameters, on: .any)
+    }
+
+    var totalBytes: UInt64 { files.values.reduce(0) { $0 + $1.size } }
+
+    func start() async throws -> UInt16 {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                guard !stopped else {
+                    lock.unlock()
+                    continuation.resume(throwing: AppClipServerError.cancelled)
+                    return
+                }
+                startContinuation = continuation
+                lock.unlock()
+                listener.stateUpdateHandler = { [weak self] state in self?.handleListenerState(state) }
+                listener.newConnectionHandler = { [weak self] connection in self?.accept(connection) }
+                listener.start(queue: queue)
+            }
+        } onCancel: { [weak self] in self?.stop(error: AppClipServerError.cancelled) }
+    }
+
+    func waitUntilComplete() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                if let result = completionResult {
+                    lock.unlock()
+                    continuation.resume(with: result)
+                } else {
+                    completionContinuation = continuation
+                    lock.unlock()
+                }
+            }
+        } onCancel: { [weak self] in self?.stop(error: AppClipServerError.cancelled) }
+    }
+
+    func stop(error: Error = AppClipServerError.cancelled) {
+        let start: CheckedContinuation<UInt16, Error>?
+        let completion: CheckedContinuation<Void, Error>?
+        let activeConnections: [NWConnection]
+        lock.lock()
+        guard !stopped else { lock.unlock(); return }
+        stopped = true
+        completionResult = .failure(error)
+        start = startContinuation
+        completion = completionContinuation
+        startContinuation = nil
+        completionContinuation = nil
+        activeConnections = Array(connections.values)
+        connections.removeAll()
+        lock.unlock()
+        listener.cancel()
+        activeConnections.forEach { $0.cancel() }
+        start?.resume(throwing: error)
+        completion?.resume(throwing: error)
+    }
+
+    private func handleListenerState(_ state: NWListener.State) {
+        switch state {
+        case .ready:
+            guard let rawPort = listener.port?.rawValue else { stop(error: AppClipServerError.listenerFailed); return }
+            lock.lock()
+            let continuation = startContinuation
+            startContinuation = nil
+            lock.unlock()
+            continuation?.resume(returning: rawPort)
+        case .failed(let error): stop(error: error)
+        case .cancelled: break
+        default: break
+        }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        lock.lock()
+        requestCount += 1
+        let allowed = !stopped && requestCount <= 205
+        if allowed { connections[ObjectIdentifier(connection)] = connection }
+        lock.unlock()
+        guard allowed else { connection.cancel(); return }
+        connection.start(queue: queue)
+        Task {
+            defer {
+                self.lock.lock()
+                self.connections.removeValue(forKey: ObjectIdentifier(connection))
+                self.lock.unlock()
+                connection.cancel()
+            }
+            do { try await handle(connection) }
+            catch {
+                self.lock.lock()
+                let canReply = !self.stopped
+                self.lock.unlock()
+                if canReply { try? await sendResponse(connection, status: 400, reason: "Bad Request", body: Data(), contentType: nil) }
+            }
+        }
+    }
+
+    private func handle(_ connection: NWConnection) async throws {
+        let request = try await readRequest(connection)
+        guard let remoteIP = Self.remoteIPv4(connection.endpoint) else { throw AppClipServerError.forbidden }
+        let components = try Self.parseTarget(request.target)
+        let path = components.path
+        let query = try Self.uniqueQuery(components)
+
+        if request.method == "POST" && path == "/api/localsend/v2/prepare-download" {
+            guard request.bodyBytes == 0 else { throw AppClipServerError.invalidRequest }
+            let supplied = Data((query["pin"] ?? "").utf8)
+            guard supplied.constantTimeEquals(pin) else { return try await sendResponse(connection, status: 403, reason: "Forbidden", body: Data(), contentType: nil) }
+            guard authorize(remoteIP: remoteIP, requestedSession: query["sessionId"]) else {
+                return try await sendResponse(connection, status: 403, reason: "Forbidden", body: Data(), contentType: nil)
+            }
+            let body = try manifestJSON()
+            return try await sendResponse(connection, status: 200, reason: "OK", body: body, contentType: "application/json")
+        }
+
+        if request.method == "GET" && path == "/api/localsend/v2/download" {
+            guard request.bodyBytes == 0,
+                  validate(remoteIP: remoteIP, session: query["sessionId"]),
+                  let fileID = query["fileId"], let file = beginFile(fileID) else {
+                return try await sendResponse(connection, status: 403, reason: "Forbidden", body: Data(), contentType: nil)
+            }
+            do {
+                try await sendFile(connection, file: file)
+                finishFile(file)
+            } catch {
+                abandonFile(file.id)
+                connection.cancel()
+            }
+            return
+        }
+
+        if request.method == "POST" && path == "/api/localsend/v2/cancel" {
+            guard validate(remoteIP: remoteIP, session: query["sessionId"]) else {
+                return try await sendResponse(connection, status: 403, reason: "Forbidden", body: Data(), contentType: nil)
+            }
+            try await sendResponse(connection, status: 204, reason: "No Content", body: Data(), contentType: nil)
+            stop(error: AppClipServerError.cancelled)
+            return
+        }
+
+        try await sendResponse(connection, status: 404, reason: "Not Found", body: Data(), contentType: nil)
+    }
+
+    private func authorize(remoteIP: String, requestedSession: String?) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if let acceptedIP { return acceptedIP == remoteIP && (requestedSession == nil || requestedSession == sessionID) }
+        guard requestedSession == nil else { return false }
+        acceptedIP = remoteIP
+        return true
+    }
+
+    private func validate(remoteIP: String, session: String?) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return !stopped && acceptedIP == remoteIP && session == sessionID
+    }
+
+    private func beginFile(_ id: String) -> AppClipStagedFile? {
+        lock.lock(); defer { lock.unlock() }
+        guard !stopped, !inFlight.contains(id), !completed.contains(id), let file = files[id] else { return nil }
+        inFlight.insert(id)
+        return file
+    }
+
+    private func abandonFile(_ id: String) {
+        lock.lock(); inFlight.remove(id); lock.unlock()
+    }
+
+    private func finishFile(_ file: AppClipStagedFile) {
+        var continuation: CheckedContinuation<Void, Error>?
+        lock.lock()
+        inFlight.remove(file.id)
+        completed.insert(file.id)
+        progress[file.id] = file.size
+        if completed.count == files.count && completionResult == nil {
+            completionResult = .success(())
+            continuation = completionContinuation
+            completionContinuation = nil
+        }
+        lock.unlock()
+        emitProgress(fileID: file.id, bytes: file.size)
+        continuation?.resume()
+    }
+
+    private func emitProgress(fileID: String, bytes: UInt64) {
+        let callback: ((UInt64, UInt64) -> Void)?
+        let shouldNotify: Bool
+        lock.lock()
+        progress[fileID] = min(bytes, files[fileID]?.size ?? 0)
+        let sent = progress.values.reduce(0, +)
+        let total = totalBytes
+        shouldNotify = sent == total || sent >= lastProgressNotification + 1_048_576
+        if shouldNotify { lastProgressNotification = sent }
+        callback = onProgress
+        lock.unlock()
+        if shouldNotify { callback?(sent, total) }
+    }
+
+    private func manifestJSON() throws -> Data {
+        let fileMap = Dictionary(uniqueKeysWithValues: files.values.map { file in
+            (file.id, [
+                "id": file.id,
+                "fileName": file.name,
+                "size": NSNumber(value: file.size),
+                "fileType": file.fileType,
+            ] as [String: Any])
+        })
+        let response: [String: Any] = [
+            "info": [
+                "alias": alias,
+                "version": "2.2",
+                "deviceModel": "iPhone",
+                "deviceType": "mobile",
+                "fingerprint": "appclip-\(sessionID)",
+                "download": true,
+            ],
+            "sessionId": sessionID,
+            "files": fileMap,
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [.sortedKeys])
+    }
+
+    private func sendFile(_ connection: NWConnection, file: AppClipStagedFile) async throws {
+        let header = "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: \(file.size)\r\nConnection: close\r\n\r\n"
+        try await send(connection, Data(header.utf8), complete: file.size == 0)
+        guard file.size > 0 else { return }
+        let handle = try FileHandle(forReadingFrom: file.url)
+        defer { try? handle.close() }
+        var sent: UInt64 = 0
+        while let chunk = try handle.read(upToCount: 64 * 1_024), !chunk.isEmpty {
+            sent += UInt64(chunk.count)
+            guard sent <= file.size else { throw AppClipServerError.fileChanged }
+            try await send(connection, chunk, complete: sent == file.size)
+            emitProgress(fileID: file.id, bytes: sent)
+        }
+        guard sent == file.size else { throw AppClipServerError.fileChanged }
+    }
+
+    private func sendResponse(_ connection: NWConnection, status: Int, reason: String, body: Data, contentType: String?) async throws {
+        var header = "HTTP/1.1 \(status) \(reason)\r\nContent-Length: \(body.count)\r\nConnection: close\r\n"
+        if let contentType { header += "Content-Type: \(contentType)\r\n" }
+        header += "\r\n"
+        var data = Data(header.utf8)
+        data.append(body)
+        try await send(connection, data, complete: true)
+    }
+
+    private func send(_ connection: NWConnection, _ data: Data, complete: Bool) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            connection.send(content: data, contentContext: .defaultMessage, isComplete: complete, completion: .contentProcessed { error in
+                if let error { continuation.resume(throwing: error) } else { continuation.resume() }
+            })
+        }
+    }
+
+    private func readRequest(_ connection: NWConnection) async throws -> HTTPRequest {
+        var received = Data()
+        let marker = Data("\r\n\r\n".utf8)
+        while received.range(of: marker) == nil {
+            let chunk = try await receive(connection)
+            received.append(chunk)
+            guard received.count <= 8_192 else { throw AppClipServerError.invalidRequest }
+        }
+        guard let boundary = received.range(of: marker), boundary.upperBound == received.count,
+              let text = String(data: received[..<boundary.lowerBound], encoding: .ascii) else {
+            throw AppClipServerError.invalidRequest
+        }
+        let lines = text.components(separatedBy: "\r\n")
+        guard let first = lines.first else { throw AppClipServerError.invalidRequest }
+        let requestParts = first.split(separator: " ")
+        guard requestParts.count == 3, requestParts[2] == "HTTP/1.1" else { throw AppClipServerError.invalidRequest }
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let separator = line.firstIndex(of: ":") else { throw AppClipServerError.invalidRequest }
+            let name = String(line[..<separator]).trimmingCharacters(in: .whitespaces).lowercased()
+            guard !name.isEmpty, headers[name] == nil else { throw AppClipServerError.invalidRequest }
+            headers[name] = String(line[line.index(after: separator)...]).trimmingCharacters(in: .whitespaces)
+        }
+        let bodyBytes: Int
+        if let value = headers["content-length"] {
+            guard let parsed = Int(value) else { throw AppClipServerError.invalidRequest }
+            bodyBytes = parsed
+        } else {
+            bodyBytes = 0
+        }
+        guard headers["transfer-encoding"] == nil, bodyBytes == 0 else {
+            throw AppClipServerError.invalidRequest
+        }
+        return HTTPRequest(method: String(requestParts[0]), target: String(requestParts[1]), bodyBytes: bodyBytes)
+    }
+
+    private func receive(_ connection: NWConnection) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 4_096) { data, _, complete, error in
+                if let error { continuation.resume(throwing: error) }
+                else if let data, !data.isEmpty { continuation.resume(returning: data) }
+                else if complete { continuation.resume(throwing: AppClipServerError.invalidRequest) }
+                else { continuation.resume(throwing: AppClipServerError.invalidRequest) }
+            }
+        }
+    }
+
+    private static func parseTarget(_ target: String) throws -> URLComponents {
+        guard target.utf8.count <= 2_048, target.first == "/",
+              let components = URLComponents(string: "http://localhost\(target)"),
+              components.fragment == nil else {
+            throw AppClipServerError.invalidRequest
+        }
+        return components
+    }
+
+    private static func uniqueQuery(_ components: URLComponents) throws -> [String: String] {
+        var values: [String: String] = [:]
+        for item in components.queryItems ?? [] {
+            guard values[item.name] == nil, let value = item.value else { throw AppClipServerError.invalidRequest }
+            values[item.name] = value
+        }
+        return values
+    }
+
+    private static func remoteIPv4(_ endpoint: NWEndpoint) -> String? {
+        guard case .hostPort(let host, _) = endpoint else { return nil }
+        let value = String(describing: host)
+        return AppClipInvocation.isCanonicalPrivateIPv4(value) ? value : nil
+    }
+}
+
+private struct HTTPRequest {
+    let method: String
+    let target: String
+    let bodyBytes: Int
+}
+
+enum AppClipServerError: Error, LocalizedError {
+    case invalidFiles
+    case listenerFailed
+    case invalidRequest
+    case forbidden
+    case fileChanged
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFiles: return "The selected files cannot be shared."
+        case .listenerFailed: return "The iPhone could not open a direct connection."
+        case .invalidRequest, .forbidden: return "The receiver sent an invalid request."
+        case .fileChanged: return "A selected file changed during transfer."
+        case .cancelled: return "The transfer was cancelled."
+        }
+    }
+}

--- a/app/ios/AppClip/AppClipRootView.swift
+++ b/app/ios/AppClip/AppClipRootView.swift
@@ -114,6 +114,7 @@ struct AppClipFullAppSheet: View {
     }
 }
 
+@available(iOS 16.0, *)
 struct AppClipMessageView: View {
     let icon: String
     let title: String

--- a/app/ios/AppClip/AppClipRootView.swift
+++ b/app/ios/AppClip/AppClipRootView.swift
@@ -1,0 +1,129 @@
+// AppClipRootView is the shared native "Send with LocalSend" media-transfer screen.
+// The App Clip displays it directly; the installed Runner presents it for the same invocation URL.
+// UI and physical transfer remain device-unverified; AppClipProtocolTests cover the wire capability.
+import PhotosUI
+import SwiftUI
+
+@available(iOS 16.0, *)
+struct AppClipRootView: View {
+    let invocation: AppClipInvocation
+    let onDismiss: (() -> Void)?
+    @StateObject private var coordinator: AppClipTransferCoordinator
+    @State private var picks: [PhotosPickerItem] = []
+    @Environment(\.scenePhase) private var scenePhase
+
+    init(invocation: AppClipInvocation, onDismiss: (() -> Void)? = nil) {
+        self.invocation = invocation
+        self.onDismiss = onDismiss
+        _coordinator = StateObject(wrappedValue: AppClipTransferCoordinator(invocation: invocation))
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                // blueSendHeroIcon — large blue filled upload circle at the top of the transfer screen.
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 68))
+                    .foregroundStyle(.blue)
+                Text("Send to \(invocation.receiverName)")
+                    .font(.title2.bold())
+                    .multilineTextAlignment(.center)
+                content
+                if let webView = coordinator.bootstrapWebView {
+                    AppClipBootstrapWebView(webView: webView)
+                        .frame(width: 1, height: 1)
+                        .opacity(0.01)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(24)
+            .navigationTitle("LocalSend")
+            .toolbar {
+                if let onDismiss {
+                    // navigationCloseButton — closes the installed-app sheet and cancels active transfer work.
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close") {
+                            coordinator.cancel()
+                            onDismiss()
+                        }
+                    }
+                }
+            }
+        }
+        .onChange(of: scenePhase) { phase in
+            if phase == .background && coordinator.isActive { coordinator.cancel() }
+        }
+        .onDisappear {
+            if coordinator.isActive { coordinator.cancel() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch coordinator.phase {
+        case .choosing:
+            Text(picks.isEmpty ? "Choose photos or videos to send." : "\(picks.count) item(s) selected")
+                .foregroundStyle(.secondary)
+            // borderedMediaPickerButton — centered system picker for photos and videos.
+            PhotosPicker(selection: $picks, maxSelectionCount: 100, matching: .any(of: [.images, .videos])) {
+                Label("Choose photos and videos", systemImage: "photo.on.rectangle")
+            }
+            .buttonStyle(.bordered)
+            // prominentBlueSendButton — starts staging and direct transfer for the selection.
+            Button("Send") { coordinator.send(picks) }
+                .buttonStyle(.borderedProminent)
+                .disabled(picks.isEmpty)
+        case .staging:
+            progress("Preparing selected items…")
+        case .joining:
+            progress("Connecting privately…")
+        case .waitingForReceiver:
+            progress("Waiting for acceptance on \(invocation.receiverName)…")
+        case .transferring:
+            // horizontalTransferProgress — determinate progress while Android downloads files.
+            ProgressView(value: coordinator.progress)
+            Text("Sending… \(Int(coordinator.progress * 100))%")
+        case .completed:
+            AppClipMessageView(icon: "checkmark.circle.fill", title: "Sent", message: "All selected items were received.")
+        case .failed(let message):
+            AppClipMessageView(icon: "exclamationmark.triangle", title: "Transfer stopped", message: message)
+            // prominentRetryButton — returns a failed transfer to media selection.
+            Button("Try again") { coordinator.reset() }.buttonStyle(.borderedProminent)
+        }
+        if coordinator.isActive {
+            // borderedCancelButton — tears down any active direct-transfer phase.
+            Button("Cancel", role: .cancel) { coordinator.cancel() }.buttonStyle(.bordered)
+        }
+    }
+
+    private func progress(_ label: String) -> some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text(label).multilineTextAlignment(.center).foregroundStyle(.secondary)
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct AppClipFullAppSheet: View {
+    let invocation: AppClipInvocation
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        AppClipRootView(invocation: invocation, onDismiss: { dismiss() })
+    }
+}
+
+struct AppClipMessageView: View {
+    let icon: String
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: icon).font(.system(size: 48))
+            Text(title).font(.title3.bold())
+            Text(message).multilineTextAlignment(.center).foregroundStyle(.secondary)
+        }
+    }
+}

--- a/app/ios/AppClip/AppClipTransferCoordinator.swift
+++ b/app/ios/AppClip/AppClipTransferCoordinator.swift
@@ -1,0 +1,187 @@
+// AppClipTransferCoordinator drives the App Clip's "Choose photos and videos" send flow.
+// It stages media before leaving internet, joins Android's hotspot, bootstraps, serves LocalSend v2,
+// and tears down every temporary/network resource. Unit/static checks exist; device UI is unverified.
+import CoreTransferable
+import Foundation
+import PhotosUI
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+import WebKit
+
+@available(iOS 16.0, *)
+@MainActor
+final class AppClipTransferCoordinator: ObservableObject {
+    enum Phase: Equatable {
+        case choosing
+        case staging
+        case joining
+        case waitingForReceiver
+        case transferring
+        case completed
+        case failed(String)
+    }
+
+    @Published private(set) var phase: Phase = .choosing
+    @Published private(set) var progress = 0.0
+    @Published private(set) var bootstrapWebView: WKWebView?
+
+    let invocation: AppClipInvocation
+    private let bootstrapClient = AppClipBootstrapClient()
+    private var task: Task<Void, Never>?
+    private var server: AppClipReverseDownloadServer?
+
+    init(invocation: AppClipInvocation) {
+        self.invocation = invocation
+        bootstrapClient.onWebViewChanged = { [weak self] in self?.bootstrapWebView = $0 }
+    }
+
+    var isActive: Bool {
+        switch phase {
+        case .staging, .joining, .waitingForReceiver, .transferring: return true
+        default: return false
+        }
+    }
+
+    func send(_ picks: [PhotosPickerItem]) {
+        guard !isActive, !picks.isEmpty else { return }
+        task?.cancel()
+        task = Task { await run(picks) }
+    }
+
+    func cancel() {
+        task?.cancel()
+        bootstrapClient.cancel()
+        server?.stop()
+    }
+
+    func reset() {
+        cancel()
+        progress = 0
+        phase = .choosing
+    }
+
+    private func run(_ picks: [PhotosPickerItem]) async {
+        phase = .staging
+        progress = 0
+        UIApplication.shared.isIdleTimerDisabled = true
+        var staged: [AppClipStagedFile] = []
+        var joined = false
+        defer {
+            server?.stop()
+            server = nil
+            bootstrapWebView = nil
+            if joined { AppClipHotspot.remove(ssid: invocation.ssid) }
+            for file in staged { try? FileManager.default.removeItem(at: file.url) }
+            UIApplication.shared.isIdleTimerDisabled = false
+        }
+
+        do {
+            staged = try await Self.stage(picks)
+            try Task.checkCancellation()
+            phase = .joining
+            try await AppClipHotspot.join(ssid: invocation.ssid, passphrase: invocation.passphrase)
+            joined = true
+            try Task.checkCancellation()
+
+            let token = AppClipBootstrap.downloadToken(sessionKey: invocation.sessionKey)
+            let server = try AppClipReverseDownloadServer(files: staged, alias: UIDevice.current.name.isEmpty ? "iPhone" : UIDevice.current.name, pin: token)
+            self.server = server
+            server.onProgress = { [weak self] sent, total in
+                Task { @MainActor in
+                    guard let self else { return }
+                    self.phase = .transferring
+                    self.progress = total == 0 ? 1 : min(Double(sent) / Double(total), 1)
+                }
+            }
+            let listenerPort = try await server.start()
+            let bootstrapBody = try AppClipBootstrap.body(invocation: invocation, listenerPort: listenerPort)
+            phase = .waitingForReceiver
+            try await bootstrapClient.perform(candidates: try AppClipBootstrap.candidates(invocation: invocation), body: bootstrapBody)
+            try await server.waitUntilComplete()
+            try Task.checkCancellation()
+            progress = 1
+            phase = .completed
+        } catch is CancellationError {
+            phase = .failed(AppClipBootstrapError.cancelled.localizedDescription)
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    private static func stage(_ picks: [PhotosPickerItem]) async throws -> [AppClipStagedFile] {
+        guard picks.count <= 100 else { throw AppClipStageError.tooManyFiles }
+        var staged: [AppClipStagedFile] = []
+        do {
+            for (index, item) in picks.enumerated() {
+                try Task.checkCancellation()
+                guard let transferred = try await item.loadTransferable(type: AppClipTransferredFile.self) else {
+                    throw AppClipStageError.unavailable
+                }
+                let attributes = try FileManager.default.attributesOfItem(atPath: transferred.url.path)
+                guard let number = attributes[.size] as? NSNumber else { throw AppClipStageError.unavailable }
+                let size = number.uint64Value
+                guard size <= 4 * 1_024 * 1_024 * 1_024 else {
+                    try? FileManager.default.removeItem(at: transferred.url)
+                    throw AppClipStageError.fileTooLarge
+                }
+                let type = item.supportedContentTypes.first ?? .data
+                guard type.conforms(to: .image) || type.conforms(to: .movie) else {
+                    try? FileManager.default.removeItem(at: transferred.url)
+                    throw AppClipStageError.unsupportedType
+                }
+                let ext = type.preferredFilenameExtension ?? (type.conforms(to: .image) ? "jpg" : "mov")
+                let name = String(format: type.conforms(to: .image) ? "IMG_%04d.%@" : "VID_%04d.%@", index + 1, ext)
+                staged.append(AppClipStagedFile(
+                    id: UUID().uuidString,
+                    name: name,
+                    size: size,
+                    fileType: type.conforms(to: .image) ? "image" : "video",
+                    url: transferred.url
+                ))
+            }
+            let total = staged.reduce(UInt64(0)) { $0 + $1.size }
+            guard total <= 20 * 1_024 * 1_024 * 1_024 else { throw AppClipStageError.sessionTooLarge }
+            return staged
+        } catch {
+            for file in staged { try? FileManager.default.removeItem(at: file.url) }
+            throw error
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+private struct AppClipTransferredFile: Transferable {
+    let url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(contentType: .item) { item in
+            SentTransferredFile(item.url)
+        } importing: { received in
+            let extensionName = received.file.pathExtension
+            let destination = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension(extensionName)
+            try FileManager.default.copyItem(at: received.file, to: destination)
+            return AppClipTransferredFile(url: destination)
+        }
+    }
+}
+
+enum AppClipStageError: Error, LocalizedError {
+    case unavailable
+    case unsupportedType
+    case tooManyFiles
+    case fileTooLarge
+    case sessionTooLarge
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable: return "A selected item could not be prepared."
+        case .unsupportedType: return "Only photos and videos can be sent."
+        case .tooManyFiles: return "Select no more than 100 items."
+        case .fileTooLarge: return "A selected item is larger than 4 GB."
+        case .sessionTooLarge: return "The selection is larger than 20 GB."
+        }
+    }
+}

--- a/app/ios/AppClip/Info.plist
+++ b/app/ios/AppClip/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>LocalSend</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>LocalSendClip</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>AppClipInvocationBaseURL</key>
+	<string>$(APP_CLIP_INVOCATION_BASE_URL)</string>
+	<key>NSAppClip</key>
+	<dict>
+		<key>NSAppClipRequestEphemeralUserNotification</key>
+		<false/>
+		<key>NSAppClipRequestLocationConfirmation</key>
+		<false/>
+	</dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>LocalSend uses the private phone-to-phone network to send the items you select.</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/app/ios/AppClip/LocalSendClipApp.swift
+++ b/app/ios/AppClip/LocalSendClipApp.swift
@@ -1,0 +1,53 @@
+// LocalSendClipApp is the native "Send with LocalSend" App Clip UI invoked by Android NFC or QR.
+// It validates the capability URL, lets the user choose media, and delegates the private transfer.
+// Protocol tests exist; signed App Clip launch and the complete tap-to-send UI remain unverified.
+import SwiftUI
+
+@main
+struct LocalSendClipApp: App {
+    @State private var invocation: AppClipInvocation?
+    @State private var launchError: String?
+
+    var body: some Scene {
+        WindowGroup {
+            Group {
+                if let invocation {
+                    AppClipRootView(invocation: invocation).id(invocation)
+                } else if let launchError {
+                    AppClipMessageView(icon: "exclamationmark.triangle", title: "Unable to open LocalSend", message: launchError)
+                } else {
+                    ProgressView("Opening LocalSend…")
+                }
+            }
+            .onOpenURL(perform: handle)
+            .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                guard let url = activity.webpageURL else {
+                    launchError = "The App Clip invitation did not include a web address."
+                    return
+                }
+                handle(url)
+            }
+            .task {
+                do {
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                } catch {
+                    return
+                }
+                if invocation == nil && launchError == nil {
+                    launchError = "No direct-transfer invitation was received."
+                }
+            }
+        }
+    }
+
+    private func handle(_ url: URL) {
+        do {
+            let parsed = try AppClipInvocation.configured(url: url)
+            if parsed != invocation { invocation = parsed }
+            launchError = nil
+        } catch {
+            invocation = nil
+            launchError = "The direct-transfer invitation is invalid or expired."
+        }
+    }
+}

--- a/app/ios/AppClipTests/AppClipProtocolTests.swift
+++ b/app/ios/AppClipTests/AppClipProtocolTests.swift
@@ -1,0 +1,42 @@
+// AppClipProtocolTests locks the Android/iOS invocation, HMAC, and derived-PIN wire contract.
+// These tests run in the macOS Xcode workflow; physical NFC, hotspot, and transfer UI are separate gates.
+import XCTest
+@testable import LocalSendClip
+
+final class AppClipProtocolTests: XCTestCase {
+    func testParsesStrictInvocation() throws {
+        let sessionID = Data((0..<16).map { UInt8($0) }).base64URL
+        let key = Data((0..<32).map { UInt8($0) }).base64URL
+        let url = try XCTUnwrap(URL(string: "https://localsend.org/clip?v=1&sid=\(sessionID)&k=\(key)&ssid=Local%20Send&pass=12345678&hosts=192.168.43.1,172.20.10.1&bp=8080&name=Pixel"))
+        let invocation = try AppClipInvocation(url: url)
+        XCTAssertEqual(invocation.hosts, ["192.168.43.1", "172.20.10.1"])
+        XCTAssertEqual(invocation.bootstrapPort, 8080)
+    }
+
+    func testRejectsDuplicateAndNonCanonicalHosts() throws {
+        let sessionID = Data(repeating: 0, count: 16).base64URL
+        let key = Data(repeating: 0, count: 32).base64URL
+        XCTAssertThrowsError(try AppClipInvocation(url: XCTUnwrap(URL(string: "https://localsend.org/clip?v=1&v=1&sid=\(sessionID)&k=\(key)&ssid=Local&pass=12345678&hosts=10.0.0.1&bp=8080&name=Pixel"))))
+        XCTAssertFalse(AppClipInvocation.isCanonicalPrivateIPv4("192.168.001.1"))
+        XCTAssertFalse(AppClipInvocation.isCanonicalPrivateIPv4("8.8.8.8"))
+    }
+
+    func testRejectsUnknownFieldsAndControlCharacters() throws {
+        let sessionID = Data(repeating: 0, count: 16).base64URL
+        let key = Data(repeating: 0, count: 32).base64URL
+        let base = "https://localsend.org/clip?v=1&sid=\(sessionID)&k=\(key)&ssid=Local&pass=12345678&hosts=10.0.0.1&bp=8080&name=Pixel"
+        XCTAssertThrowsError(try AppClipInvocation(url: XCTUnwrap(URL(string: base + "&extra=1"))))
+        XCTAssertThrowsError(try AppClipInvocation(url: XCTUnwrap(URL(string: base.replacingOccurrences(of: "name=Pixel", with: "name=Pixel%0AInjected")))))
+    }
+
+    func testMatchesAndroidBootstrapFixture() throws {
+        let sessionID = Data((0..<16).map { UInt8($0) }).base64URL
+        let keyBytes = Data((0..<32).map { UInt8($0) })
+        let url = try XCTUnwrap(URL(string: "https://localsend.org/clip?v=1&sid=\(sessionID)&k=\(keyBytes.base64URL)&ssid=Local&pass=12345678&hosts=10.0.0.1&bp=8080&name=Pixel"))
+        let invocation = try AppClipInvocation(url: url)
+        let nonce = Data((0..<16).map { UInt8(0xa0 + $0) })
+        let body = try AppClipBootstrap.body(invocation: invocation, listenerPort: 8080, issuedAtMillis: 1_700_000_000_000, nonce: nonce)
+        XCTAssertEqual(body.map { String(format: "%02x", $0) }.joined(), "01000102030405060708090a0b0c0d0e0f1f900000018bcfe56800a0a1a2a3a4a5a6a7a8a9aaabacadaeaf268b9b48e5b2564018c313fe6e41d2cb2ea801bd9b95fcc4a415f234b8d1db3c")
+        XCTAssertEqual(AppClipBootstrap.downloadToken(sessionKey: keyBytes), "pk1G7b8k5hTIZy-kMRJmCLYFNGHb0FdNQhB0DT_o7Pw")
+    }
+}

--- a/app/ios/Flutter/AppClip.xcconfig
+++ b/app/ios/Flutter/AppClip.xcconfig
@@ -1,0 +1,1 @@
+#include "Generated.xcconfig"

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -19,6 +19,23 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		E90D52B8096B253F54908565 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0628E22A788D91D99A60B3EB /* Pods_Runner.framework */; };
+		A10000000000000000000001 /* LocalSendClipApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000013 /* LocalSendClipApp.swift */; };
+		A10000000000000000000002 /* AppClipInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000014 /* AppClipInvocation.swift */; };
+		A10000000000000000000003 /* AppClipBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000015 /* AppClipBootstrap.swift */; };
+		A10000000000000000000004 /* AppClipHotspot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000016 /* AppClipHotspot.swift */; };
+		A10000000000000000000005 /* AppClipReverseDownloadServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000017 /* AppClipReverseDownloadServer.swift */; };
+		A10000000000000000000006 /* AppClipTransferCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000018 /* AppClipTransferCoordinator.swift */; };
+		A10000000000000000000007 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
+		A10000000000000000000008 /* LocalSendClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* LocalSendClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A10000000000000000000009 /* AppClipProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000001B /* AppClipProtocolTests.swift */; };
+		A1000000000000000000003A /* AppClipRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* AppClipRootView.swift */; };
+		A1000000000000000000003B /* AppClipRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* AppClipRootView.swift */; };
+		A1000000000000000000003D /* RunnerSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003C /* RunnerSceneDelegate.swift */; };
+		A1000000000000000000003E /* AppClipInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000014 /* AppClipInvocation.swift */; };
+		A1000000000000000000003F /* AppClipBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000015 /* AppClipBootstrap.swift */; };
+		A10000000000000000000040 /* AppClipHotspot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000016 /* AppClipHotspot.swift */; };
+		A10000000000000000000041 /* AppClipReverseDownloadServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000017 /* AppClipReverseDownloadServer.swift */; };
+		A10000000000000000000042 /* AppClipTransferCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000018 /* AppClipTransferCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,6 +45,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 28D9F9A129638D5E0028B96E;
 			remoteInfo = ShareExtension;
+		};
+		A10000000000000000000021 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000028;
+			remoteInfo = LocalSendClip;
+		};
+		A10000000000000000000022 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000028;
+			remoteInfo = LocalSendClip;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -51,6 +82,17 @@
 			files = (
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000023 /* Embed App Clips */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/AppClips";
+			dstSubfolderSpec = 16;
+			files = (
+				A10000000000000000000008 /* LocalSendClip.app in Embed App Clips */,
+			);
+			name = "Embed App Clips";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -85,6 +127,20 @@
 		A2BF1CF158EF83DE50B03565 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		B97818B16CFBA751581F52D0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		E27045CC3CCE78EFE26BEAA2 /* Pods-ShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-ShareExtension/Pods-ShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		A10000000000000000000011 /* LocalSendClip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LocalSendClip.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000012 /* AppClipTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppClipTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000013 /* LocalSendClipApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSendClipApp.swift; sourceTree = "<group>"; };
+		A10000000000000000000014 /* AppClipInvocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipInvocation.swift; sourceTree = "<group>"; };
+		A10000000000000000000015 /* AppClipBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipBootstrap.swift; sourceTree = "<group>"; };
+		A10000000000000000000016 /* AppClipHotspot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipHotspot.swift; sourceTree = "<group>"; };
+		A10000000000000000000017 /* AppClipReverseDownloadServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipReverseDownloadServer.swift; sourceTree = "<group>"; };
+		A10000000000000000000018 /* AppClipTransferCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipTransferCoordinator.swift; sourceTree = "<group>"; };
+		A10000000000000000000019 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1000000000000000000001A /* AppClip.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AppClip.entitlements; sourceTree = "<group>"; };
+		A1000000000000000000001B /* AppClipProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipProtocolTests.swift; sourceTree = "<group>"; };
+		A1000000000000000000001C /* AppClip.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AppClip.xcconfig; path = Flutter/AppClip.xcconfig; sourceTree = "<group>"; };
+		A10000000000000000000039 /* AppClipRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipRootView.swift; sourceTree = "<group>"; };
+		A1000000000000000000003C /* RunnerSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerSceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +157,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				E90D52B8096B253F54908565 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000024 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000025 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,6 +208,7 @@
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
+				A1000000000000000000001C /* AppClip.xcconfig */,
 			);
 			name = Flutter;
 			sourceTree = "<group>";
@@ -149,6 +220,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				28D9F9A329638D5E0028B96E /* ShareExtension */,
+				A10000000000000000000026 /* AppClip */,
+				A10000000000000000000027 /* AppClipTests */,
 				97C146EF1CF9000F007C117D /* Products */,
 				59B9B2A902E417D8EA9C7BB8 /* Pods */,
 				C869F3F44E625CCF2D1A5B44 /* Frameworks */,
@@ -160,6 +233,8 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				28D9F9A229638D5E0028B96E /* ShareExtension.appex */,
+				A10000000000000000000011 /* LocalSendClip.app */,
+				A10000000000000000000012 /* AppClipTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -168,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				281A2070295BE78500C3D1F9 /* Runner.entitlements */,
+				A1000000000000000000003C /* RunnerSceneDelegate.swift */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -188,6 +264,30 @@
 				052009B9C8E63670A6F30787 /* Pods_ShareExtension.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000026 /* AppClip */ = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000001A /* AppClip.entitlements */,
+				A10000000000000000000013 /* LocalSendClipApp.swift */,
+				A10000000000000000000014 /* AppClipInvocation.swift */,
+				A10000000000000000000015 /* AppClipBootstrap.swift */,
+				A10000000000000000000016 /* AppClipHotspot.swift */,
+				A10000000000000000000017 /* AppClipReverseDownloadServer.swift */,
+				A10000000000000000000018 /* AppClipTransferCoordinator.swift */,
+				A10000000000000000000039 /* AppClipRootView.swift */,
+				A10000000000000000000019 /* Info.plist */,
+			);
+			path = AppClip;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000027 /* AppClipTests */ = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000001B /* AppClipProtocolTests.swift */,
+			);
+			path = AppClipTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -218,6 +318,7 @@
 				9C4064819D92C3F1614A347F /* [CP] Check Pods Manifest.lock */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				28D9F9AD29638D5E0028B96E /* Embed Foundation Extensions */,
+				A10000000000000000000023 /* Embed App Clips */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -230,11 +331,47 @@
 			);
 			dependencies = (
 				28D9F9AB29638D5E0028B96E /* PBXTargetDependency */,
+				A1000000000000000000002E /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
+		};
+		A10000000000000000000028 /* LocalSendClip */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000037 /* Build configuration list for PBXNativeTarget "LocalSendClip" */;
+			buildPhases = (
+				A1000000000000000000002C /* Sources */,
+				A10000000000000000000024 /* Frameworks */,
+				A1000000000000000000002A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LocalSendClip;
+			productName = LocalSendClip;
+			productReference = A10000000000000000000011 /* LocalSendClip.app */;
+			productType = "com.apple.product-type.application.on-demand-install-capable";
+		};
+		A10000000000000000000029 /* AppClipTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000038 /* Build configuration list for PBXNativeTarget "AppClipTests" */;
+			buildPhases = (
+				A1000000000000000000002D /* Sources */,
+				A10000000000000000000025 /* Frameworks */,
+				A1000000000000000000002B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1000000000000000000002F /* PBXTargetDependency */,
+			);
+			name = AppClipTests;
+			productName = AppClipTests;
+			productReference = A10000000000000000000012 /* AppClipTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -248,6 +385,12 @@
 				TargetAttributes = {
 					28D9F9A129638D5E0028B96E = {
 						CreatedOnToolsVersion = 14.0;
+					};
+					A10000000000000000000028 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					A10000000000000000000029 = {
+						CreatedOnToolsVersion = 15.0;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -270,6 +413,8 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				28D9F9A129638D5E0028B96E /* ShareExtension */,
+				A10000000000000000000028 /* LocalSendClip */,
+				A10000000000000000000029 /* AppClipTests */,
 			);
 		};
 /* End PBXProject section */
@@ -292,6 +437,21 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				840EA3FC2B0910B000C0FED7 /* MyLocalSendStoreKit.storekit in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000002A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000007 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000002B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -423,7 +583,36 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				A1000000000000000000003D /* RunnerSceneDelegate.swift in Sources */,
+				A1000000000000000000003E /* AppClipInvocation.swift in Sources */,
+				A1000000000000000000003F /* AppClipBootstrap.swift in Sources */,
+				A10000000000000000000040 /* AppClipHotspot.swift in Sources */,
+				A10000000000000000000041 /* AppClipReverseDownloadServer.swift in Sources */,
+				A10000000000000000000042 /* AppClipTransferCoordinator.swift in Sources */,
+				A1000000000000000000003B /* AppClipRootView.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000002C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000001 /* LocalSendClipApp.swift in Sources */,
+				A10000000000000000000002 /* AppClipInvocation.swift in Sources */,
+				A10000000000000000000003 /* AppClipBootstrap.swift in Sources */,
+				A10000000000000000000004 /* AppClipHotspot.swift in Sources */,
+				A10000000000000000000005 /* AppClipReverseDownloadServer.swift in Sources */,
+				A10000000000000000000006 /* AppClipTransferCoordinator.swift in Sources */,
+				A1000000000000000000003A /* AppClipRootView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000002D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000009 /* AppClipProtocolTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -434,6 +623,16 @@
 			isa = PBXTargetDependency;
 			target = 28D9F9A129638D5E0028B96E /* ShareExtension */;
 			targetProxy = 28D9F9AA29638D5E0028B96E /* PBXContainerItemProxy */;
+		};
+		A1000000000000000000002E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A10000000000000000000028 /* LocalSendClip */;
+			targetProxy = A10000000000000000000021 /* PBXContainerItemProxy */;
+		};
+		A1000000000000000000002F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A10000000000000000000028 /* LocalSendClip */;
+			targetProxy = A10000000000000000000022 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -465,6 +664,131 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		A10000000000000000000031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1000000000000000000001C /* AppClip.xcconfig */;
+			buildSettings = {
+				APP_CLIP_ASSOCIATED_DOMAIN = "appclips:localsend.org";
+				APP_CLIP_INVOCATION_BASE_URL = "https://localsend.org/clip";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = AppClip/AppClip.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 3W7H4PYMCV;
+				INFOPLIST_FILE = AppClip/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks", );
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.localsend.localsendApp.Clip;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		A10000000000000000000032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1000000000000000000001C /* AppClip.xcconfig */;
+			buildSettings = {
+				APP_CLIP_ASSOCIATED_DOMAIN = "appclips:localsend.org";
+				APP_CLIP_INVOCATION_BASE_URL = "https://localsend.org/clip";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = AppClip/AppClip.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 3W7H4PYMCV;
+				INFOPLIST_FILE = AppClip/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks", );
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.localsend.localsendApp.Clip;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		A10000000000000000000033 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1000000000000000000001C /* AppClip.xcconfig */;
+			buildSettings = {
+				APP_CLIP_ASSOCIATED_DOMAIN = "appclips:localsend.org";
+				APP_CLIP_INVOCATION_BASE_URL = "https://localsend.org/clip";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = AppClip/AppClip.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 3W7H4PYMCV;
+				INFOPLIST_FILE = AppClip/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks", );
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.localsend.localsendApp.Clip;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Profile;
+		};
+		A10000000000000000000034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3W7H4PYMCV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.localsend.localsendApp.AppClipTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LocalSendClip.app/LocalSendClip";
+			};
+			name = Debug;
+		};
+		A10000000000000000000035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3W7H4PYMCV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.localsend.localsendApp.AppClipTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LocalSendClip.app/LocalSendClip";
+			};
+			name = Release;
+		};
+		A10000000000000000000036 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3W7H4PYMCV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.localsend.localsendApp.AppClipTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LocalSendClip.app/LocalSendClip";
+			};
+			name = Profile;
+		};
 		249021D3217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -519,6 +843,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
+				APP_CLIP_ASSOCIATED_DOMAIN = "appclips:localsend.org";
+				APP_CLIP_INVOCATION_BASE_URL = "https://localsend.org/clip";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -761,6 +1087,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
+				APP_CLIP_ASSOCIATED_DOMAIN = "appclips:localsend.org";
+				APP_CLIP_INVOCATION_BASE_URL = "https://localsend.org/clip";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -786,6 +1114,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
+				APP_CLIP_ASSOCIATED_DOMAIN = "appclips:localsend.org";
+				APP_CLIP_INVOCATION_BASE_URL = "https://localsend.org/clip";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -809,6 +1139,26 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		A10000000000000000000037 /* Build configuration list for PBXNativeTarget "LocalSendClip" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000031 /* Debug */,
+				A10000000000000000000032 /* Release */,
+				A10000000000000000000033 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000038 /* Build configuration list for PBXNativeTarget "AppClipTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000034 /* Debug */,
+				A10000000000000000000035 /* Release */,
+				A10000000000000000000036 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		28D9F9B129638D5E0028B96E /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/LocalSendClip.xcscheme
+++ b/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/LocalSendClip.xcscheme
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion="1510" version="1.3">
+   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A10000000000000000000028" BuildableName="LocalSendClip.app" BlueprintName="LocalSendClip" ReferencedContainer="container:Runner.xcodeproj"/>
+         </BuildActionEntry>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="NO" buildForProfiling="NO" buildForArchiving="NO" buildForAnalyzing="YES">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A10000000000000000000029" BuildableName="AppClipTests.xctest" BlueprintName="AppClipTests" ReferencedContainer="container:Runner.xcodeproj"/>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
+      <MacroExpansion>
+         <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A10000000000000000000028" BuildableName="LocalSendClip.app" BlueprintName="LocalSendClip" ReferencedContainer="container:Runner.xcodeproj"/>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference skipped="NO">
+            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A10000000000000000000029" BuildableName="AppClipTests.xctest" BlueprintName="AppClipTests" ReferencedContainer="container:Runner.xcodeproj"/>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" allowLocationSimulation="YES">
+      <BuildableProductRunnable runnableDebuggingMode="0">
+         <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A10000000000000000000028" BuildableName="LocalSendClip.app" BlueprintName="LocalSendClip" ReferencedContainer="container:Runner.xcodeproj"/>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction buildConfiguration="Profile" shouldUseLaunchSchemeArgsEnv="YES" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES">
+      <BuildableProductRunnable runnableDebuggingMode="0">
+         <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A10000000000000000000028" BuildableName="LocalSendClip.app" BlueprintName="LocalSendClip" ReferencedContainer="container:Runner.xcodeproj"/>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration="Debug"/>
+   <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES"/>
+</Scheme>

--- a/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000029"
+               BuildableName = "AppClipTests.xctest"
+               BlueprintName = "AppClipTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -38,6 +52,16 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000029"
+               BuildableName = "AppClipTests.xctest"
+               BlueprintName = "AppClipTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -22,6 +22,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>AppClipInvocationBaseURL</key>
+	<string>$(APP_CLIP_INVOCATION_BASE_URL)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
@@ -53,7 +55,7 @@
               <key>UISceneClassName</key>
               <string>UIWindowScene</string>
               <key>UISceneDelegateClassName</key>
-              <string>FlutterSceneDelegate</string>
+			  <string>$(PRODUCT_MODULE_NAME).RunnerSceneDelegate</string>
               <key>UISceneConfigurationName</key>
               <string>flutter</string>
               <key>UISceneStoryboardFile</key>

--- a/app/ios/Runner/RunnerSceneDelegate.swift
+++ b/app/ios/Runner/RunnerSceneDelegate.swift
@@ -1,0 +1,66 @@
+// RunnerSceneDelegate handles the production "Send with LocalSend" universal link in the full app.
+// Apple launches Runner instead of its App Clip when LocalSend is installed, so iOS 16+ presents the
+// same validated native sender sheet. Earlier iOS versions receive a clear unsupported-version alert.
+import Flutter
+import SwiftUI
+import UIKit
+
+final class RunnerSceneDelegate: FlutterSceneDelegate {
+    override func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        super.scene(scene, willConnectTo: session, options: connectionOptions)
+        guard let activity = connectionOptions.userActivities.first(where: { $0.activityType == NSUserActivityTypeBrowsingWeb }) else { return }
+        handle(activity)
+    }
+
+    override func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        super.scene(scene, continue: userActivity)
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb else { return }
+        handle(userActivity)
+    }
+
+    private func handle(_ activity: NSUserActivity) {
+        guard let url = activity.webpageURL else { return }
+        DispatchQueue.main.async { [weak self] in self?.presentTransfer(for: url) }
+    }
+
+    private func presentTransfer(for url: URL) {
+        guard #available(iOS 16.0, *) else {
+            presentError("Sending from an App Clip invitation requires iOS 16 or later.")
+            return
+        }
+        do {
+            let invocation = try AppClipInvocation.configured(url: url)
+            let controller = UIHostingController(rootView: AppClipFullAppSheet(invocation: invocation))
+            controller.restorationIdentifier = "LocalSendAppClipTransfer"
+            controller.modalPresentationStyle = .formSheet
+            guard let presenter = Self.topViewController(from: window?.rootViewController) else { return }
+            if presenter.restorationIdentifier == controller.restorationIdentifier {
+                presenter.dismiss(animated: false) { [weak self] in
+                    Self.topViewController(from: self?.window?.rootViewController)?.present(controller, animated: true)
+                }
+            } else {
+                presenter.present(controller, animated: true)
+            }
+        } catch {
+            presentError("The direct-transfer invitation is invalid or expired.")
+        }
+    }
+
+    private func presentError(_ message: String) {
+        guard let presenter = Self.topViewController(from: window?.rootViewController) else { return }
+        let alert = UIAlertController(title: "Unable to open LocalSend", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        presenter.present(alert, animated: true)
+    }
+
+    private static func topViewController(from root: UIViewController?) -> UIViewController? {
+        if let presented = root?.presentedViewController { return topViewController(from: presented) }
+        if let navigation = root as? UINavigationController { return topViewController(from: navigation.visibleViewController) }
+        if let tabs = root as? UITabBarController { return topViewController(from: tabs.selectedViewController) }
+        return root
+    }
+}

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 58
-/// Strings: 21022 (362 per locale)
+/// Strings: 21038 (362 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -48,6 +48,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 
   late final Translations$general$en general = Translations$general$en.internal(_root);
   late final Translations$receiveTab$en receiveTab = Translations$receiveTab$en.internal(_root);
+  late final Translations$appClip$en appClip = Translations$appClip$en.internal(_root);
   late final Translations$sendTab$en sendTab = Translations$sendTab$en.internal(_root);
   late final Translations$settingsTab$en settingsTab = Translations$settingsTab$en.internal(_root);
   late final Translations$troubleshootPage$en troubleshootPage = Translations$troubleshootPage$en.internal(_root);
@@ -214,6 +215,63 @@ class Translations$receiveTab$en {
 
   /// en: 'Receive via link'
   String get link => 'Receive via link';
+}
+
+// Path: appClip
+class Translations$appClip$en {
+  Translations$appClip$en.internal(this._root);
+
+  final Translations _root; // ignore: unused_field
+
+  // Translations
+
+  /// en: 'Receive from iPhone'
+  String get title => 'Receive from iPhone';
+
+  /// en: 'An iPhone can send photos and videos without installing LocalSend.'
+  String get intro => 'An iPhone can send photos and videos without installing LocalSend.';
+
+  /// en: 'Preparing a private connection…'
+  String get starting => 'Preparing a private connection…';
+
+  /// en: 'Hold the unlocked iPhone near this phone, or scan the QR code.'
+  String get readyNfc => 'Hold the unlocked iPhone near this phone, or scan the QR code.';
+
+  /// en: 'Scan this QR code with the iPhone camera.'
+  String get readyQr => 'Scan this QR code with the iPhone camera.';
+
+  /// en: 'Waiting for the iPhone…'
+  String get waiting => 'Waiting for the iPhone…';
+
+  /// en: 'Reading the file offer…'
+  String get preparing => 'Reading the file offer…';
+
+  /// en: '{name} wants to send {count} file(s).'
+  String offer({required Object name, required Object count}) => '${name} wants to send ${count} file(s).';
+
+  /// en: 'Receiving files…'
+  String get receiving => 'Receiving files…';
+
+  /// en: 'All files were received.'
+  String get completed => 'All files were received.';
+
+  /// en: 'Retry failed files'
+  String get retryFailed => 'Retry failed files';
+
+  /// en: 'Receive from iPhone is unavailable on this device.'
+  String get unavailable => 'Receive from iPhone is unavailable on this device.';
+
+  /// en: 'The App Clip invocation URL has not been configured for this build.'
+  String get notConfigured => 'The App Clip invocation URL has not been configured for this build.';
+
+  /// en: 'Nearby Wi-Fi and notification permissions are required.'
+  String get permissionDenied => 'Nearby Wi-Fi and notification permissions are required.';
+
+  /// en: 'The direct connection stopped before the transfer completed.'
+  String get failed => 'The direct connection stopped before the transfer completed.';
+
+  /// en: 'NFC is unavailable; the QR code still works.'
+  String get nfcOptional => 'NFC is unavailable; the QR code still works.';
 }
 
 // Path: sendTab

--- a/app/lib/pages/app_clip_receive_page.dart
+++ b/app/lib/pages/app_clip_receive_page.dart
@@ -1,0 +1,594 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:localsend_app/gen/strings.g.dart';
+import 'package:localsend_app/provider/device_info_provider.dart';
+import 'package:localsend_app/provider/http_provider.dart';
+import 'package:localsend_app/provider/receive_history_provider.dart';
+import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/util/native/channel/android_channel.dart';
+import 'package:localsend_app/util/native/directories.dart';
+import 'package:localsend_isolates/file_saver.dart';
+import 'package:localsend_isolates/model/dto/file_dto.dart';
+import 'package:localsend_isolates/model/file_type.dart';
+import 'package:localsend_isolates/rust/api/cancel.dart';
+import 'package:localsend_isolates/rust/api/http.dart' as rust_http;
+import 'package:localsend_isolates/rust/api/model.dart' as rust_model;
+import 'package:localsend_isolates/util/file_size_helper.dart';
+import 'package:localsend_isolates/util/rust.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+import 'package:refena_flutter/refena_flutter.dart';
+import 'package:routerino/routerino.dart';
+import 'package:uuid/uuid.dart';
+
+enum _DirectFilePhase { queued, receiving, completed, failed }
+
+class _DirectFile {
+  final rust_model.FileDto source;
+  final FileDto display;
+  _DirectFilePhase phase = _DirectFilePhase.queued;
+  double progress = 0;
+  FileSaveTarget? target;
+  bool savedToGallery = false;
+  String? finalPath;
+  RsCancellationToken? cancelToken;
+
+  _DirectFile(this.source) : display = source.toDart();
+}
+
+/// Android's direct-receive surface for an iOS App Clip sender.
+///
+/// Hotspot and NFC ownership stay in the native `AppClipHostService` through the
+/// channel. This page retains only redacted state plus the QR capability while
+/// visible, confirms the whole offer, and streams files through the Rust v2
+/// client into LocalSend's existing incoming-file saver.
+class AppClipReceivePage extends StatefulWidget {
+  const AppClipReceivePage({super.key});
+
+  @override
+  State<AppClipReceivePage> createState() => _AppClipReceivePageState();
+}
+
+class _AppClipReceivePageState extends State<AppClipReceivePage> with Refena {
+  StreamSubscription<AppClipHostState>? _hostSubscription;
+  AppClipHostState _hostState = const AppClipHostState(state: 'idle', hceAvailable: false);
+  AppClipBootstrap? _bootstrap;
+  rust_http.RsPrepareDownloadResponse? _offer;
+  rust_http.RsHttpClient? _client;
+  RsCancellationToken? _prepareCancelToken;
+  List<_DirectFile> _files = const [];
+  String? _invocationUrl;
+  String? _failureCode;
+  bool _starting = true;
+  bool _loadingOffer = false;
+  bool _transferring = false;
+  bool _completed = false;
+  bool _disposed = false;
+  bool _nativeAcknowledged = false;
+  String? _destinationDirectory;
+  String? _cacheDirectory;
+  bool _saveToGallery = false;
+  int? _androidSdkInt;
+  final Set<String> _createdDirectories = {};
+  Future<void>? _teardownFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => unawaited(_begin()));
+  }
+
+  Future<void> _begin() async {
+    try {
+      await _beginSession();
+    } catch (_) {
+      _setFailure('START_FAILED');
+    }
+  }
+
+  Future<void> _beginSession() async {
+    await _teardown(notifyPeer: true);
+    if (!mounted) return;
+    await _hostSubscription?.cancel();
+    _hostSubscription = null;
+    _teardownFuture = null;
+    _createdDirectories.clear();
+    setState(() {
+      _hostState = const AppClipHostState(state: 'idle', hceAvailable: false);
+      _bootstrap = null;
+      _offer = null;
+      _client = null;
+      _files = const [];
+      _invocationUrl = null;
+      _failureCode = null;
+      _starting = true;
+      _loadingOffer = false;
+      _transferring = false;
+      _completed = false;
+      _nativeAcknowledged = false;
+      _destinationDirectory = null;
+      _cacheDirectory = null;
+      _saveToGallery = false;
+      _androidSdkInt = null;
+    });
+
+    var prerequisites = await getAppClipHostPrerequisitesAndroid();
+    if (prerequisites.missing.contains('APP_CLIP_URL_NOT_CONFIGURED')) {
+      _setFailure('APP_CLIP_URL_NOT_CONFIGURED');
+      return;
+    }
+    final permissions = <Permission>[];
+    if (prerequisites.missing.contains('android.permission.NEARBY_WIFI_DEVICES')) {
+      permissions.add(Permission.nearbyWifiDevices);
+    }
+    if (prerequisites.missing.contains('android.permission.ACCESS_FINE_LOCATION')) {
+      permissions.add(Permission.location);
+    }
+    if (prerequisites.missing.contains('android.permission.POST_NOTIFICATIONS')) {
+      permissions.add(Permission.notification);
+    }
+    if (permissions.isNotEmpty) {
+      await permissions.request();
+      prerequisites = await getAppClipHostPrerequisitesAndroid();
+    }
+    if (!prerequisites.available) {
+      _setFailure(prerequisites.missing.any((value) => value.startsWith('android.permission.')) ? 'PERMISSION_DENIED' : 'UNAVAILABLE');
+      return;
+    }
+
+    _hostSubscription = watchAppClipHostStateAndroid().listen(
+      _onHostState,
+      onError: (_) => _setFailure('EVENT_CHANNEL_FAILED'),
+    );
+    final alias = ref.read(settingsProvider).alias;
+    final state = await startAppClipHostAndroid(alias);
+    _onHostState(state);
+  }
+
+  void _onHostState(AppClipHostState state) {
+    if (!mounted || _disposed) return;
+    final previousState = _hostState.state;
+    setState(() {
+      _hostState = state;
+      _starting = state.state == 'startingHotspot';
+    });
+    if (state.state == 'failed') {
+      _setFailure(state.message ?? 'FAILED');
+    } else if (state.state == 'unavailable') {
+      _setFailure(state.message ?? 'UNAVAILABLE');
+    } else if (state.state == 'idle' && previousState != 'idle' && !_completed) {
+      _setFailure('SESSION_STOPPED');
+    } else if (state.state == 'readyForTap') {
+      unawaited(_loadInvocationUrl());
+    } else if (state.state == 'waitingForApproval') {
+      unawaited(_loadOffer());
+    }
+  }
+
+  Future<void> _loadInvocationUrl() async {
+    try {
+      final value = await getAppClipInvocationUrlAndroid();
+      if (!mounted || value == null) return;
+      setState(() => _invocationUrl = value);
+    } catch (_) {
+      _setFailure('INVOCATION_URL_UNAVAILABLE');
+    }
+  }
+
+  Future<void> _loadOffer() async {
+    if (_loadingOffer || _offer != null) return;
+    setState(() => _loadingOffer = true);
+    try {
+      final bootstrap = await getAppClipBootstrapAndroid();
+      if (bootstrap == null) throw StateError('BOOTSTRAP_MISSING');
+      final client = ref.read(httpProvider).appClipAuthenticated();
+      final cancelToken = createCancellationToken();
+      _prepareCancelToken = cancelToken;
+      final offer = await client.prepareDownload(
+        protocol: rust_model.ProtocolType.http,
+        ip: bootstrap.peerIp,
+        port: bootstrap.peerPort,
+        pin: bootstrap.downloadToken,
+        cancelToken: cancelToken,
+      );
+      final files = _validateOffer(offer);
+      if (!mounted) return;
+      setState(() {
+        _bootstrap = bootstrap;
+        _client = client;
+        _offer = offer;
+        _files = files;
+        _loadingOffer = false;
+      });
+    } catch (_) {
+      _setFailure('PREPARE_DOWNLOAD_FAILED');
+    }
+  }
+
+  List<_DirectFile> _validateOffer(rust_http.RsPrepareDownloadResponse offer) {
+    if (!offer.info.download || offer.files.isEmpty || offer.files.length > 10_000) {
+      throw StateError('INVALID_OFFER');
+    }
+    final maxFileSize = BigInt.from(4) * BigInt.from(1024).pow(3);
+    final maxSessionSize = BigInt.from(20) * BigInt.from(1024).pow(3);
+    var total = BigInt.zero;
+    final files = <_DirectFile>[];
+    for (final entry in offer.files.entries) {
+      final file = entry.value;
+      if (entry.key != file.id || file.size < BigInt.zero || file.size > maxFileSize || !utf8.encode(file.fileName).length.inRange(1, 255)) {
+        throw StateError('INVALID_FILE');
+      }
+      final direct = _DirectFile(file);
+      if (direct.display.fileType != FileType.image && direct.display.fileType != FileType.video) {
+        throw StateError('UNSUPPORTED_FILE_TYPE');
+      }
+      total += file.size;
+      files.add(direct);
+    }
+    if (total > maxSessionSize) throw StateError('SESSION_TOO_LARGE');
+    return files;
+  }
+
+  Future<void> _accept() async {
+    try {
+      await _acceptOffer();
+    } catch (_) {
+      _setFailure('RECEIVE_SETUP_FAILED');
+    }
+  }
+
+  Future<void> _acceptOffer() async {
+    final bootstrap = _bootstrap;
+    final offer = _offer;
+    if (_transferring || bootstrap == null || offer == null) return;
+    if (!_nativeAcknowledged) {
+      if (!await acknowledgeAppClipBootstrapAndroid(bootstrap.sessionId)) {
+        _setFailure('BOOTSTRAP_EXPIRED');
+        return;
+      }
+      _nativeAcknowledged = true;
+    }
+
+    _androidSdkInt ??= ref.read(deviceInfoProvider).androidSdkInt;
+    if (_androidSdkInt != null && _androidSdkInt! < 33) await Permission.storage.request();
+    final settings = ref.read(settingsProvider);
+    _destinationDirectory ??= settings.destination ?? await getDefaultDestinationDirectory();
+    _cacheDirectory ??= await getCacheDirectory();
+    _saveToGallery = settings.saveToGallery && _files.every((file) => !file.display.fileName.contains('/'));
+    await _runTransfers(_files.where((file) => file.phase != _DirectFilePhase.completed));
+  }
+
+  Future<void> _runTransfers(Iterable<_DirectFile> files) async {
+    if (_transferring || _destinationDirectory == null || _cacheDirectory == null) return;
+    setState(() => _transferring = true);
+    for (final file in files) {
+      await _downloadFile(
+        file,
+        destinationDirectory: _destinationDirectory!,
+        cacheDirectory: _cacheDirectory!,
+        saveToGallery: _saveToGallery,
+        createdDirectories: _createdDirectories,
+        androidSdkInt: _androidSdkInt,
+      );
+      if (_disposed) return;
+    }
+    if (!mounted) return;
+    final allCompleted = _files.every((file) => file.phase == _DirectFilePhase.completed);
+    setState(() {
+      _transferring = false;
+      _completed = allCompleted;
+    });
+    if (allCompleted) await _teardown(notifyPeer: false);
+  }
+
+  Future<void> _downloadFile(
+    _DirectFile file, {
+    required String destinationDirectory,
+    required String cacheDirectory,
+    required bool saveToGallery,
+    required Set<String> createdDirectories,
+    required int? androidSdkInt,
+  }) async {
+    final bootstrap = _bootstrap!;
+    final offer = _offer!;
+    final client = _client!;
+    final cancelToken = createCancellationToken();
+    file.cancelToken = cancelToken;
+    try {
+      file.target = file.target == null
+          ? await prepareFileSaveTarget(
+              destinationDirectory: destinationDirectory,
+              cacheDirectory: cacheDirectory,
+              fileName: file.display.fileName,
+              saveToGallery: saveToGallery,
+              isImage: file.display.fileType == FileType.image,
+              createdDirectories: createdDirectories,
+              androidSdkInt: androidSdkInt,
+            )
+          : await reopenFileSaveTarget(file.target!);
+      _updateFile(file, phase: _DirectFilePhase.receiving, progress: 0);
+      var failed = false;
+      await for (final event in client.downloadToTarget(
+        protocol: rust_model.ProtocolType.http,
+        ip: bootstrap.peerIp,
+        port: bootstrap.peerPort,
+        sessionId: offer.sessionId,
+        fileId: file.source.id,
+        path: file.target!.path,
+        fileDescriptor: file.target!.fileDescriptor,
+        expectedSize: file.source.size,
+        cancelToken: cancelToken,
+      )) {
+        if (event is rust_http.RsDownloadEvent_Progress) {
+          _updateFile(file, progress: event.progress);
+        } else if (event is rust_http.RsDownloadEvent_Failed) {
+          failed = true;
+        }
+      }
+      if (failed) throw StateError('DOWNLOAD_FAILED');
+
+      var finalPath = file.target!.displayPath;
+      var savedToGallery = false;
+      if (saveToGallery) {
+        final gallery = await saveCachedFileToGallery(
+          cachedPath: file.target!.path!,
+          destinationDirectory: destinationDirectory,
+          fileName: file.display.fileName,
+          isImage: file.display.fileType == FileType.image,
+          createdDirectories: createdDirectories,
+        );
+        savedToGallery = gallery.$1;
+        finalPath = gallery.$2 ?? finalPath;
+      }
+      file.finalPath = finalPath;
+      file.savedToGallery = savedToGallery;
+      _updateFile(file, phase: _DirectFilePhase.completed, progress: 1);
+      await ref
+          .redux(receiveHistoryProvider)
+          .dispatchAsync(
+            AddHistoryEntryAction(
+              entryId: const Uuid().v4(),
+              fileName: file.display.fileName,
+              fileType: file.display.fileType,
+              path: savedToGallery ? null : finalPath,
+              savedToGallery: savedToGallery,
+              isMessage: false,
+              fileSize: file.display.size,
+              senderAlias: offer.info.alias,
+              timestamp: DateTime.now().toUtc(),
+            ),
+          );
+    } catch (_) {
+      _updateFile(file, phase: _DirectFilePhase.failed);
+    } finally {
+      file.cancelToken = null;
+    }
+  }
+
+  Future<void> _retryFailed() async {
+    await _runTransfers(_files.where((file) => file.phase == _DirectFilePhase.failed));
+  }
+
+  Future<void> _teardown({required bool notifyPeer}) {
+    return _teardownFuture ??= _performTeardown(notifyPeer: notifyPeer);
+  }
+
+  Future<void> _performTeardown({required bool notifyPeer}) async {
+    _prepareCancelToken?.cancel();
+    for (final file in _files) {
+      file.cancelToken?.cancel();
+    }
+    final bootstrap = _bootstrap;
+    final offer = _offer;
+    final client = _client;
+    if (notifyPeer && bootstrap != null && offer != null && client != null) {
+      try {
+        await client.cancel(
+          protocol: rust_model.ProtocolType.http,
+          ip: bootstrap.peerIp,
+          port: bootstrap.peerPort,
+          sessionId: offer.sessionId,
+        );
+      } catch (_) {
+        // Best effort: native teardown below still revokes the hotspot capability.
+      }
+    }
+    await stopAppClipHostAndroid();
+  }
+
+  void _updateFile(_DirectFile file, {_DirectFilePhase? phase, double? progress}) {
+    if (!mounted || _disposed) return;
+    setState(() {
+      if (phase != null) file.phase = phase;
+      if (progress != null) file.progress = progress.clamp(0, 1);
+    });
+  }
+
+  void _setFailure(String code) {
+    if (!mounted || _disposed) return;
+    setState(() {
+      _failureCode = code;
+      _starting = false;
+      _loadingOffer = false;
+      _transferring = false;
+    });
+    unawaited(_teardown(notifyPeer: true));
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _prepareCancelToken?.cancel();
+    for (final file in _files) {
+      file.cancelToken?.cancel();
+    }
+    unawaited(_hostSubscription?.cancel());
+    unawaited(_teardown(notifyPeer: true));
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) unawaited(_teardown(notifyPeer: true));
+      },
+      child: Scaffold(
+        appBar: AppBar(title: Text(t.appClip.title)),
+        body: SafeArea(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 620),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: _content(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _content() {
+    if (_failureCode != null) {
+      final message = switch (_failureCode) {
+        'APP_CLIP_URL_NOT_CONFIGURED' => t.appClip.notConfigured,
+        'PERMISSION_DENIED' => t.appClip.permissionDenied,
+        'UNAVAILABLE' => t.appClip.unavailable,
+        _ => t.appClip.failed,
+      };
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 72),
+          const SizedBox(height: 20),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 8),
+          Text(_failureCode!, style: Theme.of(context).textTheme.bodySmall),
+          const SizedBox(height: 24),
+          FilledButton.icon(onPressed: _begin, icon: const Icon(Icons.refresh), label: Text(t.appClip.retryFailed)),
+        ],
+      );
+    }
+    if (_completed) {
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.check_circle_outline, size: 72),
+          const SizedBox(height: 20),
+          Text(t.appClip.completed, style: Theme.of(context).textTheme.titleLarge, textAlign: TextAlign.center),
+          const SizedBox(height: 24),
+          FilledButton(onPressed: () => context.pop(), child: Text(t.general.done)),
+        ],
+      );
+    }
+    if (_offer != null) return _offerContent();
+    if (_loadingOffer) return _centerProgress(t.appClip.preparing);
+    if (_invocationUrl != null) {
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(t.appClip.intro, textAlign: TextAlign.center),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: 260,
+            height: 260,
+            child: PrettyQrView.data(
+              data: _invocationUrl!,
+              errorCorrectLevel: QrErrorCorrectLevel.Q,
+              decoration: PrettyQrDecoration(
+                shape: PrettyQrSmoothSymbol(roundFactor: 0, color: Theme.of(context).colorScheme.onSurface),
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(_hostState.hceAvailable ? t.appClip.readyNfc : t.appClip.readyQr, textAlign: TextAlign.center),
+          if (!_hostState.hceAvailable) ...[
+            const SizedBox(height: 8),
+            Text(t.appClip.nfcOptional, style: Theme.of(context).textTheme.bodySmall, textAlign: TextAlign.center),
+          ],
+          const SizedBox(height: 16),
+          Text(t.appClip.waiting, style: Theme.of(context).textTheme.bodySmall),
+        ],
+      );
+    }
+    return _centerProgress(_starting ? t.appClip.starting : t.appClip.waiting);
+  }
+
+  Widget _offerContent() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          _transferring ? t.appClip.receiving : t.appClip.offer(name: _offer!.info.alias, count: _files.length),
+          style: Theme.of(context).textTheme.titleLarge,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 20),
+        Expanded(
+          child: ListView.separated(
+            itemCount: _files.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final file = _files[index];
+              return ListTile(
+                leading: Icon(file.display.fileType == FileType.image ? Icons.image_outlined : Icons.movie_outlined),
+                title: Text(file.display.fileName, maxLines: 2, overflow: TextOverflow.ellipsis),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(file.display.size.asReadableFileSize),
+                    if (file.phase == _DirectFilePhase.receiving) LinearProgressIndicator(value: file.progress),
+                    if (file.phase == _DirectFilePhase.failed) Text(t.general.error, style: TextStyle(color: Theme.of(context).colorScheme.error)),
+                  ],
+                ),
+                trailing: switch (file.phase) {
+                  _DirectFilePhase.completed => const Icon(Icons.check_circle_outline),
+                  _DirectFilePhase.failed => const Icon(Icons.error_outline),
+                  _ => null,
+                },
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 20),
+        if (!_transferring && _files.any((file) => file.phase == _DirectFilePhase.failed))
+          FilledButton.icon(onPressed: _retryFailed, icon: const Icon(Icons.refresh), label: Text(t.appClip.retryFailed))
+        else if (!_transferring)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              OutlinedButton.icon(
+                onPressed: () async {
+                  await _teardown(notifyPeer: true);
+                  if (mounted) context.pop();
+                },
+                icon: const Icon(Icons.close),
+                label: Text(t.general.decline),
+              ),
+              const SizedBox(width: 16),
+              FilledButton.icon(onPressed: _accept, icon: const Icon(Icons.check), label: Text(t.general.accept)),
+            ],
+          ),
+      ],
+    );
+  }
+
+  Widget _centerProgress(String label) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const CircularProgressIndicator(),
+        const SizedBox(height: 20),
+        Text(label, textAlign: TextAlign.center),
+      ],
+    );
+  }
+}
+
+extension on int {
+  bool inRange(int minimum, int maximum) => this >= minimum && this <= maximum;
+}

--- a/app/lib/pages/tabs/receive_tab.dart
+++ b/app/lib/pages/tabs/receive_tab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/state/server/server_state.dart';
+import 'package:localsend_app/pages/app_clip_receive_page.dart';
 import 'package:localsend_app/pages/home_page.dart';
 import 'package:localsend_app/pages/home_page_controller.dart';
 import 'package:localsend_app/pages/receive_history_page.dart';
@@ -9,6 +10,7 @@ import 'package:localsend_app/provider/animation_provider.dart';
 import 'package:localsend_app/provider/local_ip_provider.dart';
 import 'package:localsend_app/provider/network/server/server_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/widget/animations/initial_fade_transition.dart';
 import 'package:localsend_app/widget/column_list_view.dart';
 import 'package:localsend_app/widget/custom_icon_button.dart';
@@ -119,6 +121,19 @@ class _ReceiveTabState extends State<ReceiveTab> {
                       ),
                     ),
                   ),
+                  if (checkPlatform([TargetPlatform.android]))
+                    Padding(
+                      padding: const EdgeInsets.only(top: 10),
+                      child: Center(
+                        child: OutlinedButton.icon(
+                          onPressed: () async {
+                            await context.push(() => const AppClipReceivePage());
+                          },
+                          icon: const Icon(Icons.phone_iphone),
+                          label: Text(t.appClip.title),
+                        ),
+                      ),
+                    ),
                   const SizedBox(height: 15),
                 ],
               ),

--- a/app/lib/provider/http_provider.dart
+++ b/app/lib/provider/http_provider.dart
@@ -35,6 +35,18 @@ class HttpClientCollection {
       expectedFingerprint: fingerprint,
     );
   }
+
+  /// Plain-HTTP client for an App Clip peer authenticated by the short-lived
+  /// bootstrap capability and derived download PIN. It must not be used for
+  /// ordinary discovery or transfer sessions.
+  RsHttpClient appClipAuthenticated() {
+    return createClient(
+      privateKey: _privateKey,
+      cert: _certificate,
+      version: LsHttpClientVersion.v2,
+      expectedFingerprint: null,
+    );
+  }
 }
 
 /// Provides an HTTP client for each protocol version.

--- a/app/lib/util/native/channel/android_channel.dart
+++ b/app/lib/util/native/channel/android_channel.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 part 'android_channel.mapper.dart';
 
 const _methodChannel = MethodChannel('org.localsend.localsend_app/localsend');
+const _appClipEventChannel = EventChannel('org.localsend.localsend_app/localsend/app-clip-events');
 final _logger = Logger('AndroidSaf');
 
 /// From Android 10 and above, we need to use the Storage Access Framework (SAF) to access files due to the scoped storage.
@@ -86,6 +87,91 @@ Future<void> flushPendingShareIntentsAndroid() async {
 Future<void> openGallery() async {
   _logger.info('Opening gallery');
   await _methodChannel.invokeMethod('openGallery');
+}
+
+/// Redacted native lifecycle state for the Android-hosted iOS App Clip session.
+Stream<AppClipHostState> watchAppClipHostStateAndroid() {
+  return _appClipEventChannel.receiveBroadcastStream().map((event) => AppClipHostState.fromMap((event as Map).cast<Object?, Object?>()));
+}
+
+Future<AppClipHostPrerequisites> getAppClipHostPrerequisitesAndroid() async {
+  final value = await _methodChannel.invokeMethod<Map>('getAppClipHostPrerequisites');
+  return AppClipHostPrerequisites.fromMap((value ?? const {}).cast<Object?, Object?>());
+}
+
+Future<AppClipHostState> getAppClipHostStateAndroid() async {
+  final value = await _methodChannel.invokeMethod<Map>('getAppClipHostState');
+  return AppClipHostState.fromMap((value ?? const {}).cast<Object?, Object?>());
+}
+
+Future<AppClipHostState> startAppClipHostAndroid(String deviceName) async {
+  final value = await _methodChannel.invokeMethod<Map>('startAppClipHost', {'deviceName': deviceName});
+  return AppClipHostState.fromMap((value ?? const {}).cast<Object?, Object?>());
+}
+
+Future<String?> getAppClipInvocationUrlAndroid() => _methodChannel.invokeMethod<String>('getAppClipInvocationUrl');
+
+Future<AppClipBootstrap?> getAppClipBootstrapAndroid() async {
+  final value = await _methodChannel.invokeMethod<Map>('getAppClipBootstrap');
+  return value == null ? null : AppClipBootstrap.fromMap(value.cast<Object?, Object?>());
+}
+
+Future<bool> acknowledgeAppClipBootstrapAndroid(String sessionId) async {
+  return await _methodChannel.invokeMethod<bool>('acknowledgeAppClipBootstrap', {'sessionId': sessionId}) ?? false;
+}
+
+Future<void> stopAppClipHostAndroid() => _methodChannel.invokeMethod<void>('stopAppClipHost');
+
+class AppClipHostPrerequisites {
+  final bool available;
+  final bool hceAvailable;
+  final List<String> missing;
+
+  const AppClipHostPrerequisites({required this.available, required this.hceAvailable, required this.missing});
+
+  factory AppClipHostPrerequisites.fromMap(Map<Object?, Object?> value) {
+    return AppClipHostPrerequisites(
+      available: value['available'] == true,
+      hceAvailable: value['hceAvailable'] == true,
+      missing: (value['missing'] as List?)?.whereType<String>().toList(growable: false) ?? const [],
+    );
+  }
+}
+
+class AppClipHostState {
+  final String state;
+  final String? message;
+  final bool hceAvailable;
+  final String? sessionId;
+
+  const AppClipHostState({required this.state, this.message, required this.hceAvailable, this.sessionId});
+
+  factory AppClipHostState.fromMap(Map<Object?, Object?> value) {
+    return AppClipHostState(
+      state: value['state'] as String? ?? 'failed',
+      message: value['message'] as String?,
+      hceAvailable: value['hceAvailable'] == true,
+      sessionId: value['sessionId'] as String?,
+    );
+  }
+}
+
+class AppClipBootstrap {
+  final String sessionId;
+  final String peerIp;
+  final int peerPort;
+  final String downloadToken;
+
+  const AppClipBootstrap({required this.sessionId, required this.peerIp, required this.peerPort, required this.downloadToken});
+
+  factory AppClipBootstrap.fromMap(Map<Object?, Object?> value) {
+    return AppClipBootstrap(
+      sessionId: value['sessionId'] as String,
+      peerIp: value['peerIp'] as String,
+      peerPort: value['peerPort'] as int,
+      downloadToken: value['downloadToken'] as String,
+    );
+  }
 }
 
 @MappableClass()

--- a/docs/APP_CLIP_DEPLOYMENT.md
+++ b/docs/APP_CLIP_DEPLOYMENT.md
@@ -1,0 +1,63 @@
+# iOS App Clip deployment
+
+The app source is configured for the production invocation prefix `https://localsend.org/clip`, App Clip bundle ID `org.localsend.localsendApp.Clip`, parent bundle ID `org.localsend.localsendApp`, Apple Team ID `3W7H4PYMCV`, and associated domain `appclips:localsend.org`.
+
+## 1. Deploy the website companion
+
+Merge and deploy the companion `localsend/website` change that provides:
+
+- `https://localsend.org/clip`, including the App Clip card metadata for App Store ID `1661733229`;
+- `https://localsend.org/.well-known/apple-app-site-association`, with `3W7H4PYMCV.org.localsend.localsendApp.Clip` under `appclips.apps`;
+- `Content-Type: application/json` and no redirect for the AASA response;
+- `Referrer-Policy: no-referrer` and `Cache-Control: no-store` for `/clip`.
+
+After deployment, verify the real responses:
+
+```bash
+curl -i https://localsend.org/.well-known/apple-app-site-association
+curl -i https://localsend.org/clip
+```
+
+The first response must be HTTP 200, must not redirect, and must contain the exact App Clip identifier. The second must be HTTP 200 and contain `app-clip-bundle-id=org.localsend.localsendApp.Clip`.
+
+## 2. Configure Apple identifiers and capabilities
+
+In Certificates, Identifiers & Profiles:
+
+1. Keep the parent App ID `org.localsend.localsendApp` and enable Associated Domains and Hotspot Configuration for the installed-app fallback.
+2. Register the App Clip ID `org.localsend.localsendApp.Clip` under that parent.
+3. Enable On Demand Install Capable, Associated Domains, and Hotspot Configuration for the App Clip ID.
+4. Regenerate the parent and App Clip provisioning profiles after changing capabilities.
+
+The checked-in entitlements require the same values. Do not change only the portal or only the project.
+
+## 3. Configure App Store Connect
+
+After uploading a build containing `LocalSendClip`:
+
+1. Create the required default App Clip experience.
+2. Use `https://localsend.org/clip` as its associated website invocation URL.
+3. Provide the required 1800 x 1200 (3:2) header image, a subtitle of at most 56 characters, and the `View` or `Open` action.
+4. Confirm App Store Connect reports the AASA association as valid.
+
+Registering the `/clip` prefix covers the per-session query parameters because App Clip experiences use URL-prefix matching.
+
+## 4. Build-time overrides
+
+Production defaults are checked in. Staging can override them without editing source:
+
+- Android: `-PappClipInvocationBaseUrl=https://host/path`
+- Xcode: `APP_CLIP_INVOCATION_BASE_URL=https://host/path APP_CLIP_ASSOCIATED_DOMAIN=appclips:host`
+
+The Android and iOS values must name the same HTTPS origin and path. Both parsers reject a mismatched or malformed invitation.
+
+## 5. Release verification
+
+Before enabling the Android Receive action in a release:
+
+1. Run the macOS App Clip workflow and archive the parent app with its embedded clip.
+2. Test the launch experience in TestFlight or with an Xcode Local Experience.
+3. On a physical Android/iPhone pair, exercise NFC and QR invocation, media selection, hotspot approval, Android acceptance/decline, full transfer, cancellation, failed-file retry, background teardown, and the installed-full-app fallback.
+4. Verify App Clip Diagnostics on iPhone reports no AASA or experience mismatch.
+
+The invocation query is a short-lived bearer capability containing hotspot credentials and a session key. App code does not log or persist it, and the website fallback removes it from browser history after hydration. Its initial HTML and response headers disable referrer propagation. Deployment operators must also ensure CDN/origin access logs do not retain query strings.

--- a/docs/APP_CLIP_DESIGN.md
+++ b/docs/APP_CLIP_DESIGN.md
@@ -1,0 +1,243 @@
+# iOS App Clip sender design
+
+Status: architecture proposal for `feat/ios-app-clip`; no runtime behavior is implemented by this document.
+
+Related issue: [#3255](https://github.com/localsend/localsend/issues/3255).
+
+## Scope
+
+The first App Clip feature lets an iPhone without LocalSend installed select photos and videos through PhotosPicker and send them to a nearby Android device running LocalSend. Android hosts a temporary local-only Wi-Fi network and exposes a dynamic App Clip invocation URL through NFC Host Card Emulation and a QR fallback.
+
+This proposal does not claim to provide durable no-install receipt on iPhone. Apple restricts the Photos and Files/File Provider capabilities needed to keep received files from an App Clip. A receive-preview/install handoff is a separate feature.
+
+The normal LocalSend LAN discovery, upload protocol, server settings, and non-Android platforms remain unchanged.
+
+## Why this shape
+
+- The App Clip stays native SwiftUI and links only Apple frameworks. It does not embed the Flutter engine or every LocalSend plugin, keeping the physical-invocation binary below Apple's 15 MB uncompressed limit.
+- The file transfer uses LocalSend v2's existing reverse-download API. It does not introduce ClipDrop's separate framing protocol.
+- The Android device connects back to an inbound App Clip listener. This preserves the App Clip transport established by the ClipDrop prototype and avoids making the App Clip initiate a private-address socket.
+- A small authenticated HTTP bootstrap listener is separate from LocalSend's normal HTTP server because the normal server may be configured for HTTPS with a self-signed certificate that `WKWebView` cannot trust automatically.
+- All App Clip behavior is opt-in from a new Android receive action. Nothing starts in the background and ordinary LocalSend transfers do not change.
+
+## Components
+
+### Shared Flutter/Rust
+
+- `packages/core`: extend the v2 client with a bounded, cancellable download-to-path/file-descriptor operation with size validation and progress.
+- `packages/localsend_isolates`: expose prepare-download and download-to-target through the existing Rust/Dart bridge.
+- `app/lib/provider/network/app_clip`: own the App Clip receive session, file acceptance, save targets, progress, cancellation, history, and teardown.
+- `app/lib/pages`: add an Android-only entry action and a direct-receive page using LocalSend's existing receive/progress visual components.
+
+### Android
+
+- `AppClipHostService`: foreground owner of `LocalOnlyHotspotReservation`, the bootstrap listener, and the HCE payload.
+- `Type4NdefTag`: pure Kotlin Type-4 NDEF state machine serving exactly one URI record.
+- `AppClipNdefService`: thin `HostApduService` adapter, enabled only while a ready session exists.
+- `AppClipBootstrapServer`: bounded one-shot HTTP listener that authenticates the App Clip's callback and retains the peer result until Dart acknowledges it.
+- Existing `MainActivity` method channel plus one event stream: start/stop/status/acknowledge the host session. No transfer bytes cross the Flutter platform channel.
+
+### iOS
+
+- A native `LocalSendClip` target embedded in Runner, alongside the existing Share Extension.
+- A small native `AppClipTransferKit` module shared by Runner and `LocalSendClip`, containing invocation parsing, PhotosPicker staging, hotspot join, reverse-download server, authenticated bootstrap, and the LocalSend-branded SwiftUI flow.
+- The full Flutter Runner remains LocalSend's installed iOS app and `@main` entry point. Runner's existing AppDelegate presents the shared native send flow when it receives the same invocation URL, because iOS launches the full app instead of its App Clip after installation. The App Clip has its own `@main`; no standalone ClipDrop parent app is imported.
+
+## Ordered end-to-end flow
+
+1. On Android 8.0 or newer, the user opens Receive and chooses **Receive from iPhone**.
+2. Flutter checks HCE, Wi-Fi, notification, nearby-Wi-Fi/location, and foreground-service prerequisites. A missing prerequisite is shown before session startup.
+3. Flutter asks `AppClipHostService` to start. The service generates a fresh session ID and 32-byte session key using `SecureRandom`.
+4. The service starts `LocalOnlyHotspot`. It reads the OS-generated SSID and passphrase and identifies up to four newly available private IPv4 addresses from the live interface set. It never assumes `192.168.43.1`.
+5. The service binds the bootstrap listener to an ephemeral port on all local interfaces.
+6. The service constructs the invocation URL described below, arms HCE with one NDEF URI record, and returns the same URL to Flutter for QR rendering. Neither the URL nor its credentials are logged or persisted.
+7. The user holds the unlocked iPhone near the Android device, or scans the QR. iOS presents the App Clip card and launches `LocalSendClip` with the invocation URL.
+8. The App Clip validates the URL version, field sizes, address classes, port ranges, and cryptographic material before showing a destination.
+9. The iPhone user selects photos or videos through PhotosPicker. Every item is copied to the App Clip's temporary directory while internet access is still available. A partial staging failure stops the attempt visibly.
+10. On Send, the App Clip joins the Android local-only hotspot with `NEHotspotConfiguration(joinOnce: true)`.
+11. The App Clip starts a Wi-Fi-only `NWListener` on an ephemeral port. Its HTTP server is limited to the endpoints and limits below.
+12. The App Clip builds the bootstrap body, then a nonpersistent `WKWebView` POSTs it to each exact private IPv4 bootstrap candidate. Redirects, popups, credentials, downloads, hostname targets, and non-candidate origins are rejected.
+13. Android accepts at most 4 KiB, validates the body in constant time, checks the session/TTL/replay state, records the App Clip IP from the accepted socket rather than the request body, consumes the bootstrap once, and returns HTTP 202.
+14. The service reports `{sessionId, peerIp, peerPort, downloadToken}` to Dart. The result remains queryable until Dart acknowledges it, so activity recreation cannot lose the session.
+15. Flutter creates the existing LocalSend v2 HTTP client in HTTP mode and calls `prepare-download` with the derived download token as `pin`.
+16. The App Clip server returns LocalSend's standard `PrepareDownloadResponseDtoV2`. The App Clip auto-accepts only the authenticated session created by step 13.
+17. Flutter creates an incoming transfer state from the returned device/file metadata and shows LocalSend's receive confirmation UI. No file request is made before the Android user accepts it.
+18. For each accepted file, Flutter prepares the normal destination path or Android SAF file descriptor. Rust issues `GET /api/localsend/v2/download`, streams to that target, validates the declared byte count, and emits throttled progress.
+19. Successful files are added to LocalSend receive history. Failed files remain visible and retryable without creating duplicate destination names.
+20. When every accepted file reaches a terminal state, Android stops the foreground transfer notification, disarms HCE, closes the bootstrap listener and hotspot, and returns to the normal network.
+21. The App Clip marks success only after all offered files were downloaded completely. It tears down its listener, removes the temporary hotspot configuration, deletes staged files, and shows Done.
+
+## Invocation URL contract
+
+The production base URL and path require LocalSend maintainer/App Store configuration. The code must read them from iOS/Android build configuration rather than scattering a literal.
+
+Query fields are unique; duplicates are invalid.
+
+| Field | Encoding | Limit | Meaning |
+|---|---|---:|---|
+| `v` | ASCII integer | `1` | Invocation contract version. |
+| `sid` | base64url without padding | 16 decoded bytes | Per-attempt session ID. |
+| `k` | base64url without padding | 32 decoded bytes | Per-attempt bearer/session key. |
+| `ssid` | percent-encoded UTF-8 | 1-32 bytes | Android local-only hotspot SSID. |
+| `pass` | percent-encoded UTF-8 | 8-63 bytes | Ephemeral hotspot passphrase. |
+| `hosts` | comma-separated canonical IPv4 literals | 1-4 entries | Bootstrap candidates; RFC1918 only, no leading-zero variants. |
+| `bp` | ASCII integer | 1-65535 | Android bootstrap listener port. |
+| `name` | percent-encoded UTF-8 | 1-80 bytes | Android display alias. |
+
+The full URL is limited to 1,024 UTF-8 bytes. Unknown fields are ignored for forward compatibility; invalid required fields fail closed. The URL is a short-lived bearer capability and must never enter logs, analytics, history, crash text, clipboard, or persistent preferences.
+
+## Type-4 NDEF contract
+
+- Application AID: `D2760000850101`.
+- Capability Container file ID: `E103`.
+- NDEF file ID: `E104`.
+- The NDEF message contains exactly one NFC Forum well-known URI record (`TNF=wellKnown`, type `U`, MB=1, ME=1).
+- The URI record uses prefix byte `0x00` followed by the complete HTTPS invocation URL.
+- No Android Application Record, external record, text record, or second URI record is emitted.
+- Supported APDUs are SELECT application, SELECT CC/NDEF file, and bounded READ BINARY. Malformed lengths, invalid offsets, unknown files, UPDATE BINARY, and unknown instructions fail without mutating state.
+- The service is disabled and serves no session after stop, timeout, terminal transfer state, or process restart.
+
+Pure JVM tests byte-compare the CC file and NDEF file, cover chunked reads and APDU errors, and prove that a new session cannot expose a previous URL.
+
+## Bootstrap body contract
+
+All integers are unsigned big-endian. The exact body is 75 bytes:
+
+```
+version        1 byte   = 0x01
+sessionId     16 bytes  = decoded sid
+listenerPort   2 bytes
+issuedAt        8 bytes = Unix milliseconds
+nonce          16 bytes = fresh random value
+mac            32 bytes = HMAC-SHA256(sessionKey, all preceding bytes)
+```
+
+Android accepts the body only when:
+
+- request method/path/content type are exactly `POST`, `/api/localsend/app-clip/v1/bootstrap`, and `application/octet-stream`;
+- Content-Length is exactly 75 and never exceeds the 4 KiB server cap;
+- version/session match the active attempt;
+- listener port is nonzero;
+- `issuedAt` is within 120 seconds of Android wall-clock time;
+- the nonce has not been consumed;
+- the HMAC matches in constant time;
+- no bootstrap was previously accepted for the attempt.
+
+The listener returns 202 only after storing the peer IP, listener port, and derived token atomically. Replays return 409; authentication failures return 403; invalid shape returns 400; no active session returns 404. Responses contain no secrets.
+
+The reverse-download PIN is `base64url(HMAC-SHA256(sessionKey, "localsend-app-clip-download-v1"))` without padding. It is never sent in the bootstrap body and is available independently to both sides.
+
+## LocalSend v2 reverse-download contract
+
+The App Clip implements only:
+
+1. `POST /api/localsend/v2/prepare-download?pin=<downloadToken>`
+2. `GET /api/localsend/v2/download?sessionId=<id>&fileId=<id>`
+3. `POST /api/localsend/v2/cancel?sessionId=<id>` for explicit Android decline/cancel
+
+The prepare response is the existing camel-case JSON shape:
+
+```json
+{
+  "info": {
+    "alias": "iPhone",
+    "version": "2.2",
+    "deviceModel": "iPhone",
+    "deviceType": "mobile",
+    "fingerprint": "<per-attempt identifier>",
+    "download": true
+  },
+  "sessionId": "<random session id>",
+  "files": {
+    "<file id>": {
+      "id": "<file id>",
+      "fileName": "photo.jpg",
+      "size": 123,
+      "fileType": "image/jpeg"
+    }
+  }
+}
+```
+
+The proposed App Clip-specific server limits are 10,000 files, 4 GiB per file, 20 GiB per session, 255 UTF-8 bytes per file name, 64 KiB request headers, and one authenticated session. Duplicate IDs, duplicate query fields, traversal names, size overflow, and unknown files fail closed. Every response uses `Connection: close`; the client may open one request per connection.
+
+Downloads return `application/octet-stream`, exact `Content-Length`, and a sanitized `Content-Disposition`. The App Clip streams from disk in bounded chunks and never loads a whole file into memory.
+
+Android's new Rust bridge operation accepts exactly one destination: path or Android file descriptor. It validates the number of written bytes against the file DTO, truncates stale target tails, transfers descriptor ownership once, supports cancellation, and emits progress no more often than every 20 ms plus the final event.
+
+## State, cancellation, and recovery
+
+Android host states:
+
+```
+idle -> startingHotspot -> readyForTap -> waitingForClip
+     -> waitingForApproval -> receiving -> completed
+     -> failed | cancelled -> idle
+```
+
+- Start is idempotent; a second start while active returns the current redacted state.
+- Stop is safe from every state and closes HCE, listener, hotspot, and pending client work exactly once.
+- Activity recreation reads the service's current redacted state; secrets never cross to widgets or restoration data.
+- A 10-minute ready timeout and 2-minute post-bootstrap approval timeout tear down the session visibly.
+- Decline/cancel calls the App Clip cancel endpoint best-effort, cancels the Rust token, aborts unfinished save targets, and tears down the hotspot.
+- App Clip cancellation closes its listener and staged files. Android treats connection loss as a terminal failure with Retry/Close actions.
+- Ordinary LocalSend sessions are not silently replaced. The App Clip action is disabled while another transfer session is active, and ordinary inbound requests are rejected while the direct receive session owns the transfer slot.
+
+## Permissions and capabilities
+
+Android:
+
+- feature-gated to API 26+;
+- `CHANGE_WIFI_STATE`, `ACCESS_WIFI_STATE`, `ACCESS_NETWORK_STATE`, `NFC`;
+- `ACCESS_FINE_LOCATION` through Android 12 and `NEARBY_WIFI_DEVICES` on Android 13+ as required by the hotspot API;
+- `FOREGROUND_SERVICE_CONNECTED_DEVICE` and notification permission where applicable;
+- `android.hardware.nfc.hce` remains optional so non-HCE devices can still use normal LocalSend; the App Clip action explains that the QR fallback still requires hotspot support.
+
+iOS App Clip:
+
+- App Clip parent association and embed phase;
+- Hotspot Configuration entitlement;
+- Associated Domains for the production App Clip experience;
+- no Photo Library usage prompt for PhotosPicker;
+- the parent Runner carries matching Associated Domains and Hotspot Configuration capabilities and handles the same invocation URL with `AppClipTransferKit`;
+- temporary-file and foreground-only operation;
+- no background networking, Bluetooth dependency, or persistent identifier.
+
+## Verification gates
+
+Automated on Linux:
+
+- Rust v2 download-to-target success, size mismatch, path failure, cancellation, and progress tests;
+- Dart controller tests with fake host platform and fake reverse-download client;
+- pure JVM APDU/NDEF, invocation encoding, bootstrap authentication, replay, timeout, and redaction tests. Android compilation is a separate authorized gate.
+
+macOS CI:
+
+- generate/update bindings;
+- build Runner, Share Extension, and `LocalSendClip` for simulator without signing;
+- run Swift invocation/bootstrap/HTTP parser/state tests;
+- archive and report the App Clip's uncompressed size; the physical-invocation limit is 15 MB.
+
+Real devices before a non-draft PR claim:
+
+1. Android action starts the hotspot and exposes a QR/NFC payload.
+2. A clean iPhone shows the App Clip card and launches the clip with the URL.
+3. PhotosPicker and Files selection stage successfully.
+4. The iPhone joins the hotspot.
+5. WebKit bootstrap reaches Android and Android connects back.
+6. Android accept, decline, retry, cancel, rotation, and background/foreground paths are exercised.
+7. Multiple file types and a large file arrive byte-identically at the configured destination.
+8. HCE is disarmed and both phones return to their normal networks after every terminal path.
+
+Until those clicks and observations occur, the feature is source/test/compile verified only, not end-to-end verified.
+
+## Reviewable implementation series
+
+1. Rust v2 reverse-download-to-target API and tests.
+2. Rust/Dart bridge plus controller tests, with no UI or platform change.
+3. Android host/HCE/bootstrap service and pure JVM tests.
+4. Android LocalSend receive action and direct-session UI.
+5. Native App Clip target, Swift protocol implementation, and simulator tests.
+6. macOS size/build CI, device-test evidence, documentation, and final PR description.
+
+Each commit must leave normal LocalSend transfers passing. The branch remains draft until the macOS and real-device gates are complete.

--- a/docs/APP_CLIP_DESIGN.md
+++ b/docs/APP_CLIP_DESIGN.md
@@ -67,9 +67,11 @@ The normal LocalSend LAN discovery, upload protocol, server settings, and non-An
 20. When every accepted file reaches a terminal state, Android stops the foreground transfer notification, disarms HCE, closes the bootstrap listener and hotspot, and returns to the normal network.
 21. The App Clip marks success only after all offered files were downloaded completely. It tears down its listener, removes the temporary hotspot configuration, deletes staged files, and shows Done.
 
+If the full LocalSend app is already installed, iOS launches it instead of the App Clip. Runner's scene delegate validates the same invocation and presents the shared native sender screen on iOS 16 or later; its target carries the same hotspot capability required by that flow. Older supported Runner versions show an explicit unsupported-version message.
+
 ## Invocation URL contract
 
-The production base URL and path require LocalSend maintainer/App Store configuration. The code must read them from iOS/Android build configuration rather than scattering a literal.
+The checked-in production base URL is `https://localsend.org/clip`. Android reads it from the overridable `appClipInvocationBaseUrl` project property; iOS reads the matching overridable `APP_CLIP_INVOCATION_BASE_URL` target setting. Both iOS targets carry the configurable `APP_CLIP_ASSOCIATED_DOMAIN` entitlement, whose source default is `appclips:localsend.org`. Deployment also requires the matching AASA response and App Store Connect experience described in `APP_CLIP_DEPLOYMENT.md`.
 
 Query fields are unique; duplicates are invalid.
 
@@ -84,7 +86,7 @@ Query fields are unique; duplicates are invalid.
 | `bp` | ASCII integer | 1-65535 | Android bootstrap listener port. |
 | `name` | percent-encoded UTF-8 | 1-80 bytes | Android display alias. |
 
-The full URL is limited to 1,024 UTF-8 bytes. Unknown fields are ignored for forward compatibility; invalid required fields fail closed. The URL is a short-lived bearer capability and must never enter logs, analytics, history, crash text, clipboard, or persistent preferences.
+The full URL is limited to 1,024 UTF-8 bytes. Missing, duplicate, unknown, or invalid fields fail closed; a future version must explicitly update both parsers. The URL is a short-lived bearer capability and must never enter logs, analytics, history, crash text, clipboard, or persistent preferences.
 
 ## Type-4 NDEF contract
 

--- a/packages/core/src/http/client/v2.rs
+++ b/packages/core/src/http/client/v2.rs
@@ -4,11 +4,25 @@ use crate::http::dto_v2::{
     InfoResponseDtoV2, PrepareDownloadResponseDtoV2, PrepareUploadRequestDtoV2,
     PrepareUploadResponseDtoV2, PrepareUploadResultV2, RegisterDtoV2, RegisterResponseDtoV2,
 };
+use crate::http::server::common::save::{spawn_file_writer, FileTimestamps};
 use crate::model::discovery::ProtocolType;
 use futures_util::StreamExt;
 use reqwest::{Response, StatusCode};
+use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+
+/// Destination for a file fetched through the Download API.
+#[derive(Debug)]
+pub enum FileDownloadTarget {
+    /// Create or truncate a file at this path.
+    Path(PathBuf),
+
+    /// Write to an owned Android file descriptor, such as a SAF document.
+    #[cfg(target_os = "android")]
+    Fd(std::os::fd::OwnedFd),
+}
 
 /// HTTP client for LocalSend Protocol v2.2.
 pub struct LsHttpClientV2 {
@@ -373,6 +387,31 @@ impl LsHttpClientV2 {
         session_id: Option<&str>,
         pin: Option<&str>,
     ) -> Result<PrepareDownloadResponseDtoV2, ClientError> {
+        self.prepare_download_with_cancel(
+            protocol,
+            ip,
+            port,
+            session_id,
+            pin,
+            CancellationToken::new(),
+        )
+        .await
+    }
+
+    /// Prepares a reverse-download session with cancellation support.
+    pub async fn prepare_download_with_cancel(
+        &self,
+        protocol: ProtocolType,
+        ip: &str,
+        port: u16,
+        session_id: Option<&str>,
+        pin: Option<&str>,
+        cancel: CancellationToken,
+    ) -> Result<PrepareDownloadResponseDtoV2, ClientError> {
+        if cancel.is_cancelled() {
+            return Err(ClientError::Cancelled);
+        }
+
         let mut params: Vec<(&'static str, &str)> = Vec::new();
         if let Some(session_id) = session_id {
             params.push(("sessionId", session_id));
@@ -390,7 +429,11 @@ impl LsHttpClientV2 {
         }
         .to_string();
 
-        let res = self.client.post(&url).send().await?;
+        let send = self.client.post(&url).send();
+        let res = tokio::select! {
+            _ = cancel.cancelled() => return Err(ClientError::Cancelled),
+            result = send => result?,
+        };
 
         if res.status() != StatusCode::OK {
             return res.into_error().await;
@@ -480,5 +523,92 @@ impl LsHttpClientV2 {
         writer.flush().await?;
 
         Ok(total_bytes)
+    }
+
+    /// Downloads a file directly to a path or Android file descriptor.
+    ///
+    /// The destination is truncated to the received size, and the transfer
+    /// fails unless that size exactly matches `expected_size`. Progress values
+    /// are cumulative bytes written and may be dropped when the receiver lags.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn download_to_target(
+        &self,
+        protocol: ProtocolType,
+        ip: &str,
+        port: u16,
+        session_id: &str,
+        file_id: &str,
+        target: FileDownloadTarget,
+        expected_size: u64,
+        progress_tx: Option<mpsc::Sender<u64>>,
+        cancel: CancellationToken,
+    ) -> Result<(), ClientError> {
+        if cancel.is_cancelled() {
+            return Err(ClientError::Cancelled);
+        }
+
+        let response = tokio::select! {
+            _ = cancel.cancelled() => return Err(ClientError::Cancelled),
+            result = self.download(protocol, ip, port, session_id, file_id) => result?,
+        };
+
+        if let Some(content_length) = response.content_length() {
+            if content_length != expected_size {
+                return Err(anyhow::anyhow!(
+                    "Expected {expected_size} bytes, response declares {content_length}"
+                )
+                .into());
+            }
+        }
+
+        let (binary_tx, result_rx) = match target {
+            FileDownloadTarget::Path(path) => spawn_file_writer(
+                async move {
+                    tokio::fs::File::create(&path)
+                        .await
+                        .map_err(|e| format!("Failed to create {}: {e}", path.display()))
+                },
+                expected_size,
+                progress_tx,
+                FileTimestamps::default(),
+            ),
+            #[cfg(target_os = "android")]
+            FileDownloadTarget::Fd(fd) => spawn_file_writer(
+                async move {
+                    // Ownership was captured before the request started, so every
+                    // early-return path closes the descriptor automatically.
+                    let file = std::fs::File::from(fd);
+                    Ok(tokio::fs::File::from_std(file))
+                },
+                expected_size,
+                progress_tx,
+                FileTimestamps::default(),
+            ),
+        };
+
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = tokio::select! {
+            _ = cancel.cancelled() => return Err(ClientError::Cancelled),
+            chunk = stream.next() => chunk,
+        } {
+            let chunk = chunk?;
+            if tokio::select! {
+                _ = cancel.cancelled() => return Err(ClientError::Cancelled),
+                result = binary_tx.send(chunk) => result,
+            }
+            .is_err()
+            {
+                break;
+            }
+        }
+        drop(binary_tx);
+
+        let result = tokio::select! {
+            _ = cancel.cancelled() => return Err(ClientError::Cancelled),
+            result = result_rx => result,
+        }
+        .map_err(|_| anyhow::anyhow!("File writer stopped before reporting a result"))?;
+
+        result.map_err(|message| anyhow::anyhow!(message).into())
     }
 }

--- a/packages/core/src/http/server/common/save.rs
+++ b/packages/core/src/http/server/common/save.rs
@@ -249,7 +249,7 @@ pub(crate) async fn save_req_to_target(
 /// Spawns a task that writes incoming chunks to a file provided by `open`.
 ///
 /// Returns the sender for the binary chunks and a receiver for the final result.
-fn spawn_file_writer(
+pub(crate) fn spawn_file_writer(
     open: impl Future<Output = Result<tokio::fs::File, String>> + Send + 'static,
     expected_size: u64,
     progress_tx: Option<mpsc::Sender<u64>>,

--- a/packages/core/tests/v2_web_download.rs
+++ b/packages/core/tests/v2_web_download.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "http")]
 
 use bytes::Bytes;
+use localsend::http::client::v2::FileDownloadTarget;
 use localsend::http::client::{ClientError, LsHttpClientV2};
 use localsend::http::server::v2::ServerEventV2;
 use localsend::http::server::web::WebDownloadConfig;
@@ -15,7 +16,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Notify};
+use tokio_util::sync::CancellationToken;
 
 struct TestServer {
     port: u16,
@@ -30,6 +32,11 @@ struct TestServer {
 enum TestFileContent {
     Bytes(Bytes),
     Path(PathBuf),
+    Gated {
+        first: Bytes,
+        release: Arc<Notify>,
+        rest: Bytes,
+    },
 }
 
 impl TestFileContent {
@@ -58,6 +65,15 @@ impl TestFileContent {
                         break; // client disconnected
                     }
                 }
+            }
+            TestFileContent::Gated {
+                first,
+                release,
+                rest,
+            } => {
+                let _ = tx.send(first).await;
+                release.notified().await;
+                let _ = tx.send(rest).await;
             }
         }
     }
@@ -465,6 +481,190 @@ async fn test_full_download_flow() {
     assert_eq!(reused.session_id, response.session_id);
     assert_eq!(server.prepare_download_events.load(Ordering::SeqCst), 1);
 
+    let _ = std::fs::remove_file(disk_path);
+}
+
+#[tokio::test]
+async fn test_download_to_path_validates_size_truncates_and_reports_progress() {
+    let (config, contents, disk_path, _) = web_download_config(None);
+    let server = start_test_server(Some((config, contents)), true).await;
+    let client = LsHttpClientV2::try_new_without_cert().unwrap();
+    let response = client
+        .prepare_download(ProtocolType::Http, "127.0.0.1", server.port, None, None)
+        .await
+        .unwrap();
+    let destination =
+        std::env::temp_dir().join(format!("localsend-download-{}", uuid::Uuid::new_v4()));
+    std::fs::write(&destination, b"stale content longer than the download").unwrap();
+    let (progress_tx, mut progress_rx) = mpsc::channel(16);
+
+    client
+        .download_to_target(
+            ProtocolType::Http,
+            "127.0.0.1",
+            server.port,
+            &response.session_id,
+            "file-text",
+            FileDownloadTarget::Path(destination.clone()),
+            5,
+            Some(progress_tx),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(std::fs::read(&destination).unwrap(), b"hello");
+    let mut last_progress = None;
+    while let Some(progress) = progress_rx.recv().await {
+        last_progress = Some(progress);
+    }
+    assert_eq!(last_progress, Some(5));
+
+    let _ = std::fs::remove_file(destination);
+    let _ = std::fs::remove_file(disk_path);
+}
+
+#[tokio::test]
+async fn test_download_to_path_rejects_declared_size_mismatch_before_writing() {
+    let (config, contents, disk_path, _) = web_download_config(None);
+    let server = start_test_server(Some((config, contents)), true).await;
+    let client = LsHttpClientV2::try_new_without_cert().unwrap();
+    let response = client
+        .prepare_download(ProtocolType::Http, "127.0.0.1", server.port, None, None)
+        .await
+        .unwrap();
+    let destination =
+        std::env::temp_dir().join(format!("localsend-download-{}", uuid::Uuid::new_v4()));
+
+    let result = client
+        .download_to_target(
+            ProtocolType::Http,
+            "127.0.0.1",
+            server.port,
+            &response.session_id,
+            "file-text",
+            FileDownloadTarget::Path(destination.clone()),
+            4,
+            None,
+            CancellationToken::new(),
+        )
+        .await;
+
+    assert!(matches!(result, Err(ClientError::Other(_))));
+    assert!(!destination.exists());
+
+    let _ = std::fs::remove_file(disk_path);
+}
+
+#[tokio::test]
+async fn test_download_to_path_reports_invalid_destination_and_precancel() {
+    let (config, contents, disk_path, _) = web_download_config(None);
+    let server = start_test_server(Some((config, contents)), true).await;
+    let client = LsHttpClientV2::try_new_without_cert().unwrap();
+    let prepare_cancel = CancellationToken::new();
+    prepare_cancel.cancel();
+    let cancelled_prepare = client
+        .prepare_download_with_cancel(
+            ProtocolType::Http,
+            "127.0.0.1",
+            server.port,
+            None,
+            None,
+            prepare_cancel,
+        )
+        .await;
+    assert!(matches!(cancelled_prepare, Err(ClientError::Cancelled)));
+
+    let response = client
+        .prepare_download(ProtocolType::Http, "127.0.0.1", server.port, None, None)
+        .await
+        .unwrap();
+    let missing_parent = std::env::temp_dir()
+        .join(format!("localsend-missing-{}", uuid::Uuid::new_v4()))
+        .join("file");
+
+    let invalid_target = client
+        .download_to_target(
+            ProtocolType::Http,
+            "127.0.0.1",
+            server.port,
+            &response.session_id,
+            "file-text",
+            FileDownloadTarget::Path(missing_parent),
+            5,
+            None,
+            CancellationToken::new(),
+        )
+        .await;
+    assert!(matches!(invalid_target, Err(ClientError::Other(_))));
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let cancelled = client
+        .download_to_target(
+            ProtocolType::Http,
+            "127.0.0.1",
+            server.port,
+            &response.session_id,
+            "file-text",
+            FileDownloadTarget::Path(std::env::temp_dir().join("unused")),
+            5,
+            None,
+            cancel,
+        )
+        .await;
+    assert!(matches!(cancelled, Err(ClientError::Cancelled)));
+
+    let _ = std::fs::remove_file(disk_path);
+}
+
+#[tokio::test]
+async fn test_download_to_path_cancels_while_body_is_stalled() {
+    let (config, mut contents, disk_path, _) = web_download_config(None);
+    let release = Arc::new(Notify::new());
+    contents.insert(
+        "file-text".to_string(),
+        TestFileContent::Gated {
+            first: Bytes::from_static(b"h"),
+            release: release.clone(),
+            rest: Bytes::from_static(b"ello"),
+        },
+    );
+    let server = start_test_server(Some((config, contents)), true).await;
+    let client = LsHttpClientV2::try_new_without_cert().unwrap();
+    let response = client
+        .prepare_download(ProtocolType::Http, "127.0.0.1", server.port, None, None)
+        .await
+        .unwrap();
+    let destination =
+        std::env::temp_dir().join(format!("localsend-download-{}", uuid::Uuid::new_v4()));
+    let (progress_tx, mut progress_rx) = mpsc::channel(16);
+    let cancel = CancellationToken::new();
+    let download_cancel = cancel.clone();
+    let download_destination = destination.clone();
+    let download = tokio::spawn(async move {
+        client
+            .download_to_target(
+                ProtocolType::Http,
+                "127.0.0.1",
+                server.port,
+                &response.session_id,
+                "file-text",
+                FileDownloadTarget::Path(download_destination),
+                5,
+                Some(progress_tx),
+                download_cancel,
+            )
+            .await
+    });
+
+    assert_eq!(progress_rx.recv().await, Some(1));
+    cancel.cancel();
+    let result = download.await.unwrap();
+    assert!(matches!(result, Err(ClientError::Cancelled)));
+    release.notify_one();
+
+    let _ = std::fs::remove_file(destination);
     let _ = std::fs::remove_file(disk_path);
 }
 

--- a/packages/localsend_isolates/lib/file_saver.dart
+++ b/packages/localsend_isolates/lib/file_saver.dart
@@ -1,0 +1,1 @@
+export 'package:localsend_isolates/src/task/server/file_saver.dart';

--- a/packages/localsend_isolates/lib/rust/api/http.dart
+++ b/packages/localsend_isolates/lib/rust/api/http.dart
@@ -12,8 +12,8 @@ import 'package:localsend_isolates/rust/frb_generated.dart';
 
 part 'http.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `resolve_file_content`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `from`
+// These functions are ignored because they are not marked as `pub`: `resolve_download_target`, `resolve_file_content`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `from`
 
 /// Creates an HTTP client.
 ///
@@ -38,6 +38,31 @@ RsHttpClient createClient({
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsHttpClient>>
 abstract class RsHttpClient implements RustOpaqueInterface {
   Future<void> cancel({required ProtocolType protocol, required String ip, required int port, required String sessionId});
+
+  /// Downloads one reverse-transfer file, emitting progress on [sink].
+  ///
+  /// Failures are stream events for the same reason as [RsHttpClient::upload].
+  Stream<RsDownloadEvent> downloadToTarget({
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    required String sessionId,
+    required String fileId,
+    String? path,
+    int? fileDescriptor,
+    required BigInt expectedSize,
+    required RsCancellationToken cancelToken,
+  });
+
+  /// Requests the sender's reverse-download manifest.
+  Future<RsPrepareDownloadResponse> prepareDownload({
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    String? sessionId,
+    String? pin,
+    required RsCancellationToken cancelToken,
+  });
 
   Future<PrepareUploadResult> prepareUpload({
     required ProtocolType protocol,
@@ -119,6 +144,54 @@ class ResultWithPublicKeyRegisterResponseDto {
       other is ResultWithPublicKeyRegisterResponseDto && runtimeType == other.runtimeType && publicKey == other.publicKey && body == other.body;
 }
 
+class RsDownloadDeviceInfo {
+  final String alias;
+  final String version;
+  final String? deviceModel;
+  final DeviceType? deviceType;
+  final String fingerprint;
+  final bool download;
+
+  const RsDownloadDeviceInfo({
+    required this.alias,
+    required this.version,
+    this.deviceModel,
+    this.deviceType,
+    required this.fingerprint,
+    required this.download,
+  });
+
+  @override
+  int get hashCode => alias.hashCode ^ version.hashCode ^ deviceModel.hashCode ^ deviceType.hashCode ^ fingerprint.hashCode ^ download.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RsDownloadDeviceInfo &&
+          runtimeType == other.runtimeType &&
+          alias == other.alias &&
+          version == other.version &&
+          deviceModel == other.deviceModel &&
+          deviceType == other.deviceType &&
+          fingerprint == other.fingerprint &&
+          download == other.download;
+}
+
+@freezed
+sealed class RsDownloadEvent with _$RsDownloadEvent {
+  const RsDownloadEvent._();
+
+  /// Download progress as a fraction from 0.0 through 1.0. Throttled.
+  const factory RsDownloadEvent.progress({
+    required double progress,
+  }) = RsDownloadEvent_Progress;
+
+  /// The download failed. Always the final event.
+  const factory RsDownloadEvent.failed({
+    required RsHttpClientError error,
+  }) = RsDownloadEvent_Failed;
+}
+
 @freezed
 sealed class RsHttpClientError with _$RsHttpClientError implements FrbException {
   const RsHttpClientError._();
@@ -139,6 +212,30 @@ sealed class RsHttpClientError with _$RsHttpClientError implements FrbException 
   const factory RsHttpClientError.other(
     String field0,
   ) = RsHttpClientError_Other;
+}
+
+class RsPrepareDownloadResponse {
+  final RsDownloadDeviceInfo info;
+  final String sessionId;
+  final Map<String, FileDto> files;
+
+  const RsPrepareDownloadResponse({
+    required this.info,
+    required this.sessionId,
+    required this.files,
+  });
+
+  @override
+  int get hashCode => info.hashCode ^ sessionId.hashCode ^ files.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RsPrepareDownloadResponse &&
+          runtimeType == other.runtimeType &&
+          info == other.info &&
+          sessionId == other.sessionId &&
+          files == other.files;
 }
 
 @freezed

--- a/packages/localsend_isolates/lib/rust/api/http.freezed.dart
+++ b/packages/localsend_isolates/lib/rust/api/http.freezed.dart
@@ -176,7 +176,7 @@ return failed(_that.error);case _:
 
 class RsDownloadEvent_Progress extends RsDownloadEvent {
   const RsDownloadEvent_Progress({required this.progress}): super._();
-  
+
 
  final  double progress;
 
@@ -242,7 +242,7 @@ as double,
 
 class RsDownloadEvent_Failed extends RsDownloadEvent {
   const RsDownloadEvent_Failed({required this.error}): super._();
-  
+
 
  final  RsHttpClientError error;
 
@@ -305,7 +305,7 @@ as RsHttpClientError,
 @override
 @pragma('vm:prefer-inline')
 $RsHttpClientErrorCopyWith<$Res> get error {
-  
+
   return $RsHttpClientErrorCopyWith<$Res>(_self.error, (value) {
     return _then(_self.copyWith(error: value));
   });

--- a/packages/localsend_isolates/lib/rust/api/http.freezed.dart
+++ b/packages/localsend_isolates/lib/rust/api/http.freezed.dart
@@ -12,6 +12,307 @@ part of 'http.dart';
 // dart format off
 T _$identity<T>(T value) => value;
 /// @nodoc
+mixin _$RsDownloadEvent {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RsDownloadEvent);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'RsDownloadEvent()';
+}
+
+
+}
+
+/// @nodoc
+class $RsDownloadEventCopyWith<$Res>  {
+$RsDownloadEventCopyWith(RsDownloadEvent _, $Res Function(RsDownloadEvent) __);
+}
+
+
+/// Adds pattern-matching-related methods to [RsDownloadEvent].
+extension RsDownloadEventPatterns on RsDownloadEvent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( RsDownloadEvent_Progress value)?  progress,TResult Function( RsDownloadEvent_Failed value)?  failed,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case RsDownloadEvent_Progress() when progress != null:
+return progress(_that);case RsDownloadEvent_Failed() when failed != null:
+return failed(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( RsDownloadEvent_Progress value)  progress,required TResult Function( RsDownloadEvent_Failed value)  failed,}){
+final _that = this;
+switch (_that) {
+case RsDownloadEvent_Progress():
+return progress(_that);case RsDownloadEvent_Failed():
+return failed(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( RsDownloadEvent_Progress value)?  progress,TResult? Function( RsDownloadEvent_Failed value)?  failed,}){
+final _that = this;
+switch (_that) {
+case RsDownloadEvent_Progress() when progress != null:
+return progress(_that);case RsDownloadEvent_Failed() when failed != null:
+return failed(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( double progress)?  progress,TResult Function( RsHttpClientError error)?  failed,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case RsDownloadEvent_Progress() when progress != null:
+return progress(_that.progress);case RsDownloadEvent_Failed() when failed != null:
+return failed(_that.error);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( double progress)  progress,required TResult Function( RsHttpClientError error)  failed,}) {final _that = this;
+switch (_that) {
+case RsDownloadEvent_Progress():
+return progress(_that.progress);case RsDownloadEvent_Failed():
+return failed(_that.error);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( double progress)?  progress,TResult? Function( RsHttpClientError error)?  failed,}) {final _that = this;
+switch (_that) {
+case RsDownloadEvent_Progress() when progress != null:
+return progress(_that.progress);case RsDownloadEvent_Failed() when failed != null:
+return failed(_that.error);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class RsDownloadEvent_Progress extends RsDownloadEvent {
+  const RsDownloadEvent_Progress({required this.progress}): super._();
+  
+
+ final  double progress;
+
+/// Create a copy of RsDownloadEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RsDownloadEvent_ProgressCopyWith<RsDownloadEvent_Progress> get copyWith => _$RsDownloadEvent_ProgressCopyWithImpl<RsDownloadEvent_Progress>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RsDownloadEvent_Progress&&(identical(other.progress, progress) || other.progress == progress));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,progress);
+
+@override
+String toString() {
+  return 'RsDownloadEvent.progress(progress: $progress)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RsDownloadEvent_ProgressCopyWith<$Res> implements $RsDownloadEventCopyWith<$Res> {
+  factory $RsDownloadEvent_ProgressCopyWith(RsDownloadEvent_Progress value, $Res Function(RsDownloadEvent_Progress) _then) = _$RsDownloadEvent_ProgressCopyWithImpl;
+@useResult
+$Res call({
+ double progress
+});
+
+
+
+
+}
+/// @nodoc
+class _$RsDownloadEvent_ProgressCopyWithImpl<$Res>
+    implements $RsDownloadEvent_ProgressCopyWith<$Res> {
+  _$RsDownloadEvent_ProgressCopyWithImpl(this._self, this._then);
+
+  final RsDownloadEvent_Progress _self;
+  final $Res Function(RsDownloadEvent_Progress) _then;
+
+/// Create a copy of RsDownloadEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? progress = null,}) {
+  return _then(RsDownloadEvent_Progress(
+progress: null == progress ? _self.progress : progress // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class RsDownloadEvent_Failed extends RsDownloadEvent {
+  const RsDownloadEvent_Failed({required this.error}): super._();
+  
+
+ final  RsHttpClientError error;
+
+/// Create a copy of RsDownloadEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RsDownloadEvent_FailedCopyWith<RsDownloadEvent_Failed> get copyWith => _$RsDownloadEvent_FailedCopyWithImpl<RsDownloadEvent_Failed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RsDownloadEvent_Failed&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,error);
+
+@override
+String toString() {
+  return 'RsDownloadEvent.failed(error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RsDownloadEvent_FailedCopyWith<$Res> implements $RsDownloadEventCopyWith<$Res> {
+  factory $RsDownloadEvent_FailedCopyWith(RsDownloadEvent_Failed value, $Res Function(RsDownloadEvent_Failed) _then) = _$RsDownloadEvent_FailedCopyWithImpl;
+@useResult
+$Res call({
+ RsHttpClientError error
+});
+
+
+$RsHttpClientErrorCopyWith<$Res> get error;
+
+}
+/// @nodoc
+class _$RsDownloadEvent_FailedCopyWithImpl<$Res>
+    implements $RsDownloadEvent_FailedCopyWith<$Res> {
+  _$RsDownloadEvent_FailedCopyWithImpl(this._self, this._then);
+
+  final RsDownloadEvent_Failed _self;
+  final $Res Function(RsDownloadEvent_Failed) _then;
+
+/// Create a copy of RsDownloadEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? error = null,}) {
+  return _then(RsDownloadEvent_Failed(
+error: null == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as RsHttpClientError,
+  ));
+}
+
+/// Create a copy of RsDownloadEvent
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RsHttpClientErrorCopyWith<$Res> get error {
+  
+  return $RsHttpClientErrorCopyWith<$Res>(_self.error, (value) {
+    return _then(_self.copyWith(error: value));
+  });
+}
+}
+
+/// @nodoc
 mixin _$RsHttpClientError {
 
 

--- a/packages/localsend_isolates/lib/rust/frb_generated.dart
+++ b/packages/localsend_isolates/lib/rust/frb_generated.dart
@@ -76,7 +76,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1979579466;
+  int get rustContentHash => -1834150773;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'rust_lib_localsend_app',
@@ -150,6 +150,29 @@ abstract class RustLibApi extends BaseApi {
     required String ip,
     required int port,
     required String sessionId,
+  });
+
+  Stream<RsDownloadEvent> crateApiHttpRsHttpClientDownloadToTarget({
+    required RsHttpClient that,
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    required String sessionId,
+    required String fileId,
+    String? path,
+    int? fileDescriptor,
+    required BigInt expectedSize,
+    required RsCancellationToken cancelToken,
+  });
+
+  Future<RsPrepareDownloadResponse> crateApiHttpRsHttpClientPrepareDownload({
+    required RsHttpClient that,
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    String? sessionId,
+    String? pin,
+    required RsCancellationToken cancelToken,
   });
 
   Future<PrepareUploadResult> crateApiHttpRsHttpClientPrepareUpload({
@@ -858,6 +881,95 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Stream<RsDownloadEvent> crateApiHttpRsHttpClientDownloadToTarget({
+    required RsHttpClient that,
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    required String sessionId,
+    required String fileId,
+    String? path,
+    int? fileDescriptor,
+    required BigInt expectedSize,
+    required RsCancellationToken cancelToken,
+  }) {
+    final sink = RustStreamSink<RsDownloadEvent>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpClient(that, serializer);
+            sse_encode_StreamSink_rs_download_event_Sse(sink, serializer);
+            sse_encode_protocol_type(protocol, serializer);
+            sse_encode_String(ip, serializer);
+            sse_encode_u_16(port, serializer);
+            sse_encode_String(sessionId, serializer);
+            sse_encode_String(fileId, serializer);
+            sse_encode_opt_String(path, serializer);
+            sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
+            sse_encode_u_64(expectedSize, serializer);
+            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateApiHttpRsHttpClientDownloadToTargetConstMeta,
+          argValues: [that, sink, protocol, ip, port, sessionId, fileId, path, fileDescriptor, expectedSize, cancelToken],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateApiHttpRsHttpClientDownloadToTargetConstMeta => const TaskConstMeta(
+    debugName: 'RsHttpClient_download_to_target',
+    argNames: ['that', 'sink', 'protocol', 'ip', 'port', 'sessionId', 'fileId', 'path', 'fileDescriptor', 'expectedSize', 'cancelToken'],
+  );
+
+  @override
+  Future<RsPrepareDownloadResponse> crateApiHttpRsHttpClientPrepareDownload({
+    required RsHttpClient that,
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    String? sessionId,
+    String? pin,
+    required RsCancellationToken cancelToken,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpClient(that, serializer);
+          sse_encode_protocol_type(protocol, serializer);
+          sse_encode_String(ip, serializer);
+          sse_encode_u_16(port, serializer);
+          sse_encode_opt_String(sessionId, serializer);
+          sse_encode_opt_String(pin, serializer);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_rs_prepare_download_response,
+          decodeErrorData: sse_decode_rs_http_client_error,
+        ),
+        constMeta: kCrateApiHttpRsHttpClientPrepareDownloadConstMeta,
+        argValues: [that, protocol, ip, port, sessionId, pin, cancelToken],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiHttpRsHttpClientPrepareDownloadConstMeta => const TaskConstMeta(
+    debugName: 'RsHttpClient_prepare_download',
+    argNames: ['that', 'protocol', 'ip', 'port', 'sessionId', 'pin', 'cancelToken'],
+  );
+
+  @override
   Future<PrepareUploadResult> crateApiHttpRsHttpClientPrepareUpload({
     required RsHttpClient that,
     required ProtocolType protocol,
@@ -880,7 +992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_String(publicKey, serializer);
           sse_encode_opt_String(pin, serializer);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_prepare_upload_result,
@@ -915,7 +1027,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(ip, serializer);
           sse_encode_u_16(port, serializer);
           sse_encode_box_autoadd_register_dto(payload, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_result_with_public_key_register_response_dto,
@@ -972,7 +1084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(contentLength, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1015,7 +1127,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1042,7 +1154,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1069,7 +1181,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1097,7 +1209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
             sse_encode_StreamSink_rs_server_event_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1134,7 +1246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(fileId, serializer);
           sse_encode_opt_String(path, serializer);
           sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1174,7 +1286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_String(path, serializer);
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_u_64(fileSize, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1203,7 +1315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_String(sessionId, serializer);
           sse_encode_bool(accept, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1229,7 +1341,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
           sse_encode_opt_list_String(acceptedFileIds, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1254,7 +1366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1279,7 +1391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1307,7 +1419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver(that, serializer);
             sse_encode_StreamSink_list_prim_u_8_strict_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1335,7 +1447,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender(that, serializer);
           sse_encode_list_prim_u_8_loose(data, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1360,7 +1472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1388,7 +1500,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1415,7 +1527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_file_dto,
@@ -1443,7 +1555,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileReceiver_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1473,7 +1585,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1501,7 +1613,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_box_autoadd_rtc_send_file_response(status, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1527,7 +1639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1553,7 +1665,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCReceiveController(that, serializer);
           sse_encode_Set_String_None(selection, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1581,7 +1693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_file_error_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1608,7 +1720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Set_String_None,
@@ -1636,7 +1748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
             sse_encode_StreamSink_rtc_status_Sse(sink, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1664,7 +1776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(fileId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCFileSender,
@@ -1690,7 +1802,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRTCSendController(that, serializer);
           sse_encode_String(pin, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1729,7 +1841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               onConnection,
               serializer,
             );
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1755,7 +1867,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken,
@@ -1790,7 +1902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_ls_http_client_version(version, serializer);
           sse_encode_opt_String(expectedFingerprint, serializer);
           sse_encode_opt_box_autoadd_u_32(timeoutMs, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpClient,
@@ -1814,7 +1926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1839,7 +1951,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1863,7 +1975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_key_pair,
@@ -1887,7 +1999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_security_context,
@@ -1918,7 +2030,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_encode_opt_box_autoadd_i_32(fileDescriptor, serializer);
             sse_encode_opt_list_prim_u_8_strict(bytes, serializer);
             sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsCancellationToken(cancelToken, serializer);
-            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52, port: port_);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54, port: port_);
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
@@ -1945,7 +2057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1970,7 +2082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(path, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_file_metadata,
@@ -1995,7 +2107,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2048,7 +2160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(certPem, serializer);
           sse_encode_String(privateKeyPem, serializer);
           sse_encode_u_64(timeoutMs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsDiscovery,
@@ -2125,7 +2237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_bool(verifyChecksums, serializer);
           sse_encode_box_autoadd_web_params(web, serializer);
           sse_encode_opt_String(showToken, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRsHttpServer,
@@ -2151,7 +2263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cert, serializer);
           sse_encode_String(publicKey, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2518,6 +2630,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Sse(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
+  RustStreamSink<RsDownloadEvent> dco_decode_StreamSink_rs_download_event_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
@@ -3161,6 +3279,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RsDownloadDeviceInfo dco_decode_rs_download_device_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    return RsDownloadDeviceInfo(
+      alias: dco_decode_String(arr[0]),
+      version: dco_decode_String(arr[1]),
+      deviceModel: dco_decode_opt_String(arr[2]),
+      deviceType: dco_decode_opt_box_autoadd_device_type(arr[3]),
+      fingerprint: dco_decode_String(arr[4]),
+      download: dco_decode_bool(arr[5]),
+    );
+  }
+
+  @protected
+  RsDownloadEvent dco_decode_rs_download_event(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return RsDownloadEvent_Progress(
+          progress: dco_decode_f_64(raw[1]),
+        );
+      case 1:
+        return RsDownloadEvent_Failed(
+          error: dco_decode_box_autoadd_rs_http_client_error(raw[1]),
+        );
+      default:
+        throw Exception('unreachable');
+    }
+  }
+
+  @protected
   RsHashFileEvent dco_decode_rs_hash_file_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
@@ -3205,6 +3355,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       default:
         throw Exception('unreachable');
     }
+  }
+
+  @protected
+  RsPrepareDownloadResponse dco_decode_rs_prepare_download_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return RsPrepareDownloadResponse(
+      info: dco_decode_rs_download_device_info(arr[0]),
+      sessionId: dco_decode_String(arr[1]),
+      files: dco_decode_Map_String_file_dto_None(arr[2]),
+    );
   }
 
   @protected
@@ -3805,6 +3967,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Sse(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
+
+  @protected
+  RustStreamSink<RsDownloadEvent> sse_decode_StreamSink_rs_download_event_Sse(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     throw UnimplementedError('Unreachable ()');
   }
@@ -4532,6 +4700,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RsDownloadDeviceInfo sse_decode_rs_download_device_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_alias = sse_decode_String(deserializer);
+    var var_version = sse_decode_String(deserializer);
+    var var_deviceModel = sse_decode_opt_String(deserializer);
+    var var_deviceType = sse_decode_opt_box_autoadd_device_type(deserializer);
+    var var_fingerprint = sse_decode_String(deserializer);
+    var var_download = sse_decode_bool(deserializer);
+    return RsDownloadDeviceInfo(
+      alias: var_alias,
+      version: var_version,
+      deviceModel: var_deviceModel,
+      deviceType: var_deviceType,
+      fingerprint: var_fingerprint,
+      download: var_download,
+    );
+  }
+
+  @protected
+  RsDownloadEvent sse_decode_rs_download_event(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_progress = sse_decode_f_64(deserializer);
+        return RsDownloadEvent_Progress(progress: var_progress);
+      case 1:
+        var var_error = sse_decode_box_autoadd_rs_http_client_error(deserializer);
+        return RsDownloadEvent_Failed(error: var_error);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   RsHashFileEvent sse_decode_rs_hash_file_event(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4573,6 +4777,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       default:
         throw UnimplementedError('');
     }
+  }
+
+  @protected
+  RsPrepareDownloadResponse sse_decode_rs_prepare_download_response(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_info = sse_decode_rs_download_device_info(deserializer);
+    var var_sessionId = sse_decode_String(deserializer);
+    var var_files = sse_decode_Map_String_file_dto_None(deserializer);
+    return RsPrepareDownloadResponse(info: var_info, sessionId: var_sessionId, files: var_files);
   }
 
   @protected
@@ -5230,6 +5443,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       self.setupAndSerialize(
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
+
+  @protected
+  void sse_encode_StreamSink_rs_download_event_Sse(RustStreamSink<RsDownloadEvent> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_rs_download_event,
           decodeErrorData: sse_decode_AnyhowException,
         ),
       ),
@@ -5915,6 +6142,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_rs_download_device_info(RsDownloadDeviceInfo self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.alias, serializer);
+    sse_encode_String(self.version, serializer);
+    sse_encode_opt_String(self.deviceModel, serializer);
+    sse_encode_opt_box_autoadd_device_type(self.deviceType, serializer);
+    sse_encode_String(self.fingerprint, serializer);
+    sse_encode_bool(self.download, serializer);
+  }
+
+  @protected
+  void sse_encode_rs_download_event(RsDownloadEvent self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case RsDownloadEvent_Progress(progress: final progress):
+        sse_encode_i_32(0, serializer);
+        sse_encode_f_64(progress, serializer);
+      case RsDownloadEvent_Failed(error: final error):
+        sse_encode_i_32(1, serializer);
+        sse_encode_box_autoadd_rs_http_client_error(error, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_rs_hash_file_event(RsHashFileEvent self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
@@ -5948,6 +6199,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(4, serializer);
         sse_encode_String(field0, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_rs_prepare_download_response(RsPrepareDownloadResponse self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_rs_download_device_info(self.info, serializer);
+    sse_encode_String(self.sessionId, serializer);
+    sse_encode_Map_String_file_dto_None(self.files, serializer);
   }
 
   @protected
@@ -6448,6 +6707,50 @@ class RsHttpClientImpl extends RustOpaque implements RsHttpClient {
 
   Future<void> cancel({required ProtocolType protocol, required String ip, required int port, required String sessionId}) =>
       RustLib.instance.api.crateApiHttpRsHttpClientCancel(that: this, protocol: protocol, ip: ip, port: port, sessionId: sessionId);
+
+  /// Downloads one reverse-transfer file, emitting progress on [sink].
+  ///
+  /// Failures are stream events for the same reason as [RsHttpClient::upload].
+  Stream<RsDownloadEvent> downloadToTarget({
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    required String sessionId,
+    required String fileId,
+    String? path,
+    int? fileDescriptor,
+    required BigInt expectedSize,
+    required RsCancellationToken cancelToken,
+  }) => RustLib.instance.api.crateApiHttpRsHttpClientDownloadToTarget(
+    that: this,
+    protocol: protocol,
+    ip: ip,
+    port: port,
+    sessionId: sessionId,
+    fileId: fileId,
+    path: path,
+    fileDescriptor: fileDescriptor,
+    expectedSize: expectedSize,
+    cancelToken: cancelToken,
+  );
+
+  /// Requests the sender's reverse-download manifest.
+  Future<RsPrepareDownloadResponse> prepareDownload({
+    required ProtocolType protocol,
+    required String ip,
+    required int port,
+    String? sessionId,
+    String? pin,
+    required RsCancellationToken cancelToken,
+  }) => RustLib.instance.api.crateApiHttpRsHttpClientPrepareDownload(
+    that: this,
+    protocol: protocol,
+    ip: ip,
+    port: port,
+    sessionId: sessionId,
+    pin: pin,
+    cancelToken: cancelToken,
+  );
 
   Future<PrepareUploadResult> prepareUpload({
     required ProtocolType protocol,

--- a/packages/localsend_isolates/lib/rust/frb_generated.io.dart
+++ b/packages/localsend_isolates/lib/rust/frb_generated.io.dart
@@ -195,6 +195,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<RsDownloadEvent> dco_decode_StreamSink_rs_download_event_Sse(dynamic raw);
+
+  @protected
   RustStreamSink<RsHashFileEvent> dco_decode_StreamSink_rs_hash_file_event_Sse(dynamic raw);
 
   @protected
@@ -441,10 +444,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RsDiscoveredDevice dco_decode_rs_discovered_device(dynamic raw);
 
   @protected
+  RsDownloadDeviceInfo dco_decode_rs_download_device_info(dynamic raw);
+
+  @protected
+  RsDownloadEvent dco_decode_rs_download_event(dynamic raw);
+
+  @protected
   RsHashFileEvent dco_decode_rs_hash_file_event(dynamic raw);
 
   @protected
   RsHttpClientError dco_decode_rs_http_client_error(dynamic raw);
+
+  @protected
+  RsPrepareDownloadResponse dco_decode_rs_prepare_download_response(dynamic raw);
 
   @protected
   RsServerEvent dco_decode_rs_server_event(dynamic raw);
@@ -657,6 +669,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Sse(SseDeserializer deserializer);
+
+  @protected
+  RustStreamSink<RsDownloadEvent> sse_decode_StreamSink_rs_download_event_Sse(SseDeserializer deserializer);
 
   @protected
   RustStreamSink<RsHashFileEvent> sse_decode_StreamSink_rs_hash_file_event_Sse(SseDeserializer deserializer);
@@ -907,10 +922,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RsDiscoveredDevice sse_decode_rs_discovered_device(SseDeserializer deserializer);
 
   @protected
+  RsDownloadDeviceInfo sse_decode_rs_download_device_info(SseDeserializer deserializer);
+
+  @protected
+  RsDownloadEvent sse_decode_rs_download_event(SseDeserializer deserializer);
+
+  @protected
   RsHashFileEvent sse_decode_rs_hash_file_event(SseDeserializer deserializer);
 
   @protected
   RsHttpClientError sse_decode_rs_http_client_error(SseDeserializer deserializer);
+
+  @protected
+  RsPrepareDownloadResponse sse_decode_rs_prepare_download_response(SseDeserializer deserializer);
 
   @protected
   RsServerEvent sse_decode_rs_server_event(SseDeserializer deserializer);
@@ -1169,6 +1193,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_StreamSink_list_prim_u_8_strict_Sse(RustStreamSink<Uint8List> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_StreamSink_rs_download_event_Sse(RustStreamSink<RsDownloadEvent> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_StreamSink_rs_hash_file_event_Sse(RustStreamSink<RsHashFileEvent> self, SseSerializer serializer);
 
   @protected
@@ -1419,10 +1446,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_rs_discovered_device(RsDiscoveredDevice self, SseSerializer serializer);
 
   @protected
+  void sse_encode_rs_download_device_info(RsDownloadDeviceInfo self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_rs_download_event(RsDownloadEvent self, SseSerializer serializer);
+
+  @protected
   void sse_encode_rs_hash_file_event(RsHashFileEvent self, SseSerializer serializer);
 
   @protected
   void sse_encode_rs_http_client_error(RsHttpClientError self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_rs_prepare_download_response(RsPrepareDownloadResponse self, SseSerializer serializer);
 
   @protected
   void sse_encode_rs_server_event(RsServerEvent self, SseSerializer serializer);

--- a/packages/localsend_isolates/lib/rust/frb_generated.web.dart
+++ b/packages/localsend_isolates/lib/rust/frb_generated.web.dart
@@ -197,6 +197,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<RsDownloadEvent> dco_decode_StreamSink_rs_download_event_Sse(dynamic raw);
+
+  @protected
   RustStreamSink<RsHashFileEvent> dco_decode_StreamSink_rs_hash_file_event_Sse(dynamic raw);
 
   @protected
@@ -443,10 +446,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RsDiscoveredDevice dco_decode_rs_discovered_device(dynamic raw);
 
   @protected
+  RsDownloadDeviceInfo dco_decode_rs_download_device_info(dynamic raw);
+
+  @protected
+  RsDownloadEvent dco_decode_rs_download_event(dynamic raw);
+
+  @protected
   RsHashFileEvent dco_decode_rs_hash_file_event(dynamic raw);
 
   @protected
   RsHttpClientError dco_decode_rs_http_client_error(dynamic raw);
+
+  @protected
+  RsPrepareDownloadResponse dco_decode_rs_prepare_download_response(dynamic raw);
 
   @protected
   RsServerEvent dco_decode_rs_server_event(dynamic raw);
@@ -659,6 +671,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Sse(SseDeserializer deserializer);
+
+  @protected
+  RustStreamSink<RsDownloadEvent> sse_decode_StreamSink_rs_download_event_Sse(SseDeserializer deserializer);
 
   @protected
   RustStreamSink<RsHashFileEvent> sse_decode_StreamSink_rs_hash_file_event_Sse(SseDeserializer deserializer);
@@ -909,10 +924,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RsDiscoveredDevice sse_decode_rs_discovered_device(SseDeserializer deserializer);
 
   @protected
+  RsDownloadDeviceInfo sse_decode_rs_download_device_info(SseDeserializer deserializer);
+
+  @protected
+  RsDownloadEvent sse_decode_rs_download_event(SseDeserializer deserializer);
+
+  @protected
   RsHashFileEvent sse_decode_rs_hash_file_event(SseDeserializer deserializer);
 
   @protected
   RsHttpClientError sse_decode_rs_http_client_error(SseDeserializer deserializer);
+
+  @protected
+  RsPrepareDownloadResponse sse_decode_rs_prepare_download_response(SseDeserializer deserializer);
 
   @protected
   RsServerEvent sse_decode_rs_server_event(SseDeserializer deserializer);
@@ -1171,6 +1195,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_StreamSink_list_prim_u_8_strict_Sse(RustStreamSink<Uint8List> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_StreamSink_rs_download_event_Sse(RustStreamSink<RsDownloadEvent> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_StreamSink_rs_hash_file_event_Sse(RustStreamSink<RsHashFileEvent> self, SseSerializer serializer);
 
   @protected
@@ -1421,10 +1448,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_rs_discovered_device(RsDiscoveredDevice self, SseSerializer serializer);
 
   @protected
+  void sse_encode_rs_download_device_info(RsDownloadDeviceInfo self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_rs_download_event(RsDownloadEvent self, SseSerializer serializer);
+
+  @protected
   void sse_encode_rs_hash_file_event(RsHashFileEvent self, SseSerializer serializer);
 
   @protected
   void sse_encode_rs_http_client_error(RsHttpClientError self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_rs_prepare_download_response(RsPrepareDownloadResponse self, SseSerializer serializer);
 
   @protected
   void sse_encode_rs_server_event(RsServerEvent self, SseSerializer serializer);

--- a/packages/localsend_isolates/rust/src/api/http.rs
+++ b/packages/localsend_isolates/rust/src/api/http.rs
@@ -8,8 +8,10 @@ pub use localsend::http::dto::{
     RegisterDto, RegisterResponseDto,
 };
 use localsend::model::discovery::ProtocolType;
+use localsend::model::transfer::FileDto;
 use localsend::reqwest;
 use localsend::util::error::ErrorChain;
+use std::collections::HashMap;
 
 pub struct RsHttpClient {
     inner: localsend::http::client::LsHttpClient,
@@ -86,6 +88,135 @@ impl RsHttpClient {
             .map_err(RsHttpClientError::from)?;
 
         Ok(response)
+    }
+
+    /// Requests the sender's reverse-download manifest.
+    pub async fn prepare_download(
+        &self,
+        protocol: ProtocolType,
+        ip: &str,
+        port: u16,
+        session_id: Option<String>,
+        pin: Option<String>,
+        cancel_token: &RsCancellationToken,
+    ) -> Result<RsPrepareDownloadResponse, RsHttpClientError> {
+        let client = match &self.inner {
+            localsend::http::client::LsHttpClient::V2(client) => client,
+            localsend::http::client::LsHttpClient::V3(_) => {
+                return Err(RsHttpClientError::Other(
+                    "The Download API is only available in LocalSend protocol v2".into(),
+                ));
+            }
+        };
+        let response = client
+            .prepare_download_with_cancel(
+                protocol,
+                ip,
+                port,
+                session_id.as_deref(),
+                pin.as_deref(),
+                cancel_token.inner.clone(),
+            )
+            .await
+            .map_err(|error| match error {
+                ClientError::Cancelled => {
+                    RsHttpClientError::Other("Download preparation cancelled".to_string())
+                }
+                error => RsHttpClientError::from(error),
+            })?;
+
+        Ok(RsPrepareDownloadResponse {
+            info: RsDownloadDeviceInfo {
+                alias: response.info.alias,
+                version: response.info.version,
+                device_model: response.info.device_model,
+                device_type: response.info.device_type,
+                fingerprint: response.info.fingerprint,
+                download: response.info.download,
+            },
+            session_id: response.session_id,
+            files: response.files,
+        })
+    }
+
+    /// Downloads one reverse-transfer file, emitting progress on [sink].
+    ///
+    /// Failures are stream events for the same reason as [RsHttpClient::upload].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn download_to_target(
+        &self,
+        sink: StreamSink<RsDownloadEvent>,
+        protocol: ProtocolType,
+        ip: &str,
+        port: u16,
+        session_id: &str,
+        file_id: &str,
+        path: Option<String>,
+        file_descriptor: Option<i32>,
+        expected_size: u64,
+        cancel_token: &RsCancellationToken,
+    ) {
+        let result = async {
+            let client = match &self.inner {
+                localsend::http::client::LsHttpClient::V2(client) => client,
+                localsend::http::client::LsHttpClient::V3(_) => {
+                    return Err(RsHttpClientError::Other(
+                        "The Download API is only available in LocalSend protocol v2".into(),
+                    ));
+                }
+            };
+            let target = resolve_download_target(path, file_descriptor)?;
+            let (progress_tx, mut progress_rx) = tokio::sync::mpsc::channel::<u64>(16);
+            let progress_sink = sink.clone();
+            let progress_task = tokio::spawn(async move {
+                let mut last_emit = None::<std::time::Instant>;
+                while let Some(received) = progress_rx.recv().await {
+                    let now = std::time::Instant::now();
+                    let is_final = received >= expected_size;
+                    if !is_final
+                        && last_emit.is_some_and(|last| {
+                            now.duration_since(last) < std::time::Duration::from_millis(20)
+                        })
+                    {
+                        continue;
+                    }
+                    last_emit = Some(now);
+                    let progress = if expected_size == 0 {
+                        1.0
+                    } else {
+                        (received as f64 / expected_size as f64).min(1.0)
+                    };
+                    let _ = progress_sink.add(RsDownloadEvent::Progress { progress });
+                }
+            });
+
+            let download_result = client
+                .download_to_target(
+                    protocol,
+                    ip,
+                    port,
+                    session_id,
+                    file_id,
+                    target,
+                    expected_size,
+                    Some(progress_tx),
+                    cancel_token.inner.clone(),
+                )
+                .await
+                .map_err(|error| match error {
+                    ClientError::Cancelled => {
+                        RsHttpClientError::Other("Download cancelled".to_string())
+                    }
+                    error => RsHttpClientError::from(error),
+                });
+            let _ = progress_task.await;
+            download_result
+        }
+        .await;
+
+        if let Err(error) = result {
+            let _ = sink.add(RsDownloadEvent::Failed { error });
+        }
     }
 
     /// Uploads a single file, emitting [RsUploadEvent]s on [sink].
@@ -174,6 +305,38 @@ impl RsHttpClient {
     }
 }
 
+fn resolve_download_target(
+    path: Option<String>,
+    file_descriptor: Option<i32>,
+) -> Result<localsend::http::client::v2::FileDownloadTarget, RsHttpClientError> {
+    match (path, file_descriptor) {
+        (Some(path), None) => Ok(localsend::http::client::v2::FileDownloadTarget::Path(
+            path.into(),
+        )),
+        (None, Some(file_descriptor)) => {
+            #[cfg(target_os = "android")]
+            {
+                use std::os::fd::FromRawFd;
+
+                // SAFETY: the Dart caller transfers ownership to this operation.
+                // OwnedFd closes it on every success and early-return path.
+                let fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(file_descriptor) };
+                Ok(localsend::http::client::v2::FileDownloadTarget::Fd(fd))
+            }
+            #[cfg(not(target_os = "android"))]
+            {
+                let _ = file_descriptor;
+                Err(RsHttpClientError::Other(
+                    "File descriptors are only supported on Android".into(),
+                ))
+            }
+        }
+        _ => Err(RsHttpClientError::Other(
+            "Exactly one download destination must be provided".into(),
+        )),
+    }
+}
+
 fn resolve_file_content(
     binary: Option<stream::Dart2RustStreamReceiver>,
     path: Option<String>,
@@ -210,6 +373,31 @@ pub enum RsUploadEvent {
     Progress { progress: f64 },
 
     /// The upload failed. Always the last event of the stream.
+    Failed { error: RsHttpClientError },
+}
+
+pub struct RsPrepareDownloadResponse {
+    pub info: RsDownloadDeviceInfo,
+    pub session_id: String,
+    pub files: HashMap<String, FileDto>,
+}
+
+pub struct RsDownloadDeviceInfo {
+    pub alias: String,
+    pub version: String,
+    pub device_model: Option<String>,
+    pub device_type: Option<localsend::model::discovery::DeviceType>,
+    pub fingerprint: String,
+    pub download: bool,
+}
+
+/// An event emitted while a reverse-transfer file is downloaded.
+#[derive(Clone)]
+pub enum RsDownloadEvent {
+    /// Download progress as a fraction from 0.0 through 1.0. Throttled.
+    Progress { progress: f64 },
+
+    /// The download failed. Always the final event.
     Failed { error: RsHttpClientError },
 }
 

--- a/packages/localsend_isolates/rust/src/frb_generated.rs
+++ b/packages/localsend_isolates/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1979579466;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1834150773;
 
 // Section: executor
 
@@ -996,6 +996,189 @@ fn wire__crate__api__http__RsHttpClient_cancel_impl(
                             &api_ip,
                             api_port,
                             &api_session_id,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__http__RsHttpClient_download_to_target_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "RsHttpClient_download_to_target",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsHttpClient>,
+            >>::sse_decode(&mut deserializer);
+            let api_sink = <StreamSink<
+                crate::api::http::RsDownloadEvent,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            let api_protocol = <crate::api::model::ProtocolType>::sse_decode(&mut deserializer);
+            let api_ip = <String>::sse_decode(&mut deserializer);
+            let api_port = <u16>::sse_decode(&mut deserializer);
+            let api_session_id = <String>::sse_decode(&mut deserializer);
+            let api_file_id = <String>::sse_decode(&mut deserializer);
+            let api_path = <Option<String>>::sse_decode(&mut deserializer);
+            let api_file_descriptor = <Option<i32>>::sse_decode(&mut deserializer);
+            let api_expected_size = <u64>::sse_decode(&mut deserializer);
+            let api_cancel_token = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsCancellationToken>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let mut api_cancel_token_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![
+                                    flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                        &api_that, 0, false,
+                                    ),
+                                    flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                        &api_cancel_token,
+                                        1,
+                                        false,
+                                    ),
+                                ],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                1 => {
+                                    api_cancel_token_guard =
+                                        Some(api_cancel_token.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let api_cancel_token_guard = api_cancel_token_guard.unwrap();
+                        let output_ok = Result::<_, ()>::Ok({
+                            crate::api::http::RsHttpClient::download_to_target(
+                                &*api_that_guard,
+                                api_sink,
+                                api_protocol,
+                                &api_ip,
+                                api_port,
+                                &api_session_id,
+                                &api_file_id,
+                                api_path,
+                                api_file_descriptor,
+                                api_expected_size,
+                                &*api_cancel_token_guard,
+                            )
+                            .await;
+                        })?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__http__RsHttpClient_prepare_download_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "RsHttpClient_prepare_download",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsHttpClient>,
+            >>::sse_decode(&mut deserializer);
+            let api_protocol = <crate::api::model::ProtocolType>::sse_decode(&mut deserializer);
+            let api_ip = <String>::sse_decode(&mut deserializer);
+            let api_port = <u16>::sse_decode(&mut deserializer);
+            let api_session_id = <Option<String>>::sse_decode(&mut deserializer);
+            let api_pin = <Option<String>>::sse_decode(&mut deserializer);
+            let api_cancel_token = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RsCancellationToken>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::http::RsHttpClientError>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let mut api_cancel_token_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![
+                                    flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                        &api_that, 0, false,
+                                    ),
+                                    flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                        &api_cancel_token,
+                                        1,
+                                        false,
+                                    ),
+                                ],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                1 => {
+                                    api_cancel_token_guard =
+                                        Some(api_cancel_token.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let api_cancel_token_guard = api_cancel_token_guard.unwrap();
+                        let output_ok = crate::api::http::RsHttpClient::prepare_download(
+                            &*api_that_guard,
+                            api_protocol,
+                            &api_ip,
+                            api_port,
+                            api_session_id,
+                            api_pin,
+                            &*api_cancel_token_guard,
                         )
                         .await?;
                         Ok(output_ok)
@@ -3895,6 +4078,16 @@ impl SseDecode for StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::SseCo
 }
 
 impl SseDecode
+    for StreamSink<crate::api::http::RsDownloadEvent, flutter_rust_bridge::for_generated::SseCodec>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
+impl SseDecode
     for StreamSink<
         crate::api::crypto::RsHashFileEvent,
         flutter_rust_bridge::for_generated::SseCodec,
@@ -4631,6 +4824,48 @@ impl SseDecode for crate::api::discovery::RsDiscoveredDevice {
     }
 }
 
+impl SseDecode for crate::api::http::RsDownloadDeviceInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_alias = <String>::sse_decode(deserializer);
+        let mut var_version = <String>::sse_decode(deserializer);
+        let mut var_deviceModel = <Option<String>>::sse_decode(deserializer);
+        let mut var_deviceType = <Option<crate::api::model::DeviceType>>::sse_decode(deserializer);
+        let mut var_fingerprint = <String>::sse_decode(deserializer);
+        let mut var_download = <bool>::sse_decode(deserializer);
+        return crate::api::http::RsDownloadDeviceInfo {
+            alias: var_alias,
+            version: var_version,
+            device_model: var_deviceModel,
+            device_type: var_deviceType,
+            fingerprint: var_fingerprint,
+            download: var_download,
+        };
+    }
+}
+
+impl SseDecode for crate::api::http::RsDownloadEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_progress = <f64>::sse_decode(deserializer);
+                return crate::api::http::RsDownloadEvent::Progress {
+                    progress: var_progress,
+                };
+            }
+            1 => {
+                let mut var_error = <crate::api::http::RsHttpClientError>::sse_decode(deserializer);
+                return crate::api::http::RsDownloadEvent::Failed { error: var_error };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseDecode for crate::api::crypto::RsHashFileEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4684,6 +4919,23 @@ impl SseDecode for crate::api::http::RsHttpClientError {
                 unimplemented!("");
             }
         }
+    }
+}
+
+impl SseDecode for crate::api::http::RsPrepareDownloadResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_info = <crate::api::http::RsDownloadDeviceInfo>::sse_decode(deserializer);
+        let mut var_sessionId = <String>::sse_decode(deserializer);
+        let mut var_files =
+            <std::collections::HashMap<String, crate::api::model::FileDto>>::sse_decode(
+                deserializer,
+            );
+        return crate::api::http::RsPrepareDownloadResponse {
+            info: var_info,
+            session_id: var_sessionId,
+            files: var_files,
+        };
     }
 }
 
@@ -5202,168 +5454,180 @@ fn pde_ffi_dispatcher_primary_impl(
         ),
         15 => wire__crate__api__discovery__RsDiscovery_stop_impl(port, ptr, rust_vec_len, data_len),
         16 => wire__crate__api__http__RsHttpClient_cancel_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
+        17 => wire__crate__api__http__RsHttpClient_download_to_target_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        18 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
+        18 => wire__crate__api__http__RsHttpClient_prepare_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        21 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
+        19 => wire__crate__api__http__RsHttpClient_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        22 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
+        20 => wire__crate__api__http__RsHttpClient_register_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__http__RsHttpClient_upload_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__server__RsHttpServer_cancel_session_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
+        23 => wire__crate__api__server__RsHttpServer_fail_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        25 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
+        24 => wire__crate__api__server__RsHttpServer_fail_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        26 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
+        25 => wire__crate__api__server__RsHttpServer_listen_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__server__RsHttpServer_respond_file_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        27 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
+        27 => wire__crate__api__server__RsHttpServer_respond_file_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
+        28 => wire__crate__api__server__RsHttpServer_respond_prepare_download_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
+        29 => wire__crate__api__server__RsHttpServer_respond_prepare_upload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
+        30 => wire__crate__api__server__RsHttpServer_stop_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__webrtc__RtcFileReceiver_get_file_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
+        32 => wire__crate__api__webrtc__RtcFileReceiver_receive_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
+        33 => wire__crate__api__webrtc__RtcFileSender_send_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__webrtc__RtcReceiveController_decline_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
+        35 => wire__crate__api__webrtc__RtcReceiveController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
+        36 => wire__crate__api__webrtc__RtcReceiveController_listen_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
+        37 => wire__crate__api__webrtc__RtcReceiveController_listen_receiving_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
+        38 => wire__crate__api__webrtc__RtcReceiveController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
+        39 => wire__crate__api__webrtc__RtcReceiveController_send_file_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
+        40 => wire__crate__api__webrtc__RtcReceiveController_send_pin_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
+        41 => wire__crate__api__webrtc__RtcReceiveController_send_selection_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
+        42 => wire__crate__api__webrtc__RtcSendController_listen_error_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
+        43 => wire__crate__api__webrtc__RtcSendController_listen_selected_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
+        44 => wire__crate__api__webrtc__RtcSendController_listen_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        45 => wire__crate__api__webrtc__RtcSendController_send_file_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        46 => wire__crate__api__webrtc__RtcSendController_send_pin_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        47 => wire__crate__api__webrtc__connect_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__stream__create_stream_impl(port, ptr, rust_vec_len, data_len),
+        51 => {
             wire__crate__api__logging__enable_debug_logging_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__crypto__generate_security_context_impl(
+        52 => wire__crate__api__crypto__generate_key_pair_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__crypto__generate_security_context_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
-        54 => {
+        54 => wire__crate__api__crypto__hash_file_impl(port, ptr, rust_vec_len, data_len),
+        56 => {
             wire__crate__api__metadata__read_file_metadata_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__discovery__start_discovery_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__server__start_server_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__crypto__verify_cert_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5378,10 +5642,10 @@ fn pde_ffi_dispatcher_sync_impl(
     match func_id {
         2 => wire__crate__api__stream__Dart2RustStreamSink_close_impl(ptr, rust_vec_len, data_len),
         6 => wire__crate__api__cancel__RsCancellationToken_cancel_impl(ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__cancel__create_cancellation_token_impl(ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__http__create_client_impl(ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__filename__is_valid_file_name_impl(ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__filename__sanitize_file_name_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6074,6 +6338,58 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::discovery::RsDiscoveredDevice
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::http::RsDownloadDeviceInfo {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.alias.into_into_dart().into_dart(),
+            self.version.into_into_dart().into_dart(),
+            self.device_model.into_into_dart().into_dart(),
+            self.device_type.into_into_dart().into_dart(),
+            self.fingerprint.into_into_dart().into_dart(),
+            self.download.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::http::RsDownloadDeviceInfo
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::http::RsDownloadDeviceInfo>
+    for crate::api::http::RsDownloadDeviceInfo
+{
+    fn into_into_dart(self) -> crate::api::http::RsDownloadDeviceInfo {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::http::RsDownloadEvent {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::http::RsDownloadEvent::Progress { progress } => {
+                [0.into_dart(), progress.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::http::RsDownloadEvent::Failed { error } => {
+                [1.into_dart(), error.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::http::RsDownloadEvent
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::http::RsDownloadEvent>
+    for crate::api::http::RsDownloadEvent
+{
+    fn into_into_dart(self) -> crate::api::http::RsDownloadEvent {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::crypto::RsHashFileEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -6136,6 +6452,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::http::RsHttpClientError>
     for crate::api::http::RsHttpClientError
 {
     fn into_into_dart(self) -> crate::api::http::RsHttpClientError {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::http::RsPrepareDownloadResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.info.into_into_dart().into_dart(),
+            self.session_id.into_into_dart().into_dart(),
+            self.files.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::http::RsPrepareDownloadResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::http::RsPrepareDownloadResponse>
+    for crate::api::http::RsPrepareDownloadResponse
+{
+    fn into_into_dart(self) -> crate::api::http::RsPrepareDownloadResponse {
         self
     }
 }
@@ -6869,6 +7207,15 @@ impl SseEncode for StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::SseCo
 }
 
 impl SseEncode
+    for StreamSink<crate::api::http::RsDownloadEvent, flutter_rust_bridge::for_generated::SseCodec>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
+    }
+}
+
+impl SseEncode
     for StreamSink<
         crate::api::crypto::RsHashFileEvent,
         flutter_rust_bridge::for_generated::SseCodec,
@@ -7464,6 +7811,37 @@ impl SseEncode for crate::api::discovery::RsDiscoveredDevice {
     }
 }
 
+impl SseEncode for crate::api::http::RsDownloadDeviceInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.alias, serializer);
+        <String>::sse_encode(self.version, serializer);
+        <Option<String>>::sse_encode(self.device_model, serializer);
+        <Option<crate::api::model::DeviceType>>::sse_encode(self.device_type, serializer);
+        <String>::sse_encode(self.fingerprint, serializer);
+        <bool>::sse_encode(self.download, serializer);
+    }
+}
+
+impl SseEncode for crate::api::http::RsDownloadEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::http::RsDownloadEvent::Progress { progress } => {
+                <i32>::sse_encode(0, serializer);
+                <f64>::sse_encode(progress, serializer);
+            }
+            crate::api::http::RsDownloadEvent::Failed { error } => {
+                <i32>::sse_encode(1, serializer);
+                <crate::api::http::RsHttpClientError>::sse_encode(error, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::api::crypto::RsHashFileEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7512,6 +7890,17 @@ impl SseEncode for crate::api::http::RsHttpClientError {
                 unimplemented!("");
             }
         }
+    }
+}
+
+impl SseEncode for crate::api::http::RsPrepareDownloadResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::http::RsDownloadDeviceInfo>::sse_encode(self.info, serializer);
+        <String>::sse_encode(self.session_id, serializer);
+        <std::collections::HashMap<String, crate::api::model::FileDto>>::sse_encode(
+            self.files, serializer,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Add a no-install iPhone-to-Android media sender using an iOS App Clip while preserving LocalSend's existing LAN flows.

- expose LocalSend v2 reverse-download preparation and exact-size downloads through the existing Rust/Flutter bridge
- add an Android `Receive from App Clip` host with foreground LocalOnlyHotspot ownership, optional Type-4 HCE plus QR fallback, authenticated one-shot bootstrap, explicit offer approval, cancellation, and failed-file retry
- add a small native SwiftUI App Clip that stages selected photos/videos, joins the private hotspot, serves bounded LocalSend v2 reverse downloads, and cleans up on every terminal path
- handle the same universal-link invocation in the installed iOS Runner, as required when the full app replaces the clip
- configure the production invocation prefix `https://localsend.org/clip`, associated domain, capabilities, deployment checklist, protocol tests, and macOS CI

The production website half is [LocalSend website PR #185](https://github.com/localsend/website/pull/185).

Apple documents that configured App Clip experiences support invocation by both [QR code and NFC](https://developer.apple.com/documentation/appclip/configuring-the-launch-experience-of-your-app-clip), including URL parameters for the default associated-website and advanced-experience paths.

## What the App Clip does

`LocalSendClip` is a small native SwiftUI target embedded in the iOS LocalSend app, but iOS can launch that target on demand for an iPhone that does not have LocalSend installed. The Android phone does not transmit the media over NFC. It exposes a short-lived `https://localsend.org/clip?...` invocation URL as one NFC Type-4 NDEF URI record and as a QR code.

For that URL to open the clip, the companion website PR must deploy the matching AASA file and `/clip` metadata, and the LocalSend release must configure the corresponding App Clip experience in App Store Connect. When the user taps the NFC notification or scans the QR, iOS presents the LocalSend App Clip card; opening it launches `LocalSendClip` with the complete invocation URL. If the full LocalSend iOS app is already installed, iOS launches Runner instead, and Runner presents the same native sender flow from the same URL.

The invocation URL is an ephemeral bearer capability, not a public download link. It contains the contract version, 16-byte session ID, 32-byte session key, hotspot SSID/passphrase, one to four Android private IPv4 bootstrap candidates, the Android bootstrap port, and the Android display name. Both iOS entry points reject a wrong origin or path, missing/duplicate/unknown fields, invalid encodings, non-private hosts, out-of-range ports, and an overlong URL before showing the sender UI. The URL is never logged or persisted.

The App Clip then lets the iPhone user choose photos and videos with the system PhotosPicker, copies every chosen item into temporary clip-owned storage while internet access is still available, asks the user to join Android's temporary Wi-Fi network, and serves those staged files until Android has downloaded them. It does not need Photo Library permission, does not place transfer bytes in NFC/QR/WebKit, and does not change LocalSend's normal LAN discovery or upload flow.

## What the two users tap

**Supported direction:** this is the sending flow from an iPhone to an Android phone. The iPhone can send selected photos and videos without installing the full LocalSend app. This PR does not add no-install receiving on iPhone or Android-to-iPhone transfer.

1. **On Android:** Open LocalSend, tap **Receive**, then tap **Receive from iPhone**. Grant the nearby-Wi-Fi/location and notification permissions if Android asks. Leave the QR/NFC screen open.
2. **On iPhone with NFC:** Unlock the iPhone and hold it near the Android phone's NFC area until the LocalSend App Clip appears. Apple’s [iPhone App Clip instructions](https://support.apple.com/guide/iphone/use-app-clips-iphb3a73ec53/ios) then require the user to tap **Open** or **Play**.
3. **Or use QR instead:** Open the iPhone Camera or Code Scanner, scan the QR shown by Android, tap the result, then tap **Open** or **Play** when the LocalSend App Clip appears.
4. **On iPhone:** Tap **Choose photos and videos**, select the items to send, return to LocalSend, and tap **Send**.
5. **On iPhone:** Approve the iOS system prompt to join the temporary private Wi-Fi network. Keep the App Clip in the foreground while it shows **Waiting for acceptance**.
6. **On Android:** When the file offer appears, review it and tap **Accept** to start saving the files, or **Decline** to stop. No file bytes are requested before **Accept**.
7. **If a file fails:** Tap **Retry failed files** on Android. Completed files are not downloaded again. The iPhone user can tap **Try again** after a terminal sender failure.
8. **When finished:** Android shows **Done** after every accepted file passes its byte-count check. The iPhone shows **Sent** after Android has downloaded every selected item.

## Ordered end-to-end flow

1. **Android user starts the session.** In LocalSend's Receive tab, the user chooses **Receive from iPhone**. Flutter checks Android version, hotspot support, notification permission, nearby-Wi-Fi/location permission, and whether HCE is available. HCE is optional because QR remains the fallback.
2. **Android creates one attempt.** Flutter starts `AppClipHostService`. The service generates a new 16-byte session ID and 32-byte session key with `SecureRandom`; a previous attempt's values are never reused.
3. **Android creates the private network.** The foreground service starts `LocalOnlyHotspot`, obtains the OS-generated SSID and passphrase, and discovers up to four newly appeared RFC1918 IPv4 addresses from the live interfaces instead of assuming a gateway address.
4. **Android opens the bootstrap endpoint.** `AppClipBootstrapServer` binds an ephemeral TCP port on the hotspot interfaces. This endpoint carries only the authenticated rendezvous message; it never carries media.
5. **Android builds the invocation capability.** The service constructs the bounded `https://localsend.org/clip` URL containing `v`, `sid`, `k`, `ssid`, `pass`, `hosts`, `bp`, and `name`. It arms HCE with exactly one read-only NFC Forum URI record and returns the identical URL to Flutter for QR rendering.
6. **iPhone invokes LocalSend.** The unlocked iPhone reads the NFC URI or scans the QR. After the configured website/App Store association resolves, iOS presents the LocalSend App Clip card. Opening the card launches `LocalSendClip`; an installed LocalSend app launches Runner and its shared sender instead.
7. **iOS validates before use.** The App Clip/Runner verifies the exact HTTPS origin and `/clip` path, unique bounded query fields, decoded key lengths, canonical private IPv4 candidates, and port ranges. Any mismatch ends the attempt without joining Wi-Fi or contacting an arbitrary host.
8. **iPhone user selects media.** PhotosPicker returns only the photos/videos explicitly chosen by the user. The sender copies every item to its temporary directory and records the exact file name, MIME type, ID, and byte size. If any selected item cannot be staged, the send attempt stops visibly before the network switch.
9. **iPhone user presses Send.** The sender calls `NEHotspotConfiguration` with the ephemeral SSID/passphrase and `joinOnce: true`. iOS shows its system Wi-Fi approval UI; declining it ends the attempt and leaves no listener running.
10. **iPhone becomes the file server.** After the join succeeds, the sender starts a Wi-Fi-only `NWListener` on an ephemeral port. It exposes only LocalSend v2 `prepare-download`, `download`, and `cancel` endpoints for this one attempt and streams files from temporary storage in bounded chunks.
11. **iPhone authenticates its callback.** The sender derives the reverse-download PIN locally from the session key. It then creates the exact 75-byte bootstrap body: version, session ID, listener port, issue time, fresh 16-byte nonce, and HMAC-SHA256 over the preceding bytes.
12. **WebKit crosses the App Clip local-network boundary.** A nonpersistent `WKWebView` sends `POST /api/localsend/app-clip/v1/bootstrap` with `application/octet-stream` to each exact Android private-IP candidate from the invocation URL. Redirects, popups, credentials, downloads, hostname targets, and every other origin are rejected.
13. **Android authenticates once.** The bootstrap listener accepts exactly 75 bytes, verifies the active session ID, 120-second freshness window, unused nonce, and HMAC in constant time, and records the iPhone IP from the accepted socket rather than trusting the request body. A valid first request gets HTTP 202; replay gets 409; bad authentication gets 403; malformed input gets 400.
14. **Android hands the connection to Flutter.** The service publishes only `{sessionId, peerIp, peerPort, downloadToken}`. It retains that result until Flutter acknowledges it, so Activity recreation cannot discard a successful bootstrap.
15. **Android requests the offer.** Flutter creates LocalSend's existing v2 HTTP client in plain-HTTP mode for the private hotspot and sends `POST /api/localsend/v2/prepare-download?pin=<derivedToken>` to the iPhone listener.
16. **The App Clip returns the manifest.** The sender validates the token and requesting peer, creates one LocalSend session, and returns the standard `PrepareDownloadResponseDtoV2` containing iPhone device metadata plus the exact staged file map. No file bytes move yet.
17. **Android asks the user.** LocalSend converts the manifest into its incoming-transfer model and shows the normal receive confirmation UI. The Android user can accept the complete offer or decline it; the App Clip never silently writes files to Android.
18. **Android prepares real save targets.** After acceptance, Flutter creates each normal LocalSend destination path or Android SAF file descriptor before requesting that file. Destination naming and receive history stay in LocalSend's existing save pipeline.
19. **Android downloads each accepted file.** Rust sends `GET /api/localsend/v2/download?sessionId=<id>&fileId=<id>`, streams directly into the prepared target, reports throttled progress, and verifies that the received byte count exactly matches the manifest. The App Clip serves only known IDs to the one authenticated receiver IP/session.
20. **Failures remain actionable.** Completed files enter receive history. A failed file stays visible and can be retried against its already established session without repeating bootstrap, redownloading completed files, or creating a duplicate destination. Android decline/cancel sends `POST /api/localsend/v2/cancel?sessionId=<id>` best-effort and cancels pending writes.
21. **Both sides settle every terminal path.** On complete success, decline, cancellation, timeout, backgrounding, or terminal failure, Android idempotently cancels pending work, disarms HCE, closes the bootstrap listener, releases the hotspot, and stops the foreground notification. The iOS sender closes its listener, removes the ephemeral hotspot configuration, deletes staged files, and shows the matching terminal result. Success is shown only after every accepted file has been downloaded and byte-count validated.

The byte-level URL, NDEF, bootstrap, LocalSend endpoint, size, timeout, replay, lifecycle, and cleanup contracts are in `docs/APP_CLIP_DESIGN.md`.

## Security properties

- strict URL origin/path and unique-field parsing; unknown fields fail closed
- canonical RFC1918 IPv4 candidates only
- 16-byte session ID, 32-byte key, 16-byte nonce, bounded clock skew, one-shot nonce replay cache, and constant-time HMAC checks
- derived download PIN, one accepted receiver IP/session, exact file IDs and byte counts, bounded headers/request count/file count/session size
- no credential/session logging or persistence; nonpersistent WebKit data store; idempotent teardown

## Verification completed locally

- focused Rust reverse-download tests: 13 passed
- Rust bridge build/check passed; repository CI clippy command exited 0 with pre-existing warnings only
- `localsend_isolates` Flutter tests: 20 passed, 1 pre-existing Linux skip
- app Flutter tests: 71 passed
- targeted Dart analysis: clean
- plist/entitlement/scheme XML parsing and PBX object/source-membership checks: passed
- companion website production generation, generated-output verifier, and real Chromium fallback-page click path: passed

## Fork CI verification

- exact head `f82d092d`: full LocalSend CI passed (format, Dart analysis/tests, packaging, Rust clippy/tests, signaling server, plugin crate, and CLI)
- exact head `f82d092d`: Xcode 26 native App Clip build/protocol tests and installed Runner fallback compile passed
- upstream workflow execution still requires maintainer approval for this fork-originated draft

## Device testing

This feature is untested on iOS.