### PR TITLE
fix: don't show misleading "No permission" dialog for non-Android pick errors

### DIFF
--- a/app/lib/util/native/file_picker.dart
+++ b/app/lib/util/native/file_picker.dart
@@ -17,6 +17,7 @@ import 'package:localsend_app/util/native/cross_file_converters.dart';
 import 'package:localsend_app/util/native/pick_directory_path.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/ui/asset_picker_translated_text_delegate.dart';
+import 'package:localsend_app/widget/dialogs/error_dialog.dart';
 import 'package:localsend_app/widget/dialogs/loading_dialog.dart';
 import 'package:localsend_app/widget/dialogs/message_input_dialog.dart';
 import 'package:localsend_app/widget/dialogs/no_permission_dialog.dart';
@@ -184,9 +185,18 @@ Future<void> _pickFiles(BuildContext context, Ref ref) async {
       return;
     }
 
-    // ignore: use_build_context_synchronously
-    await showDialog(context: context, builder: (_) => const NoPermissionDialog());
     _logger.warning('Failed to pick files', e);
+    if (checkPlatform([TargetPlatform.android])) {
+      // ignore: use_build_context_synchronously
+      await showDialog(context: context, builder: (_) => const NoPermissionDialog());
+    } else {
+      // No app-level file permission exists to grant outside Android, so show the real error instead.
+      await showDialog(
+        // ignore: use_build_context_synchronously
+        context: context,
+        builder: (_) => ErrorDialog(error: e.toString()),
+      );
+    }
   } finally {
     // ignore: use_build_context_synchronously
     Routerino.context.popUntilRoot(); // remove loading dialog
@@ -234,8 +244,17 @@ Future<void> _pickFolder(BuildContext context, Ref ref) async {
     }
 
     _logger.warning('Failed to pick directory', e);
-    // ignore: use_build_context_synchronously
-    await showDialog(context: context, builder: (_) => const NoPermissionDialog());
+    if (checkPlatform([TargetPlatform.android])) {
+      // ignore: use_build_context_synchronously
+      await showDialog(context: context, builder: (_) => const NoPermissionDialog());
+    } else {
+      // No app-level file permission exists to grant outside Android, so show the real error instead.
+      await showDialog(
+        // ignore: use_build_context_synchronously
+        context: context,
+        builder: (_) => ErrorDialog(error: e.toString()),
+      );
+    }
   } finally {
     // ignore: use_build_context_synchronously
     Routerino.context.popUntilRoot(); // remove loading dialog

--- a/app/lib/util/native/file_picker.dart
+++ b/app/lib/util/native/file_picker.dart
@@ -186,11 +186,11 @@ Future<void> _pickFiles(BuildContext context, Ref ref) async {
     }
 
     _logger.warning('Failed to pick files', e);
-    if (checkPlatform([TargetPlatform.android])) {
+    if (checkPlatform([TargetPlatform.android]) && !kIsWeb) {
       // ignore: use_build_context_synchronously
       await showDialog(context: context, builder: (_) => const NoPermissionDialog());
     } else {
-      // No app-level file permission exists to grant outside Android, so show the real error instead.
+      // No app-level file permission exists to grant outside native Android, so show the real error instead.
       await showDialog(
         // ignore: use_build_context_synchronously
         context: context,
@@ -244,11 +244,11 @@ Future<void> _pickFolder(BuildContext context, Ref ref) async {
     }
 
     _logger.warning('Failed to pick directory', e);
-    if (checkPlatform([TargetPlatform.android])) {
+    if (checkPlatform([TargetPlatform.android]) && !kIsWeb) {
       // ignore: use_build_context_synchronously
       await showDialog(context: context, builder: (_) => const NoPermissionDialog());
     } else {
-      // No app-level file permission exists to grant outside Android, so show the real error instead.
+      // No app-level file permission exists to grant outside native Android, so show the real error instead.
       await showDialog(
         // ignore: use_build_context_synchronously
         context: context,


### PR DESCRIPTION
Fixes #3366

The picker's catch blocks showed "No permission" for any error, even on platforms with no such permission system (desktop/iOS/web) - misleading for cases like a pre-1980 file timestamp tripping the native picker.

Now only Android (which has a real permission system) shows `NoPermissionDialog`; everywhere else shows the existing `ErrorDialog` with the real error message. Android's code path is unchanged.

Tested: `dart format`, `flutter analyze`, `flutter test` all pass. Not run in a live build (no platform build toolchain available here).

Written with AI assistance (per AGENTS.md), reviewed by me before submitting.