### PR TITLE
feat: add file send order and concurrency settings

### DIFF
--- a/app/assets/i18n/en.json
+++ b/app/assets/i18n/en.json
@@ -127,7 +127,14 @@
     "send": {
       "title": "Send",
       "shareViaLinkAutoAccept": "Automatically accept requests in \"Share via link\" mode",
-      "createChecksums": "Create checksums when sending files"
+      "createChecksums": "Create checksums when sending files",
+      "order": "File send order",
+      "orderOptions": {
+        "selection": "Selection order",
+        "smallestFirst": "Smallest files first",
+        "largestFirst": "Largest files first"
+      },
+      "concurrency": "Files sent at the same time"
     },
     "network": {
       "title": "Network",

--- a/app/assets/i18n/pt-BR.json
+++ b/app/assets/i18n/pt-BR.json
@@ -127,7 +127,14 @@
     "send": {
       "title": "Envio",
       "shareViaLinkAutoAccept": "Aceitar solicitações por link automaticamente",
-      "createChecksums": "Criar checksums ao enviar arquivos"
+      "createChecksums": "Criar checksums ao enviar arquivos",
+      "order": "Ordem de envio dos arquivos",
+      "orderOptions": {
+        "selection": "Ordem de seleção",
+        "smallestFirst": "Menores primeiro",
+        "largestFirst": "Maiores primeiro"
+      },
+      "concurrency": "Arquivos enviados ao mesmo tempo"
     },
     "network": {
       "title": "Rede",

--- a/app/lib/gen/strings.g.dart
+++ b/app/lib/gen/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 58
-/// Strings: 21022 (362 per locale)
+/// Strings: 21032 (362 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/gen/strings_en.g.dart
+++ b/app/lib/gen/strings_en.g.dart
@@ -1153,6 +1153,14 @@ class Translations$settingsTab$send$en {
 
   /// en: 'Create checksums when sending files'
   String get createChecksums => 'Create checksums when sending files';
+
+  /// en: 'File send order'
+  String get order => 'File send order';
+
+  late final Translations$settingsTab$send$orderOptions$en orderOptions = Translations$settingsTab$send$orderOptions$en.internal(_root);
+
+  /// en: 'Files sent at the same time'
+  String get concurrency => 'Files sent at the same time';
 }
 
 // Path: settingsTab.network
@@ -1867,6 +1875,24 @@ class Translations$settingsTab$general$languageOptions$en {
 
   /// en: 'System'
   String get system => 'System';
+}
+
+// Path: settingsTab.send.orderOptions
+class Translations$settingsTab$send$orderOptions$en {
+  Translations$settingsTab$send$orderOptions$en.internal(this._root);
+
+  final Translations _root; // ignore: unused_field
+
+  // Translations
+
+  /// en: 'Selection order'
+  String get selection => 'Selection order';
+
+  /// en: 'Smallest files first'
+  String get smallestFirst => 'Smallest files first';
+
+  /// en: 'Largest files first'
+  String get largestFirst => 'Largest files first';
 }
 
 // Path: settingsTab.network.networkOptions

--- a/app/lib/gen/strings_pt_BR.g.dart
+++ b/app/lib/gen/strings_pt_BR.g.dart
@@ -999,6 +999,12 @@ class Translations$settingsTab$send$pt_BR extends Translations$settingsTab$send$
   String get shareViaLinkAutoAccept => 'Aceitar solicitações por link automaticamente';
   @override
   String get createChecksums => 'Criar checksums ao enviar arquivos';
+  @override
+  String get order => 'Ordem de envio dos arquivos';
+  @override
+  late final Translations$settingsTab$send$orderOptions$pt_BR orderOptions = Translations$settingsTab$send$orderOptions$pt_BR.internal(_root);
+  @override
+  String get concurrency => 'Arquivos enviados ao mesmo tempo';
 }
 
 // Path: settingsTab.network
@@ -1606,6 +1612,21 @@ class Translations$settingsTab$general$languageOptions$pt_BR extends Translation
   // Translations
   @override
   String get system => 'Sistema';
+}
+
+// Path: settingsTab.send.orderOptions
+class Translations$settingsTab$send$orderOptions$pt_BR extends Translations$settingsTab$send$orderOptions$en {
+  Translations$settingsTab$send$orderOptions$pt_BR.internal(TranslationsPtBr root) : this._root = root, super.internal(root);
+
+  final TranslationsPtBr _root; // ignore: unused_field
+
+  // Translations
+  @override
+  String get selection => 'Ordem de seleção';
+  @override
+  String get smallestFirst => 'Menores primeiro';
+  @override
+  String get largestFirst => 'Maiores primeiro';
 }
 
 // Path: settingsTab.network.networkOptions

--- a/app/lib/model/send_concurrency.dart
+++ b/app/lib/model/send_concurrency.dart
@@ -1,0 +1,15 @@
+import 'package:localsend_isolates/constants.dart';
+
+const sendConcurrencyOptions = [1, 2, 3, 4, 5];
+
+/// A stored value can be absent or out of range, and it ends up in a [Pool]
+/// which throws for anything below one.
+int sanitizeSendConcurrency(int? storedConcurrency) {
+  if (storedConcurrency == null) {
+    return defaultSendConcurrency;
+  }
+  if (!sendConcurrencyOptions.contains(storedConcurrency)) {
+    return defaultSendConcurrency;
+  }
+  return storedConcurrency;
+}

--- a/app/lib/model/send_order.dart
+++ b/app/lib/model/send_order.dart
@@ -1,0 +1,5 @@
+enum SendOrder {
+  selection,
+  smallestFirst,
+  largestFirst,
+}

--- a/app/lib/model/state/settings_state.dart
+++ b/app/lib/model/state/settings_state.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/model/send_mode.dart';
+import 'package:localsend_app/model/send_order.dart';
 import 'package:localsend_isolates/model/device.dart';
 
 part 'settings_state.mapper.dart';
@@ -29,6 +30,8 @@ class SettingsState with SettingsStateMappable {
   final bool minimizeToTray; // minimize to tray instead of exiting the app
   final bool https;
   final SendMode sendMode;
+  final SendOrder sendOrder;
+  final int sendConcurrency;
   final bool saveWindowPlacement;
   final bool enableAnimations;
   final DeviceType? deviceType;
@@ -61,6 +64,8 @@ class SettingsState with SettingsStateMappable {
     required this.minimizeToTray,
     required this.https,
     required this.sendMode,
+    required this.sendOrder,
+    required this.sendConcurrency,
     required this.saveWindowPlacement,
     required this.enableAnimations,
     required this.deviceType,

--- a/app/lib/model/state/settings_state.mapper.dart
+++ b/app/lib/model/state/settings_state.mapper.dart
@@ -117,6 +117,16 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     'sendMode',
     _$sendMode,
   );
+  static SendOrder _$sendOrder(SettingsState v) => v.sendOrder;
+  static const Field<SettingsState, SendOrder> _f$sendOrder = Field(
+    'sendOrder',
+    _$sendOrder,
+  );
+  static int _$sendConcurrency(SettingsState v) => v.sendConcurrency;
+  static const Field<SettingsState, int> _f$sendConcurrency = Field(
+    'sendConcurrency',
+    _$sendConcurrency,
+  );
   static bool _$saveWindowPlacement(SettingsState v) => v.saveWindowPlacement;
   static const Field<SettingsState, bool> _f$saveWindowPlacement = Field(
     'saveWindowPlacement',
@@ -192,6 +202,8 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
     #minimizeToTray: _f$minimizeToTray,
     #https: _f$https,
     #sendMode: _f$sendMode,
+    #sendOrder: _f$sendOrder,
+    #sendConcurrency: _f$sendConcurrency,
     #saveWindowPlacement: _f$saveWindowPlacement,
     #enableAnimations: _f$enableAnimations,
     #deviceType: _f$deviceType,
@@ -226,6 +238,8 @@ class SettingsStateMapper extends ClassMapperBase<SettingsState> {
       minimizeToTray: data.dec(_f$minimizeToTray),
       https: data.dec(_f$https),
       sendMode: data.dec(_f$sendMode),
+      sendOrder: data.dec(_f$sendOrder),
+      sendConcurrency: data.dec(_f$sendConcurrency),
       saveWindowPlacement: data.dec(_f$saveWindowPlacement),
       enableAnimations: data.dec(_f$enableAnimations),
       deviceType: data.dec(_f$deviceType),
@@ -326,6 +340,8 @@ abstract class SettingsStateCopyWith<$R, $In extends SettingsState, $Out>
     bool? minimizeToTray,
     bool? https,
     SendMode? sendMode,
+    SendOrder? sendOrder,
+    int? sendConcurrency,
     bool? saveWindowPlacement,
     bool? enableAnimations,
     DeviceType? deviceType,
@@ -388,6 +404,8 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     bool? minimizeToTray,
     bool? https,
     SendMode? sendMode,
+    SendOrder? sendOrder,
+    int? sendConcurrency,
     bool? saveWindowPlacement,
     bool? enableAnimations,
     Object? deviceType = $none,
@@ -421,6 +439,8 @@ class _SettingsStateCopyWithImpl<$R, $Out>
       if (minimizeToTray != null) #minimizeToTray: minimizeToTray,
       if (https != null) #https: https,
       if (sendMode != null) #sendMode: sendMode,
+      if (sendOrder != null) #sendOrder: sendOrder,
+      if (sendConcurrency != null) #sendConcurrency: sendConcurrency,
       if (saveWindowPlacement != null)
         #saveWindowPlacement: saveWindowPlacement,
       if (enableAnimations != null) #enableAnimations: enableAnimations,
@@ -461,6 +481,8 @@ class _SettingsStateCopyWithImpl<$R, $Out>
     minimizeToTray: data.get(#minimizeToTray, or: $value.minimizeToTray),
     https: data.get(#https, or: $value.https),
     sendMode: data.get(#sendMode, or: $value.sendMode),
+    sendOrder: data.get(#sendOrder, or: $value.sendOrder),
+    sendConcurrency: data.get(#sendConcurrency, or: $value.sendConcurrency),
     saveWindowPlacement: data.get(
       #saveWindowPlacement,
       or: $value.saveWindowPlacement,

--- a/app/lib/pages/progress_page.dart
+++ b/app/lib/pages/progress_page.dart
@@ -16,6 +16,7 @@ import 'package:localsend_app/util/native/open_folder.dart';
 import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_app/util/native/taskbar_helper.dart';
 import 'package:localsend_app/util/notification_strings.dart';
+import 'package:localsend_app/util/send_order_sorter.dart';
 import 'package:localsend_app/util/ui/nav_bar_padding.dart';
 import 'package:localsend_app/widget/custom_progress_bar.dart';
 import 'package:localsend_app/widget/dialogs/cancel_session_dialog.dart';
@@ -120,7 +121,11 @@ class _ProgressPageState extends State<ProgressPage> with Refena {
         } else {
           final sendSession = ref.read(sendProvider)[widget.sessionId];
           if (sendSession != null) {
-            _files = sendSession.files.values.map((f) => f.file).toList();
+            _files = sortBySendOrder(
+              sendSession.files.values.map((f) => f.file).toList(),
+              ref.read(settingsProvider).sendOrder,
+              (file) => file.size,
+            );
           }
         }
 

--- a/app/lib/pages/tabs/settings_tab.dart
+++ b/app/lib/pages/tabs/settings_tab.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:localsend_app/config/theme.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/color_mode.dart';
+import 'package:localsend_app/model/send_concurrency.dart';
+import 'package:localsend_app/model/send_order.dart';
 import 'package:localsend_app/pages/about/about_page.dart';
 import 'package:localsend_app/pages/changelog_page.dart';
 import 'package:localsend_app/pages/donation/donation_page.dart';
@@ -291,6 +293,38 @@ class SettingsTab extends StatelessWidget {
                     onChanged: (b) async {
                       await ref.notifier(settingsProvider).setCreateChecksums(b);
                     },
+                  ),
+                  _SettingsEntry(
+                    label: t.settingsTab.send.order,
+                    child: CustomDropdownButton<SendOrder>(
+                      value: vm.settings.sendOrder,
+                      items: SendOrder.values.map((sendOrder) {
+                        return DropdownMenuItem(
+                          value: sendOrder,
+                          alignment: Alignment.center,
+                          child: Text(sendOrder.humanName, overflow: TextOverflow.ellipsis),
+                        );
+                      }).toList(),
+                      onChanged: (sendOrder) async {
+                        await ref.notifier(settingsProvider).setSendOrder(sendOrder);
+                      },
+                    ),
+                  ),
+                  _SettingsEntry(
+                    label: t.settingsTab.send.concurrency,
+                    child: CustomDropdownButton<int>(
+                      value: vm.settings.sendConcurrency,
+                      items: sendConcurrencyOptions.map((concurrency) {
+                        return DropdownMenuItem(
+                          value: concurrency,
+                          alignment: Alignment.center,
+                          child: Text(concurrency.toString()),
+                        );
+                      }).toList(),
+                      onChanged: (concurrency) async {
+                        await ref.notifier(settingsProvider).setSendConcurrency(concurrency);
+                      },
+                    ),
                   ),
                 ],
               ),
@@ -758,6 +792,16 @@ extension on ThemeMode {
       case ThemeMode.dark:
         return t.settingsTab.general.brightnessOptions.dark;
     }
+  }
+}
+
+extension on SendOrder {
+  String get humanName {
+    return switch (this) {
+      SendOrder.selection => t.settingsTab.send.orderOptions.selection,
+      SendOrder.smallestFirst => t.settingsTab.send.orderOptions.smallestFirst,
+      SendOrder.largestFirst => t.settingsTab.send.orderOptions.largestFirst,
+    };
   }
 }
 

--- a/app/lib/provider/network/send_provider.dart
+++ b/app/lib/provider/network/send_provider.dart
@@ -14,6 +14,7 @@ import 'package:localsend_app/provider/file_transfer_provider.dart';
 import 'package:localsend_app/provider/http_provider.dart';
 import 'package:localsend_app/provider/selection/selected_sending_files_provider.dart';
 import 'package:localsend_app/provider/settings_provider.dart';
+import 'package:localsend_app/util/send_order_sorter.dart';
 import 'package:localsend_app/widget/dialogs/pin_dialog.dart';
 import 'package:localsend_isolates/isolate.dart';
 import 'package:localsend_isolates/model/device.dart';
@@ -615,13 +616,17 @@ class SendNotifier extends Notifier<Map<String, SendSessionState>> {
       return;
     }
 
+    final settings = ref.read(settingsProvider);
+    final orderedFiles = sortBySendOrder(uploadFiles, settings.sendOrder, (file) => file.fileSize);
+
     final taskResult = ref
         .redux(parentIsolateProvider)
         .dispatchTakeResult(
           IsolateHttpUploadFilesAction(
             remoteSessionId: sessionState.remoteSessionId,
-            files: uploadFiles,
+            files: orderedFiles,
             device: sessionState.target,
+            concurrency: settings.sendConcurrency,
           ),
         );
 

--- a/app/lib/provider/persistence_provider.dart
+++ b/app/lib/provider/persistence_provider.dart
@@ -9,7 +9,9 @@ import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/model/persistence/favorite_device.dart';
 import 'package:localsend_app/model/persistence/quick_save_mode.dart';
 import 'package:localsend_app/model/persistence/receive_history_entry.dart';
+import 'package:localsend_app/model/send_concurrency.dart';
 import 'package:localsend_app/model/send_mode.dart';
+import 'package:localsend_app/model/send_order.dart';
 import 'package:localsend_app/provider/window_dimensions_provider.dart';
 import 'package:localsend_app/util/alias_generator.dart';
 import 'package:localsend_app/util/native/autostart_helper.dart';
@@ -86,6 +88,8 @@ const _autoFinish = 'ls_auto_finish';
 const _minimizeToTray = 'ls_minimize_to_tray';
 const _https = 'ls_https';
 const _sendMode = 'ls_send_mode';
+const _sendOrder = 'ls_send_order';
+const _sendConcurrency = 'ls_send_concurrency';
 const _enableAnimations = 'ls_enable_animations';
 const _deviceType = 'ls_device_type';
 const _deviceModel = 'ls_device_model';
@@ -504,6 +508,22 @@ class PersistenceService {
 
   Future<void> setSendMode(SendMode mode) async {
     await _prefs.setString(_sendMode, mode.name);
+  }
+
+  SendOrder getSendOrder() {
+    return SendOrder.values.firstWhereOrNull((order) => order.name == _prefs.getString(_sendOrder)) ?? SendOrder.selection;
+  }
+
+  Future<void> setSendOrder(SendOrder order) async {
+    await _prefs.setString(_sendOrder, order.name);
+  }
+
+  int getSendConcurrency() {
+    return sanitizeSendConcurrency(_prefs.getInt(_sendConcurrency));
+  }
+
+  Future<void> setSendConcurrency(int concurrency) async {
+    await _prefs.setInt(_sendConcurrency, concurrency);
   }
 
   Future<void> setWindowOffsetX(double x) async {

--- a/app/lib/provider/settings_provider.dart
+++ b/app/lib/provider/settings_provider.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:localsend_app/gen/strings.g.dart';
 import 'package:localsend_app/model/persistence/color_mode.dart';
 import 'package:localsend_app/model/persistence/quick_save_mode.dart';
+import 'package:localsend_app/model/send_concurrency.dart';
 import 'package:localsend_app/model/send_mode.dart';
+import 'package:localsend_app/model/send_order.dart';
 import 'package:localsend_app/model/state/settings_state.dart';
 import 'package:localsend_app/provider/persistence_provider.dart';
 import 'package:localsend_isolates/isolate.dart';
@@ -65,6 +67,8 @@ class SettingsService extends PureNotifier<SettingsState> {
     minimizeToTray: _persistence.isMinimizeToTray(),
     https: _persistence.isHttps(),
     sendMode: _persistence.getSendMode(),
+    sendOrder: _persistence.getSendOrder(),
+    sendConcurrency: _persistence.getSendConcurrency(),
     saveWindowPlacement: _persistence.getSaveWindowPlacement(),
     enableAnimations: _persistence.getEnableAnimations(),
     deviceType: _persistence.getDeviceType(),
@@ -237,6 +241,21 @@ class SettingsService extends PureNotifier<SettingsState> {
     await _persistence.setSendMode(mode);
     state = state.copyWith(
       sendMode: mode,
+    );
+  }
+
+  Future<void> setSendOrder(SendOrder order) async {
+    await _persistence.setSendOrder(order);
+    state = state.copyWith(
+      sendOrder: order,
+    );
+  }
+
+  Future<void> setSendConcurrency(int concurrency) async {
+    final sanitizedConcurrency = sanitizeSendConcurrency(concurrency);
+    await _persistence.setSendConcurrency(sanitizedConcurrency);
+    state = state.copyWith(
+      sendConcurrency: sanitizedConcurrency,
     );
   }
 

--- a/app/lib/util/send_order_sorter.dart
+++ b/app/lib/util/send_order_sorter.dart
@@ -1,0 +1,12 @@
+import 'package:collection/collection.dart';
+import 'package:localsend_app/model/send_order.dart';
+
+List<T> sortBySendOrder<T>(List<T> files, SendOrder sendOrder, int Function(T file) resolveSize) {
+  if (sendOrder == SendOrder.smallestFirst) {
+    return files.sorted((first, second) => resolveSize(first).compareTo(resolveSize(second)));
+  }
+  if (sendOrder == SendOrder.largestFirst) {
+    return files.sorted((first, second) => resolveSize(second).compareTo(resolveSize(first)));
+  }
+  return files;
+}

--- a/app/test/mocks.mocks.dart
+++ b/app/test/mocks.mocks.dart
@@ -13,12 +13,13 @@ import 'package:localsend_app/model/persistence/favorite_device.dart' as _i7;
 import 'package:localsend_app/model/persistence/quick_save_mode.dart' as _i12;
 import 'package:localsend_app/model/persistence/receive_history_entry.dart' as _i6;
 import 'package:localsend_app/model/send_mode.dart' as _i13;
+import 'package:localsend_app/model/send_order.dart' as _i14;
 import 'package:localsend_app/provider/persistence_provider.dart' as _i4;
-import 'package:localsend_isolates/model/device.dart' as _i14;
+import 'package:localsend_isolates/model/device.dart' as _i15;
 import 'package:localsend_isolates/model/stored_security_context.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i8;
-import 'package:shared_preferences/shared_preferences.dart' as _i15;
+import 'package:shared_preferences/shared_preferences.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -570,6 +571,42 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as _i5.Future<void>);
 
   @override
+  _i14.SendOrder getSendOrder() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSendOrder, []),
+            returnValue: _i14.SendOrder.selection,
+            returnValueForMissingStub: _i14.SendOrder.selection,
+          )
+          as _i14.SendOrder);
+
+  @override
+  _i5.Future<void> setSendOrder(_i14.SendOrder? order) =>
+      (super.noSuchMethod(
+            Invocation.method(#setSendOrder, [order]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  int getSendConcurrency() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSendConcurrency, []),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
+
+  @override
+  _i5.Future<void> setSendConcurrency(int? concurrency) =>
+      (super.noSuchMethod(
+            Invocation.method(#setSendConcurrency, [concurrency]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
   _i5.Future<void> setWindowOffsetX(double? x) =>
       (super.noSuchMethod(
             Invocation.method(#setWindowOffsetX, [x]),
@@ -642,7 +679,7 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
           as bool);
 
   @override
-  _i5.Future<void> setDeviceType(_i14.DeviceType? deviceType) =>
+  _i5.Future<void> setDeviceType(_i15.DeviceType? deviceType) =>
       (super.noSuchMethod(
             Invocation.method(#setDeviceType, [deviceType]),
             returnValue: _i5.Future<void>.value(),
@@ -681,7 +718,7 @@ class MockPersistenceService extends _i1.Mock implements _i4.PersistenceService 
 /// A class which mocks [SharedPreferences].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSharedPreferences extends _i1.Mock implements _i15.SharedPreferences {
+class MockSharedPreferences extends _i1.Mock implements _i16.SharedPreferences {
   @override
   Set<String> getKeys() =>
       (super.noSuchMethod(

--- a/app/test/unit/util/send_concurrency_test.dart
+++ b/app/test/unit/util/send_concurrency_test.dart
@@ -1,0 +1,27 @@
+import 'package:localsend_app/model/send_concurrency.dart';
+import 'package:localsend_isolates/constants.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('sanitizeSendConcurrency', () {
+    test('falls back to the default when nothing is stored', () {
+      expect(sanitizeSendConcurrency(null), defaultSendConcurrency);
+    });
+
+    test('keeps a stored value that is offered by the settings', () {
+      for (final concurrency in sendConcurrencyOptions) {
+        expect(sanitizeSendConcurrency(concurrency), concurrency);
+      }
+    });
+
+    test('falls back to the default for a value outside the offered range', () {
+      expect(sanitizeSendConcurrency(0), defaultSendConcurrency);
+      expect(sanitizeSendConcurrency(-1), defaultSendConcurrency);
+      expect(sanitizeSendConcurrency(42), defaultSendConcurrency);
+    });
+
+    test('never offers a concurrency below one', () {
+      expect(sendConcurrencyOptions.every((concurrency) => concurrency >= 1), isTrue);
+    });
+  });
+}

--- a/app/test/unit/util/send_order_sorter_test.dart
+++ b/app/test/unit/util/send_order_sorter_test.dart
@@ -1,0 +1,56 @@
+import 'package:localsend_app/model/send_order.dart';
+import 'package:localsend_app/util/send_order_sorter.dart';
+import 'package:localsend_isolates/isolate.dart';
+import 'package:test/test.dart';
+
+HttpUploadFile _createFile(String fileId, int fileSize) {
+  return HttpUploadFile(
+    remoteFileToken: 'token-$fileId',
+    fileId: fileId,
+    filePath: '/tmp/$fileId',
+    fileBytes: null,
+    fileSize: fileSize,
+  );
+}
+
+void main() {
+  final medium = _createFile('medium', 500);
+  final large = _createFile('large', 5000);
+  final small = _createFile('small', 5);
+  final files = [medium, large, small];
+
+  group('sortBySendOrder', () {
+    test('keeps the selection order when no size order is configured', () {
+      final sorted = sortBySendOrder(files, SendOrder.selection, (file) => file.fileSize);
+
+      expect(sorted.map((file) => file.fileId), ['medium', 'large', 'small']);
+    });
+
+    test('puts the smallest file first', () {
+      final sorted = sortBySendOrder(files, SendOrder.smallestFirst, (file) => file.fileSize);
+
+      expect(sorted.map((file) => file.fileId), ['small', 'medium', 'large']);
+    });
+
+    test('puts the largest file first', () {
+      final sorted = sortBySendOrder(files, SendOrder.largestFirst, (file) => file.fileSize);
+
+      expect(sorted.map((file) => file.fileId), ['large', 'medium', 'small']);
+    });
+
+    test('keeps the selection order of equally sized files', () {
+      final first = _createFile('first', 100);
+      final second = _createFile('second', 100);
+
+      final sorted = sortBySendOrder([first, second], SendOrder.smallestFirst, (file) => file.fileSize);
+
+      expect(sorted.map((file) => file.fileId), ['first', 'second']);
+    });
+
+    test('does not mutate the given list', () {
+      sortBySendOrder(files, SendOrder.smallestFirst, (file) => file.fileSize);
+
+      expect(files.map((file) => file.fileId), ['medium', 'large', 'small']);
+    });
+  });
+}

--- a/packages/localsend_isolates/lib/constants.dart
+++ b/packages/localsend_isolates/lib/constants.dart
@@ -22,3 +22,6 @@ const defaultDiscoveryTimeout = 500;
 /// because on some Android devices this is the only IP range
 /// that can receive UDP multicast messages.
 const defaultMulticastGroup = '224.0.0.167';
+
+/// The default number of files uploaded in parallel by one upload task.
+const defaultSendConcurrency = 2;

--- a/packages/localsend_isolates/lib/src/isolate/child/upload_isolate.dart
+++ b/packages/localsend_isolates/lib/src/isolate/child/upload_isolate.dart
@@ -13,9 +13,6 @@ import 'package:pool/pool.dart';
 import 'package:refena_flutter/refena_flutter.dart';
 import 'package:typed_isolates/typed_isolates.dart';
 
-/// How many files of a [HttpUploadFilesTask] are uploaded in parallel.
-const _concurrency = 2;
-
 /// How often a single file is uploaded at most when the receiver keeps
 /// rejecting it with a checksum mismatch (HTTP 422).
 /// Must not exceed MAX_UPLOAD_ATTEMPTS of the Rust server which stops
@@ -43,17 +40,19 @@ class HttpUploadFile {
 /// Uploads a list of files as one isolate task.
 ///
 /// This task is intended to replace the file scheduling loop in the parent
-/// isolate. Up to [_concurrency] files are uploaded in parallel and progress
+/// isolate. Up to [concurrency] files are uploaded in parallel and progress
 /// is reported across the complete list.
 class HttpUploadFilesTask implements BaseHttpUploadTask {
   final String? remoteSessionId;
   final List<HttpUploadFile> files;
   final Device device;
+  final int concurrency;
 
   HttpUploadFilesTask({
     required this.remoteSessionId,
     required this.files,
     required this.device,
+    required this.concurrency,
   });
 }
 
@@ -143,7 +142,7 @@ Future<void> setupHttpUploadIsolate(
       final cancelToken = createCancellationToken();
       ref.read(_cancelTokenProvider).putIfAbsent(task.id, () => cancelToken);
       try {
-        await Pool(_concurrency).forEach<HttpUploadFile, void>(uploadTask.files, (file) async {
+        await Pool(uploadTask.concurrency).forEach<HttpUploadFile, void>(uploadTask.files, (file) async {
           if (!ref.read(_cancelTokenProvider).containsKey(task.id)) {
             // the task was canceled, do not upload the remaining files
             return;

--- a/packages/localsend_isolates/lib/src/isolate/parent/actions.dart
+++ b/packages/localsend_isolates/lib/src/isolate/parent/actions.dart
@@ -234,11 +234,13 @@ class IsolateHttpUploadFilesAction extends ReduxActionWithResult<IsolateControll
   final String? remoteSessionId;
   final List<HttpUploadFile> files;
   final Device device;
+  final int concurrency;
 
   IsolateHttpUploadFilesAction({
     required this.remoteSessionId,
     required this.files,
     required this.device,
+    required this.concurrency,
   });
 
   @override
@@ -253,6 +255,7 @@ class IsolateHttpUploadFilesAction extends ReduxActionWithResult<IsolateControll
         remoteSessionId: remoteSessionId,
         files: files,
         device: device,
+        concurrency: concurrency,
       ),
       taskId: taskId,
     );


### PR DESCRIPTION
Two new settings in the advanced "Send" section, next to the existing checksum option.

**File send order** — selection order (default), smallest files first, or largest files first. When you send a folder with one huge file in it, that file currently blocks the queue; sending the small ones first gets most of the transfer done while the big one waits its turn.

**Files sent at the same time** — 1 to 5, defaulting to 2, which is what the app used before. Setting it to 1 uploads strictly one file after another.

Together those two cover #3088 and #2877: concurrency 1 plus selection order gives the strictly sequential, order-preserving transfer both issues ask for, without forcing that behaviour on everyone.

### How it works

`_concurrency` was a private const in `upload_isolate.dart`; it is now a field on `HttpUploadFilesTask`, so it is decided per task from the settings instead of being fixed. The sort happens once in `_sendFiles`, after the token filter, so it covers the normal send and is a no-op for the single-file retry path. `progress_page` sorts the same way, so the list on screen matches the order the files actually go out in.

`sanitizeSendConcurrency` validates on both read and write, since `Pool` throws on values below one and a stored value could come from a different version.

### Testing

- Unit tests for the ordering and for the sanitizer (`app/test/unit/util/`).
- Verified end to end against `localsend-cli` as the receiver over HTTPS. With three 200 MB files, concurrency 1 starts the uploads at +4122 ms, +5585 ms and +7007 ms (one at a time), while concurrency 3 starts them at +4052 ms, +4054 ms and +4054 ms. Ordering was checked the same way: selecting medium, large, small and choosing "smallest first" sends small, medium, large.
- `dart format`, `flutter analyze`, and the app and `localsend_isolates` test suites all pass.

The pt-BR translation is in a separate commit so it can be dropped if you would rather let Weblate handle it.