### PR TITLE
fix: Flatpak drag-and-drop for files outside Downloads

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   connectivity_plus: 7.3.1
   crypto: 3.0.7
   dart_mappable: 4.8.0
-  desktop_drop: 0.8.3
+  desktop_drop: 0.8.4
   device_apps: 2.2.0
   device_info_plus: 12.4.0
   dynamic_color: 1.8.1

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   connectivity_plus: 7.3.1
   crypto: 3.0.7
   dart_mappable: 4.8.0
-  desktop_drop: 0.7.1
+  desktop_drop: 0.8.3
   device_apps: 2.2.0
   device_info_plus: 12.4.0
   dynamic_color: 1.8.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: desktop_drop
-      sha256: "4c639b4cb80780d1cb94c3252309772e5e68522372181497bc9cd2fbd973aec1"
+      sha256: "47ded09c85909edfed644fd4cbb5051b040d0aed5c79e7e062ea4b3b7156dbe4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.3"
+    version: "0.8.4"
   device_apps:
     dependency: "direct overridden"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: desktop_drop
-      sha256: aa1e797255bfbc76f9eb5aa4f61e5b68dbf69962ab1be6495816d2f251bc0d1f
+      sha256: "4c639b4cb80780d1cb94c3252309772e5e68522372181497bc9cd2fbd973aec1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.8.3"
   device_apps:
     dependency: "direct overridden"
     description:


### PR DESCRIPTION
## Problem

On Flatpak/Wayland, dragging a file onto LocalSend shows "Place items to share" but
dropping silently does nothing — unless the file is under `~/Downloads` (#513).

## Root cause

Between two sandboxed apps, the source (Dolphin/Nautilus) hands the drop as an XDG
FileTransfer *ticket* (`application/vnd.portal.filetransfer`) instead of a file path.
desktop_drop ≤ 0.7 discarded that payload, so `files` contained sandbox-invisible
source paths whose reads failed silently inside the sandbox.

## Fix

Bump `desktop_drop` 0.7.1 → 0.8.4 ([MixinNetwork/flutter-plugins#495](https://github.com/MixinNetwork/flutter-plugins/pull/495) + [#498](https://github.com/MixinNetwork/flutter-plugins/pull/498) + [#500](https://github.com/MixinNetwork/flutter-plugins/pull/500)).
The plugin now registers the portal drag target, resolves tickets through
`org.freedesktop.portal.FileTransfer.RetrieveFiles`, and emits document-portal paths
(`/run/user/$UID/doc/…`) that read fine both inside sandboxes and out.

Android compatibility: 0.8.2 and 0.8.3 each still failed to compile Kotlin on one AGP
configuration or the other. 0.8.4 branches on the `android.builtInKotlin` property
instead of the AGP version — with `builtInKotlin=false` it applies the Kotlin Gradle
Plugin and configures `kotlinOptions` (AGP 8, or AGP 9 with Flutter < 3.47); with
`builtInKotlin=true` it skips KGP and uses `compilerOptions` (AGP 9 with Flutter 3.47+).

Verified on both AGP paths — the plugin's example app (AGP 9.1) and LocalSend itself
(AGP 8.12 / Flutter 3.41):
[AGP 8 evidence](https://github.com/loucass/localsend/actions/runs/33248645316) ·
[AGP 9 evidence](https://github.com/loucass/flutter-plugins/actions/runs/33248620672)

Fixes #513