### PR TITLE
feat(app): verify download destination is writable before accepting transfers

### DIFF
--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -426,6 +426,12 @@
       "title": "Cannot open file",
       "content": "Could not open \"{file}\". Has this file been moved, renamed or deleted?"
     },
+    "destinationNotWritable": {
+      "title": "No permission to save files",
+      "content": "LocalSend has no permission to write saved files on this path: {path}",
+      "@content": "The path of the destination folder that is not writable",
+      "flatpakHint": "If you use Flatpak, grant access to this folder via Flatseal."
+    },
     "encryptionDisabledNotice": {
       "title": "Encryption disabled",
       "content": "Communication now takes place via the unencrypted HTTP protocol. To use HTTPS protocol, enable encryption again."

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 58
-/// Strings: 21022 (362 per locale)
+/// Strings: 21025 (362 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -760,6 +760,7 @@ class Translations$dialogs$en {
   late final Translations$dialogs$addressInput$en addressInput = Translations$dialogs$addressInput$en.internal(_root);
   late final Translations$dialogs$cancelSession$en cancelSession = Translations$dialogs$cancelSession$en.internal(_root);
   late final Translations$dialogs$cannotOpenFile$en cannotOpenFile = Translations$dialogs$cannotOpenFile$en.internal(_root);
+  late final Translations$dialogs$destinationNotWritable$en destinationNotWritable = Translations$dialogs$destinationNotWritable$en.internal(_root);
   late final Translations$dialogs$encryptionDisabledNotice$en encryptionDisabledNotice = Translations$dialogs$encryptionDisabledNotice$en.internal(
     _root,
   );
@@ -1481,6 +1482,26 @@ class Translations$dialogs$cannotOpenFile$en {
 
   /// en: 'Could not open "{file}". Has this file been moved, renamed or deleted?'
   String content({required Object file}) => 'Could not open "${file}". Has this file been moved, renamed or deleted?';
+}
+
+// Path: dialogs.destinationNotWritable
+class Translations$dialogs$destinationNotWritable$en {
+  Translations$dialogs$destinationNotWritable$en.internal(this._root);
+
+  final Translations _root; // ignore: unused_field
+
+  // Translations
+
+  /// en: 'No permission to save files'
+  String get title => 'No permission to save files';
+
+  /// The path of the destination folder that is not writable
+  ///
+  /// en: 'LocalSend has no permission to write saved files on this path: {path}'
+  String content({required Object path}) => 'LocalSend has no permission to write saved files on this path: ${path}';
+
+  /// en: 'If you use Flatpak, grant access to this folder via Flatseal.'
+  String get flatpakHint => 'If you use Flatpak, grant access to this folder via Flatseal.';
 }
 
 // Path: dialogs.encryptionDisabledNotice

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -15,11 +15,13 @@ import 'package:localsend_app/provider/settings_provider.dart';
 import 'package:localsend_app/provider/version_provider.dart';
 import 'package:localsend_app/util/alias_generator.dart';
 import 'package:localsend_app/util/device_type_ext.dart';
+import 'package:localsend_app/util/file_writable_check.dart';
 import 'package:localsend_app/util/i18n.dart';
 import 'package:localsend_app/util/native/macos_channel.dart';
 import 'package:localsend_app/util/native/pick_directory_path.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/widget/custom_dropdown_button.dart';
+import 'package:localsend_app/widget/dialogs/destination_not_writable_dialog.dart';
 import 'package:localsend_app/widget/dialogs/encryption_disabled_notice.dart';
 import 'package:localsend_app/widget/dialogs/pin_dialog.dart';
 import 'package:localsend_app/widget/dialogs/quick_save_from_favorites_notice.dart';
@@ -225,6 +227,11 @@ class SettingsTab extends StatelessWidget {
 
                         final directory = await pickDirectoryPath();
                         if (directory != null) {
+                          if (!await isDirectoryWritable(directory)) {
+                            // ignore: use_build_context_synchronously
+                            await showDestinationNotWritableDialog(directory);
+                            return;
+                          }
                           if (defaultTargetPlatform == TargetPlatform.macOS) {
                             await persistDestinationFolderAccess(directory);
                           }

--- a/app/lib/provider/network/server/controller/receive_controller.dart
+++ b/app/lib/provider/network/server/controller/receive_controller.dart
@@ -22,9 +22,11 @@ import 'package:localsend_app/provider/security_provider.dart';
 import 'package:localsend_app/provider/selection/selected_receiving_files_provider.dart';
 import 'package:localsend_app/provider/selection/selected_sending_files_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/util/file_writable_check.dart';
 import 'package:localsend_app/util/native/directories.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/tray_helper.dart';
+import 'package:localsend_app/widget/dialogs/destination_not_writable_dialog.dart';
 import 'package:localsend_app/widget/dialogs/open_file_dialog.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/device.dart';
@@ -82,6 +84,16 @@ class ReceiveController {
     final files = {
       for (final entry in event.files.entries) entry.key: entry.value.toDart(),
     };
+
+    // A destination LocalSend cannot write to previously led to transfers that
+    // "finished" while silently dropping every file (#3090). Reject early with
+    // a visible error instead.
+    if (!kIsWeb && !await isDirectoryWritable(destinationDir)) {
+      _logger.warning('Destination directory is not writable: $destinationDir');
+      await showDestinationNotWritableDialog(destinationDir);
+      declineFileRequest();
+      return;
+    }
 
     // The fingerprint of the sender's mTLS certificate cannot be spoofed, unlike the
     // self-reported fingerprint in the JSON payload which is only used as fallback

--- a/app/lib/util/file_writable_check.dart
+++ b/app/lib/util/file_writable_check.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Checks whether LocalSend can actually create files in [path].
+///
+/// A missing or unwritable destination previously led to transfers that
+/// "finished" while silently dropping every file (e.g. when a Flatpak
+/// sandbox lost access to the folder), so this is checked before accepting
+/// an incoming transfer.
+Future<bool> isDirectoryWritable(String path) async {
+  try {
+    final directory = Directory(path);
+    if (!await directory.exists()) {
+      return false;
+    }
+    final probe = File(p.join(path, '.localsend_write_probe_${DateTime.now().millisecondsSinceEpoch}'));
+    await probe.create();
+    await probe.delete();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/app/lib/widget/dialogs/destination_not_writable_dialog.dart
+++ b/app/lib/widget/dialogs/destination_not_writable_dialog.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:localsend_app/gen/strings.g.dart';
+import 'package:routerino/routerino.dart';
+
+/// Shown when an incoming transfer (or a settings change) targets a
+/// destination directory LocalSend cannot write to.
+class DestinationNotWritableDialog extends StatelessWidget {
+  final String destination;
+  final String? hint;
+
+  const DestinationNotWritableDialog({super.key, required this.destination, this.hint});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(t.dialogs.destinationNotWritable.title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            t.dialogs.destinationNotWritable.content(path: destination),
+            style: const TextStyle(fontSize: 14),
+          ),
+          if (hint != null) ...[
+            const SizedBox(height: 8),
+            Text(hint!, style: const TextStyle(fontSize: 13)),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => context.pop(),
+          child: Text(t.general.close),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shows the dialog, appending the Flatpak hint when running sandboxed.
+Future<void> showDestinationNotWritableDialog(String destination) async {
+  String? hint;
+  if (await File('/.flatpak-info').exists()) {
+    hint = t.dialogs.destinationNotWritable.flatpakHint;
+  }
+  // ignore: use_build_context_synchronously
+  await Routerino.context.push(
+    () => DestinationNotWritableDialog(destination: destination, hint: hint),
+  );
+}

--- a/app/test/unit/util/file_writable_check_test.dart
+++ b/app/test/unit/util/file_writable_check_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:localsend_app/util/file_writable_check.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('existing directory is writable', () async {
+    final dir = await Directory.systemTemp.createTemp('localsend_writable');
+    addTearDown(() => dir.delete(recursive: true));
+
+    expect(await isDirectoryWritable(dir.path), isTrue);
+  });
+
+  test('nonexistent directory is not writable', () async {
+    final dir = Directory.systemTemp.createTempSync('localsend_writable');
+    final missing = p.join(dir.path, 'does-not-exist');
+    addTearDown(() => dir.delete(recursive: true));
+
+    expect(await isDirectoryWritable(missing), isFalse);
+  });
+
+  test('file path is not writable', () async {
+    final dir = Directory.systemTemp.createTempSync('localsend_writable');
+    final file = File(p.join(dir.path, 'file.txt'))..createSync();
+    addTearDown(() => dir.delete(recursive: true));
+
+    expect(await isDirectoryWritable(file.path), isFalse);
+  });
+
+  if (!Platform.isWindows) {
+    // Windows CI may run elevated, where read-only attributes do not apply.
+    test('read-only directory is not writable', () async {
+      final dir = Directory.systemTemp.createTempSync('localsend_writable');
+      addTearDown(() {
+        Process.runSync('chmod', ['u+w', dir.path]);
+        dir.deleteSync(recursive: true);
+      });
+      Process.runSync('chmod', ['u-w', dir.path]);
+
+      expect(await isDirectoryWritable(dir.path), isFalse);
+    });
+  }
+}


### PR DESCRIPTION
### What
When LocalSend cannot write to its destination folder (e.g. Flatpak access
revoked via Flatseal), incoming transfers used to "finish" while silently
dropping every file (#3090), or stall midway without any error.

The destination is now probed before a transfer is accepted: a temporary
file gets created and deleted inside the folder. If that fails, a dialog
explains the problem and the request is declined — so the sender sees a
rejection instead of a fake success.

### Details
- probe runs before both the quick-save flow and the receive dialog
- the same check applies when picking a destination folder in settings;
  an unwritable pick keeps the previous setting
- Flatpak users additionally get a hint pointing at Flatseal (detected via
  /.flatpak-info, same mechanism the tray icon code uses)
- gallery saves are unaffected (they bypass the destination folder)

Fixes #3090