### PR TITLE
fix: show "LocalSend" as title in the Linux system tray

### DIFF
--- a/app/linux/my_application.cc
+++ b/app/linux/my_application.cc
@@ -112,6 +112,10 @@ MyApplication* my_application_new() {
   // corresponding .desktop file. This ensures better integration by allowing
   // the application to be recognized beyond its binary name.
   g_set_prgname(APPLICATION_ID);
+  // The application name is shown instead of the program name wherever a
+  // human-readable label is expected, e.g. as the title of the system tray
+  // entry on Linux desktops.
+  g_set_application_name("LocalSend");
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,


### PR DESCRIPTION
## Problem

On Linux desktops (I ran into this on KDE Plasma 6 / Wayland), the system tray "Status and Notifications" popup shows the raw application ID `org.localsend.localsend_app` instead of "LocalSend".

## Root cause

The tray label is the StatusNotifierItem `Title` property. `libayatana-appindicator` fills `Title` from `g_get_application_name()`. Flutter's Linux runner never calls `g_set_application_name()`, so GTK falls back to `g_get_prgname()` — which `my_application_new()` sets to `APPLICATION_ID`. The app ID therefore ends up as the tray label.

## Fix

Set the human-readable application name next to the existing `g_set_prgname()` call in `my_application_new()`:

```c
g_set_application_name("LocalSend");
```

## Before / after

<img width="842" height="830" alt="Screenshot_20260825_224408" src="https://github.com/user-attachments/assets/a05a86ce-aa97-48d6-b47d-8c05a2d75982" />
<img width="899" height="833" alt="Screenshot_20260826_060251" src="https://github.com/user-attachments/assets/75c19f0a-b293-488c-ab88-0d2a464227cd" />
