### PR TITLE
perf(android): avoid copying files when selecting, sharing and previewing

### DIFF
--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -8,26 +8,40 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.os.Handler
+import android.os.Looper
 import android.provider.DocumentsContract
 import android.provider.MediaStore
 import android.provider.OpenableColumns
 import android.provider.Settings
 import android.util.Log
+import android.util.Size
+import androidx.annotation.RequiresApi
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+import java.util.concurrent.Executors
 
 
 private const val TAG = "LocalSend"
 private const val CHANNEL = "org.localsend.localsend_app/localsend"
+
+// The thumbnails are only ever shown in a small box, so the artefacts stay invisible.
+private const val THUMBNAIL_QUALITY = 80
+
+// Decoding a selection is IO bound, so the pool only has to keep the provider busy.
+private val thumbnailThreads = Runtime.getRuntime().availableProcessors().coerceIn(2, 4)
+
 private const val REQUEST_CODE_PICK_DIRECTORY = 1
 private const val REQUEST_CODE_PICK_DIRECTORY_PATH = 2
 private const val REQUEST_CODE_PICK_FILE = 3
@@ -56,6 +70,17 @@ class MainActivity : FlutterActivity() {
     /// A held-back share. The payload is resolved once, because building it costs a binder
     /// round-trip per URI on the main thread.
     private class PendingShare(val intent: Intent, val payload: Map<String, Any?>?)
+
+    private val thumbnailExecutor = Executors.newFixedThreadPool(thumbnailThreads)
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    override fun onDestroy() {
+        // Queued decodes would otherwise answer a channel whose engine is being torn down.
+        thumbnailExecutor.shutdownNow()
+        methodChannel?.setMethodCallHandler(null)
+        methodChannel = null
+        super.onDestroy()
+    }
 
     override fun onNewIntent(intent: Intent) {
         if (isShareIntent(intent)) {
@@ -218,6 +243,8 @@ class MainActivity : FlutterActivity() {
 
                 "getOriginalMediaUri" -> handleGetOriginalMediaUri(call, result)
 
+                "getContentThumbnail" -> handleGetContentThumbnail(call, result)
+
                 "createFile" -> handleCreateFile(call, result)
 
                 "openFileForWriting" -> handleOpenFileForWriting(call, result)
@@ -348,6 +375,51 @@ class MainActivity : FlutterActivity() {
 
     private fun hasMediaLocationPermission(): Boolean {
         return checkSelfPermission(Manifest.permission.ACCESS_MEDIA_LOCATION) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /// Asks the provider for a thumbnail instead of decoding the whole file, which for a
+    /// large photo or video means reading megabytes to render a few dozen pixels.
+    /// Returns null below Android 10, where the API does not exist and the caller falls
+    /// back to reading the file.
+    private fun handleGetContentThumbnail(call: MethodCall, result: MethodChannel.Result) {
+        val uriString = call.argument<String>("uri")
+        val size = call.argument<Int>("size")
+        if (uriString == null || size == null) {
+            result.error("INVALID_ARGUMENT", "Missing content URI or size", null)
+            return
+        }
+
+        val uri = Uri.parse(uriString)
+        if (uri.scheme != ContentResolver.SCHEME_CONTENT) {
+            result.error("INVALID_ARGUMENT", "Expected a content:// URI", null)
+            return
+        }
+
+        // Decoding is slow enough to be noticeable when a whole selection scrolls into view,
+        // so it must not run on the main thread. The version check sits inside the task
+        // because lint does not carry a guard across the lambda to the call it protects.
+        thumbnailExecutor.execute {
+            val bytes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                loadThumbnailBytes(uri, size)
+            } else {
+                null
+            }
+            mainHandler.post { result.success(bytes) }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun loadThumbnailBytes(uri: Uri, size: Int): ByteArray? {
+        return try {
+            val bitmap = contentResolver.loadThumbnail(uri, Size(size, size), null)
+            ByteArrayOutputStream().use { stream ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, THUMBNAIL_QUALITY, stream)
+                stream.toByteArray()
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not load thumbnail for $uri", e)
+            null
+        }
     }
 
     /// Creates a new file inside a SAF directory and opens it for writing.

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.localsend.localsend_app
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.ContentResolver
@@ -11,7 +12,9 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.DocumentsContract
+import android.provider.MediaStore
 import android.provider.Settings
+import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
@@ -22,6 +25,7 @@ import java.util.Locale
 import java.util.TimeZone
 
 
+private const val TAG = "LocalSend"
 private const val CHANNEL = "org.localsend.localsend_app/localsend"
 private const val REQUEST_CODE_PICK_DIRECTORY = 1
 private const val REQUEST_CODE_PICK_DIRECTORY_PATH = 2
@@ -98,6 +102,8 @@ class MainActivity : FlutterActivity() {
                 "createDirectory" -> handleCreateDirectory(call, result)
 
                 "getFileDescriptor" -> handleGetFileDescriptor(call, result)
+
+                "getOriginalMediaUri" -> handleGetOriginalMediaUri(call, result)
 
                 "createFile" -> handleCreateFile(call, result)
 
@@ -197,6 +203,39 @@ class MainActivity : FlutterActivity() {
         } catch (e: Exception) {
             result.error("OPEN_FAILED", e.message ?: "Failed to open content URI", null)
         }
+    }
+
+    /// MediaStore redacts the location EXIF tags unless the caller explicitly asks for the
+    /// original file, which in turn requires ACCESS_MEDIA_LOCATION. Opening an original URI
+    /// without that permission throws, so the redacted URI is returned when it is missing.
+    private fun handleGetOriginalMediaUri(call: MethodCall, result: MethodChannel.Result) {
+        val uriString = call.argument<String>("uri")
+        if (uriString == null) {
+            result.error("INVALID_ARGUMENT", "Missing media URI", null)
+            return
+        }
+
+        val uri = Uri.parse(uriString)
+        if (uri.scheme != ContentResolver.SCHEME_CONTENT) {
+            result.error("INVALID_ARGUMENT", "Expected a content:// URI", null)
+            return
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            result.success(uriString)
+            return
+        }
+        if (!hasMediaLocationPermission()) {
+            Log.w(TAG, "Sending $uri without its location tags: ACCESS_MEDIA_LOCATION is denied")
+            result.success(uriString)
+            return
+        }
+
+        result.success(MediaStore.setRequireOriginal(uri).toString())
+    }
+
+    private fun hasMediaLocationPermission(): Boolean {
+        return checkSelfPermission(Manifest.permission.ACCESS_MEDIA_LOCATION) == PackageManager.PERMISSION_GRANTED
     }
 
     /// Creates a new file inside a SAF directory and opens it for writing.

--- a/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/localsend/localsend_app/MainActivity.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.os.Environment
 import android.provider.DocumentsContract
 import android.provider.MediaStore
+import android.provider.OpenableColumns
 import android.provider.Settings
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
@@ -40,28 +41,124 @@ class MainActivity : FlutterActivity() {
     private var pendingResult: MethodChannel.Result? = null
     private var pendingPermissionResult: MethodChannel.Result? = null
 
-    /// share_handler drops share intents arriving via onNewIntent while the Dart side
-    /// is not subscribed to its media stream yet, which happens when this singleTask
+    /// Shares carrying files are answered with their content:// URIs instead of being
+    /// passed to share_handler, which copies every file into the app cache on the main
+    /// thread before Dart ever sees it. Text-only shares still take the plugin path.
+    ///
+    /// share_handler also drops share intents arriving via onNewIntent while the Dart
+    /// side is not subscribed to its media stream yet, which happens when this singleTask
     /// activity is relaunched into an existing task while the app is still starting.
-    /// Hold such intents back until Dart reports readiness ("shareIntentReady"), then
-    /// replay them through the regular plugin path.
-    private val pendingShareIntents = mutableListOf<Intent>()
+    /// Hold such intents back until Dart reports readiness ("shareIntentReady").
+    private val pendingShares = mutableListOf<PendingShare>()
     private var shareIntentReady = false
+    private var methodChannel: MethodChannel? = null
+
+    /// A held-back share. The payload is resolved once, because building it costs a binder
+    /// round-trip per URI on the main thread.
+    private class PendingShare(val intent: Intent, val payload: Map<String, Any?>?)
 
     override fun onNewIntent(intent: Intent) {
-        if (!shareIntentReady && (intent.action == Intent.ACTION_SEND || intent.action == Intent.ACTION_SEND_MULTIPLE)) {
-            pendingShareIntents.add(intent)
-            return
+        if (isShareIntent(intent)) {
+            val payload = sharedFilePayload(intent)
+            if (!shareIntentReady) {
+                pendingShares.add(PendingShare(intent, payload))
+                return
+            }
+            if (payload != null) {
+                methodChannel?.invokeMethod("onSharedFiles", payload)
+                return
+            }
         }
         super.onNewIntent(intent)
     }
 
-    private fun onShareIntentReady() {
+    /// Returns the payloads of the held-back shares that carry files. The remaining ones
+    /// are replayed through share_handler, which owns the text-only case.
+    private fun onShareIntentReady(): List<Map<String, Any?>> {
         shareIntentReady = true
-        val pending = pendingShareIntents.toList()
-        pendingShareIntents.clear()
-        for (intent in pending) {
-            super.onNewIntent(intent)
+        val pending = pendingShares.toList()
+        pendingShares.clear()
+
+        val payloads = mutableListOf<Map<String, Any?>>()
+        for (share in pending) {
+            if (share.payload == null) {
+                super.onNewIntent(share.intent)
+            } else {
+                payloads.add(share.payload)
+            }
+        }
+        return payloads
+    }
+
+    private fun isShareIntent(intent: Intent): Boolean {
+        return intent.action == Intent.ACTION_SEND || intent.action == Intent.ACTION_SEND_MULTIPLE
+    }
+
+    /// Null when the intent carries no file, or when any single one cannot be read.
+    /// Handing over a subset would drop the rest without the user ever learning about it,
+    /// so the whole intent is left to share_handler, which reaches schemes this path
+    /// deliberately does not (it copies, at the cost this class exists to avoid).
+    @Suppress("DEPRECATION")
+    private fun sharedFilePayload(intent: Intent): Map<String, Any?>? {
+        val uris = when (intent.action) {
+            Intent.ACTION_SEND -> listOfNotNull(intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM))
+            Intent.ACTION_SEND_MULTIPLE -> intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM).orEmpty()
+            else -> emptyList()
+        }
+        if (uris.isEmpty()) {
+            return null
+        }
+
+        val files = uris.map { uri ->
+            sharedFileInfo(uri) ?: run {
+                Log.w(TAG, "Handing the share to share_handler: $uri is not readable as a content URI")
+                return null
+            }
+        }
+
+        return mapOf(
+            "files" to files.map { it.toMap() },
+            // EXTRA_TEXT is a CharSequence, so senders styling their text would be
+            // dropped by the String accessor.
+            "text" to intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString(),
+        )
+    }
+
+    /// Only the openable columns are queried: they are the ones every content provider
+    /// must expose for a shared URI, unlike the document or media specific ones.
+    private fun sharedFileInfo(uri: Uri): FileInfo? {
+        if (uri.scheme != ContentResolver.SCHEME_CONTENT) {
+            return null
+        }
+
+        return try {
+            contentResolver.query(
+                uri,
+                arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE),
+                null,
+                null,
+                null,
+            )?.use { cursor ->
+                if (!cursor.moveToFirst() || cursor.isNull(1)) {
+                    return@use null
+                }
+                val name = cursor.getString(0) ?: return@use null
+                // A provider that cannot state a size would have the peer offered an empty
+                // file; share_handler copies such a stream instead, which at least works.
+                val size = cursor.getLong(1).takeIf { it > 0 } ?: return@use null
+
+                FileInfo(
+                    name = name,
+                    size = size,
+                    uri = uri.toString(),
+                    // Share intents carry no modification time, and the openable columns
+                    // do not expose one either.
+                    lastModified = null,
+                )
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not read shared file $uri", e)
+            null
         }
     }
 
@@ -78,11 +175,27 @@ class MainActivity : FlutterActivity() {
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        // share_handler reads the launch intent while it attaches, which happens inside
+        // the super call below, and copies the shared files right there. Claiming the
+        // intent first is the only way to keep that copy from happening.
+        val launchIntent = intent
+        if (launchIntent != null && isShareIntent(launchIntent)) {
+            val payload = sharedFilePayload(launchIntent)
+            if (payload != null) {
+                pendingShares.add(PendingShare(launchIntent, payload))
+                // An empty MAIN intent, rather than one stripped of EXTRA_STREAM, so that
+                // nothing downstream mistakes the claimed share for one still to handle.
+                setIntent(Intent(Intent.ACTION_MAIN))
+            }
+        }
+
         super.configureFlutterEngine(flutterEngine)
-        MethodChannel(
+        val channel = MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             CHANNEL
-        ).setMethodCallHandler { call, result ->
+        )
+        methodChannel = channel
+        channel.setMethodCallHandler { call, result ->
             when (call.method) {
                 "pickDirectory" -> {
                     pendingResult = result
@@ -120,8 +233,7 @@ class MainActivity : FlutterActivity() {
                 }
 
                 "shareIntentReady" -> {
-                    onShareIntentReady()
-                    result.success(null)
+                    result.success(onShareIntentReady())
                 }
 
                 "isAnimationsEnabled" -> {

--- a/app/lib/config/init.dart
+++ b/app/lib/config/init.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:localsend_app/config/refena.dart';
 import 'package:localsend_app/config/theme.dart';
+import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/pages/home_page.dart';
 import 'package:localsend_app/pages/home_page_controller.dart';
 import 'package:localsend_app/pages/whats_new_page.dart';
@@ -281,9 +282,19 @@ Future<void> postInit(BuildContext context, Ref ref, bool appStart) async {
     });
 
     if (checkPlatform([TargetPlatform.android])) {
+      setSharedFilesHandlerAndroid((shared) async {
+        await ref.global.dispatchAsync(_HandleSharedFilesAction(shared: shared));
+      });
+
       // Both messages above travel through the same messenger in order, so the stream is
-      // guaranteed to be attached natively before MainActivity replays held-back intents.
-      await flushPendingShareIntentsAndroid();
+      // guaranteed to be attached natively before MainActivity hands the held-back intents
+      // over. These arrive as content URIs rather than cache copies, so unlike the
+      // share_handler ones they do not need the cache to be preserved below.
+      for (final shared in await notifyShareIntentReadyAndroid()) {
+        // Awaited so that two shares cannot interleave their duplicate checks; converting
+        // a content URI does no IO, so nothing is held up by this.
+        await ref.global.dispatchAsync(_HandleSharedFilesAction(shared: shared));
+      }
     }
   }
 
@@ -322,21 +333,55 @@ class _HandleShareIntentAction extends AsyncGlobalAction {
 
   @override
   Future<void> reduce() async {
-    final message = payload.content;
-    if (message != null && message.trim().isNotEmpty) {
-      ref.redux(selectedSendingFilesProvider).dispatch(AddMessageAction(message: message));
-    }
-    await ref
-        .redux(selectedSendingFilesProvider)
-        .dispatchAsync(
-          AddFilesAction(
-            files: payload.attachments?.where((a) => a != null).cast<SharedAttachment>() ?? <SharedAttachment>[],
-            converter: CrossFileConverters.convertSharedAttachment,
-          ),
-        );
-
-    ref.redux(homePageControllerProvider).dispatch(ChangeTabAction(HomeTab.send));
+    await _selectShare(
+      ref: ref,
+      message: payload.content,
+      files: payload.attachments?.where((a) => a != null).cast<SharedAttachment>() ?? <SharedAttachment>[],
+      converter: CrossFileConverters.convertSharedAttachment,
+    );
   }
+}
+
+/// Handles the Android shares that MainActivity answers with content:// URIs,
+/// which spares them the copy into the app cache that share_handler would do.
+class _HandleSharedFilesAction extends AsyncGlobalAction {
+  final SharedPayload shared;
+
+  _HandleSharedFilesAction({
+    required this.shared,
+  });
+
+  @override
+  Future<void> reduce() async {
+    await _selectShare(
+      ref: ref,
+      message: shared.text,
+      files: shared.files,
+      converter: CrossFileConverters.convertFileInfo,
+    );
+  }
+}
+
+/// Puts a share into the selection and brings the send tab forward.
+Future<void> _selectShare<T>({
+  required Ref ref,
+  required String? message,
+  required Iterable<T> files,
+  required Future<CrossFile> Function(T) converter,
+}) async {
+  if (message != null && message.trim().isNotEmpty) {
+    ref.redux(selectedSendingFilesProvider).dispatch(AddMessageAction(message: message));
+  }
+  await ref
+      .redux(selectedSendingFilesProvider)
+      .dispatchAsync(
+        AddFilesAction(
+          files: files,
+          converter: converter,
+        ),
+      );
+
+  ref.redux(homePageControllerProvider).dispatch(ChangeTabAction(HomeTab.send));
 }
 
 class _HandleAppStartArgumentsAction extends AsyncGlobalAction {

--- a/app/lib/util/native/channel/android_channel.dart
+++ b/app/lib/util/native/channel/android_channel.dart
@@ -85,14 +85,38 @@ Future<void> openContentUri({
   });
 }
 
-/// Tells MainActivity that the Dart side is now subscribed to the share_handler media stream,
-/// so share intents that were held back during app start can be replayed.
-Future<void> flushPendingShareIntentsAndroid() async {
+/// Tells MainActivity that the Dart side is ready for share intents, and returns the ones
+/// that were held back during app start.
+///
+/// Only the shares carrying files come back here. Text-only ones are replayed natively
+/// through share_handler and arrive on its media stream instead.
+Future<List<SharedPayload>> notifyShareIntentReadyAndroid() async {
   try {
-    await _methodChannel.invokeMethod('shareIntentReady');
+    final result = await _methodChannel.invokeMethod<List>('shareIntentReady');
+    return (result ?? []).map((e) => _parseSharedPayload(e as Map)).toList();
   } catch (e) {
-    _logger.warning('Could not flush pending share intents', e);
+    _logger.warning('Could not read the pending share intents', e);
+    return [];
   }
+}
+
+/// Registers [onShared] for shares arriving while the app is already running.
+void setSharedFilesHandlerAndroid(Future<void> Function(SharedPayload) onShared) {
+  _methodChannel.setMethodCallHandler((call) async {
+    if (call.method != 'onSharedFiles') {
+      _logger.warning('Unknown method call from MainActivity: ${call.method}');
+      return null;
+    }
+    await onShared(_parseSharedPayload(call.arguments as Map));
+    return null;
+  });
+}
+
+SharedPayload _parseSharedPayload(Map payload) {
+  return SharedPayload(
+    files: (payload['files'] as List).map((e) => FileInfoMapper.fromJson((e as Map).cast<String, dynamic>())).toList(),
+    text: payload['text'] as String?,
+  );
 }
 
 Future<void> openGallery() async {
@@ -108,6 +132,20 @@ class PickDirectoryResult with PickDirectoryResultMappable {
   PickDirectoryResult({
     required this.directoryUri,
     required this.files,
+  });
+}
+
+/// A share intent carrying files, as content:// URIs so that nothing has to be copied.
+@MappableClass()
+class SharedPayload with SharedPayloadMappable {
+  final List<FileInfo> files;
+
+  /// Text sent alongside the files, e.g. the caption or link accompanying them.
+  final String? text;
+
+  SharedPayload({
+    required this.files,
+    required this.text,
   });
 }
 

--- a/app/lib/util/native/channel/android_channel.dart
+++ b/app/lib/util/native/channel/android_channel.dart
@@ -51,6 +51,19 @@ Future<String> getOriginalMediaUriAndroid({required String uri}) async {
   }
 }
 
+/// Returns a JPEG thumbnail of [uri] no larger than [size] in either dimension.
+///
+/// Null when the platform cannot provide one, which leaves it to the caller to fall
+/// back to decoding the file itself.
+Future<Uint8List?> getContentThumbnailAndroid({required String uri, required int size}) async {
+  try {
+    return await _methodChannel.invokeMethod<Uint8List>('getContentThumbnail', {'uri': uri, 'size': size});
+  } catch (e) {
+    _logger.warning('Could not load thumbnail for $uri', e);
+    return null;
+  }
+}
+
 /// Returns the global "Download" directory, e.g. /storage/emulated/0/Download.
 Future<String?> getDownloadsDirectoryAndroid() async {
   try {

--- a/app/lib/util/native/channel/android_channel.dart
+++ b/app/lib/util/native/channel/android_channel.dart
@@ -39,6 +39,18 @@ Future<List<FileInfo>?> pickFilesAndroid() async {
   return result.map((e) => FileInfoMapper.fromJson((e as Map).cast<String, dynamic>())).toList();
 }
 
+/// Returns a variant of [uri] that resolves to the unredacted original file, so the
+/// location EXIF tags survive. Falls back to [uri] when the platform cannot grant it,
+/// because losing the tags beats failing the whole selection.
+Future<String> getOriginalMediaUriAndroid({required String uri}) async {
+  try {
+    return await _methodChannel.invokeMethod<String>('getOriginalMediaUri', {'uri': uri}) ?? uri;
+  } catch (e) {
+    _logger.warning('Could not resolve the original media URI for $uri', e);
+    return uri;
+  }
+}
+
 /// Returns the global "Download" directory, e.g. /storage/emulated/0/Download.
 Future<String?> getDownloadsDirectoryAndroid() async {
   try {

--- a/app/lib/util/native/channel/android_channel.mapper.dart
+++ b/app/lib/util/native/channel/android_channel.mapper.dart
@@ -299,3 +299,138 @@ class _FileInfoCopyWithImpl<$R, $Out>
   ) => _FileInfoCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
+class SharedPayloadMapper extends ClassMapperBase<SharedPayload> {
+  SharedPayloadMapper._();
+
+  static SharedPayloadMapper? _instance;
+  static SharedPayloadMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = SharedPayloadMapper._());
+      FileInfoMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'SharedPayload';
+
+  static List<FileInfo> _$files(SharedPayload v) => v.files;
+  static const Field<SharedPayload, List<FileInfo>> _f$files = Field(
+    'files',
+    _$files,
+  );
+  static String? _$text(SharedPayload v) => v.text;
+  static const Field<SharedPayload, String> _f$text = Field('text', _$text);
+
+  @override
+  final MappableFields<SharedPayload> fields = const {
+    #files: _f$files,
+    #text: _f$text,
+  };
+
+  static SharedPayload _instantiate(DecodingData data) {
+    return SharedPayload(files: data.dec(_f$files), text: data.dec(_f$text));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static SharedPayload fromJson(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<SharedPayload>(map);
+  }
+
+  static SharedPayload deserialize(String json) {
+    return ensureInitialized().decodeJson<SharedPayload>(json);
+  }
+}
+
+mixin SharedPayloadMappable {
+  String serialize() {
+    return SharedPayloadMapper.ensureInitialized().encodeJson<SharedPayload>(
+      this as SharedPayload,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return SharedPayloadMapper.ensureInitialized().encodeMap<SharedPayload>(
+      this as SharedPayload,
+    );
+  }
+
+  SharedPayloadCopyWith<SharedPayload, SharedPayload, SharedPayload>
+  get copyWith => _SharedPayloadCopyWithImpl<SharedPayload, SharedPayload>(
+    this as SharedPayload,
+    $identity,
+    $identity,
+  );
+  @override
+  String toString() {
+    return SharedPayloadMapper.ensureInitialized().stringifyValue(
+      this as SharedPayload,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return SharedPayloadMapper.ensureInitialized().equalsValue(
+      this as SharedPayload,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return SharedPayloadMapper.ensureInitialized().hashValue(
+      this as SharedPayload,
+    );
+  }
+}
+
+extension SharedPayloadValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, SharedPayload, $Out> {
+  SharedPayloadCopyWith<$R, SharedPayload, $Out> get $asSharedPayload =>
+      $base.as((v, t, t2) => _SharedPayloadCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class SharedPayloadCopyWith<$R, $In extends SharedPayload, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  ListCopyWith<$R, FileInfo, FileInfoCopyWith<$R, FileInfo, FileInfo>>
+  get files;
+  $R call({List<FileInfo>? files, String? text});
+  SharedPayloadCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _SharedPayloadCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, SharedPayload, $Out>
+    implements SharedPayloadCopyWith<$R, SharedPayload, $Out> {
+  _SharedPayloadCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<SharedPayload> $mapper =
+      SharedPayloadMapper.ensureInitialized();
+  @override
+  ListCopyWith<$R, FileInfo, FileInfoCopyWith<$R, FileInfo, FileInfo>>
+  get files => ListCopyWith(
+    $value.files,
+    (v, t) => v.copyWith.$chain(t),
+    (v) => call(files: v),
+  );
+  @override
+  $R call({List<FileInfo>? files, Object? text = $none}) => $apply(
+    FieldCopyWithData({
+      if (files != null) #files: files,
+      if (text != $none) #text: text,
+    }),
+  );
+  @override
+  SharedPayload $make(CopyWithData data) => SharedPayload(
+    files: data.get(#files, or: $value.files),
+    text: data.get(#text, or: $value.text),
+  );
+
+  @override
+  SharedPayloadCopyWith<$R2, SharedPayload, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _SharedPayloadCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/app/lib/util/native/cross_file_converters.dart
+++ b/app/lib/util/native/cross_file_converters.dart
@@ -5,15 +5,46 @@ import 'package:flutter/foundation.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/util/native/channel/android_channel.dart' as android_channel;
+import 'package:localsend_app/util/native/platform_check.dart';
 import 'package:localsend_isolates/model/file_type.dart';
 import 'package:localsend_isolates/rust/api/metadata.dart';
 import 'package:localsend_isolates/util/file_path_helper.dart';
+import 'package:logging/logging.dart';
 import 'package:share_handler/share_handler.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+
+final _logger = Logger('CrossFileConverters');
 
 /// Utility functions to convert third party models to common [CrossFile] model.
 class CrossFileConverters {
   static Future<CrossFile> convertAssetEntity(AssetEntity asset) async {
+    if (checkPlatform([TargetPlatform.android])) {
+      // Reading the asset through its MediaStore URI avoids the full copy into the app
+      // cache that originFile performs, which dominates the wait for large selections.
+      final mediaUri = await asset.getMediaUrl();
+      // photo_manager reports 0 when it cannot reach the asset, and offering the peer an
+      // empty file is worse than paying for the copy below.
+      final size = await asset.fileSize;
+      if (mediaUri != null && size > 0) {
+        final modifiedSeconds = asset.modifiedDateSecond;
+        return CrossFile(
+          name: await asset.titleAsync,
+          fileType: asset.type == AssetType.video ? FileType.video : FileType.image,
+          size: size,
+          thumbnail: null,
+          asset: asset,
+          path: await android_channel.getOriginalMediaUriAndroid(uri: mediaUri),
+          bytes: null,
+          // MediaStore only provides seconds, so there is no point statting in Rust.
+          lastModified: modifiedSeconds != null && modifiedSeconds > 0
+              ? DateTime.fromMillisecondsSinceEpoch(modifiedSeconds * 1000, isUtc: true).toIso8601String()
+              : null,
+          lastAccessed: null,
+        );
+      }
+      _logger.warning('Falling back to a cache copy of ${asset.id}: uri=$mediaUri size=$size');
+    }
+
     final file = (await asset.originFile)!;
     final metadata = await readFileMetadata(path: file.path);
     return CrossFile(

--- a/app/lib/widget/file_thumbnail.dart
+++ b/app/lib/widget/file_thumbnail.dart
@@ -5,11 +5,16 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:localsend_app/model/cross_file.dart';
 import 'package:localsend_app/util/file_type_ext.dart';
+import 'package:localsend_app/util/native/channel/android_channel.dart' as android_channel;
 import 'package:localsend_isolates/model/file_type.dart';
 import 'package:uri_content/uri_content.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
 const double defaultThumbnailSize = 50;
+
+/// Resolution the thumbnails are decoded at, kept small because they are never shown
+/// larger than [defaultThumbnailSize].
+const int _thumbnailPixelSize = 64;
 
 class SmartFileThumbnail extends StatelessWidget {
   final Uint8List? bytes;
@@ -86,32 +91,36 @@ class FilePathThumbnail extends StatelessWidget {
     required this.fileType,
   });
 
+  Widget _fallbackIcon(BuildContext context, Object error, StackTrace? stackTrace) {
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: Icon(fileType.icon, size: 32),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final path = this.path;
     final Widget? thumbnail;
-    if (path != null && fileType == FileType.image) {
-      if (path!.startsWith('content://')) {
-        thumbnail = Image(
-          image: ResizeImage.resizeIfNeeded(
-            64,
-            null,
-            _ContentUriImage(Uri.parse(path!)),
-          ),
-          errorBuilder: (_, _, _) => Padding(
-            padding: const EdgeInsets.all(10),
-            child: Icon(fileType.icon, size: 32),
-          ),
-        );
-      } else {
-        thumbnail = Image.file(
-          File(path!),
-          cacheWidth: 64, // reduce memory with low cached size; do not set cacheHeight because the image must keep its ratio
-          errorBuilder: (_, _, _) => Padding(
-            padding: const EdgeInsets.all(10),
-            child: Icon(fileType.icon, size: 32),
-          ),
-        );
-      }
+    if (path == null) {
+      thumbnail = null;
+    } else if (path.startsWith('content://') && (fileType == FileType.image || fileType == FileType.video)) {
+      // Videos are included because the provider thumbnails them just as well, and they
+      // have no preview at all otherwise.
+      thumbnail = Image(
+        image: ResizeImage.resizeIfNeeded(
+          _thumbnailPixelSize,
+          null,
+          _ContentUriImage(Uri.parse(path), fileType: fileType),
+        ),
+        errorBuilder: _fallbackIcon,
+      );
+    } else if (fileType == FileType.image) {
+      thumbnail = Image.file(
+        File(path),
+        cacheWidth: _thumbnailPixelSize, // reduce memory with low cached size; do not set cacheHeight because the image must keep its ratio
+        errorBuilder: _fallbackIcon,
+      );
     } else {
       thumbnail = null;
     }
@@ -195,8 +204,9 @@ class _Thumbnail extends StatelessWidget {
 
 class _ContentUriImage extends ImageProvider<Uri> {
   final Uri uri;
+  final FileType fileType;
 
-  _ContentUriImage(this.uri);
+  _ContentUriImage(this.uri, {required this.fileType});
 
   @override
   Future<Uri> obtainKey(ImageConfiguration configuration) {
@@ -216,7 +226,19 @@ class _ContentUriImage extends ImageProvider<Uri> {
   }
 
   Future<Codec> _loadAsync(Uri key, ImageDecoderCallback decode) async {
-    final bytes = await UriContent().from(key);
-    return decode(await ImmutableBuffer.fromUint8List(bytes));
+    // Reading the whole file just to shrink it to a few dozen pixels is what makes large
+    // photos take seconds to show up, so it is only the fallback for providers that
+    // cannot thumbnail themselves.
+    final thumbnail = await android_channel.getContentThumbnailAndroid(uri: key.toString(), size: _thumbnailPixelSize);
+    if (thumbnail != null) {
+      return decode(await ImmutableBuffer.fromUint8List(thumbnail));
+    }
+
+    if (fileType == FileType.video) {
+      // Reading a video whole would cost gigabytes and still not decode as an image.
+      throw StateError('No thumbnail available for video $uri');
+    }
+
+    return decode(await ImmutableBuffer.fromUint8List(await UriContent().from(key)));
   }
 }


### PR DESCRIPTION
## Problem

On Android, three separate paths read or copy a file in full before it can be sent, which makes adding a handful of large photos or videos take tens of seconds or even minutes (sometimes crash before finishing). Reproduces reliably with a dozen large videos.

1. **Media picker.** `CrossFileConverters.convertAssetEntity` uses `AssetEntity.originFile`, which makes photo_manager copy every asset byte-for-byte into the app cache (`ScopedCache.getCacheFileFromEntity` on Android 10+). Selecting a few GB of video means copying a few GB before anything is queued.
2. **Share intents.** `share_handler` copies every shared URI into the app cache too (`FileDirectory.getAbsolutePath`), and does it synchronously from `onNewIntent`, so the copy blocks the main thread. Its `Dispatchers`/`withContext` imports are unused.
3. **Thumbnails.** `_ContentUriImage` reads the whole file into memory just to render a 64px preview (#2105).

None of these copies are necessary: uploading, hashing and web downloads already resolve `content://` through a file descriptor (`FileContent::Fd`), so a content URI is all the app needs to hold on to.

## Changes

One commit each, independent:

- **Media picker** — use the MediaStore content URI as the path instead of `originFile`. `MediaStore.setRequireOriginal()` preserves the location EXIF tags and is gated on `ACCESS_MEDIA_LOCATION`, because opening an original URI without that permission throws. Redaction zero-fills in place, so the declared size stays correct whether or not the permission is granted. photo_manager reports a size of `0` when it cannot reach an asset, so that case falls back to the copy rather than offering the peer an empty file.
- **Share intents** — `MainActivity` claims file-carrying shares and answers with content URIs; text-only shares still go through share_handler. The launch intent has to be claimed before the plugins attach, since share_handler reads and copies it during `onAttachedToActivity`. Only the openable columns are queried, as those are the ones every content provider must expose for a shared URI. A share is claimed all or nothing: handing over just the readable subset would drop the rest without the user ever learning about it.
- **Thumbnails** — ask `ContentResolver.loadThumbnail()` off the main thread, falling back to the previous full read below Android 10 (`minSdk` is 24). Videos get a preview for the first time on this path, and never fall back to the full read, which for a video would cost gigabytes and still not decode as an image.

`lastModified` is now `null` for shared files: share intents do not carry one, and the openable columns do not expose one. Previously this field held the time the cache copy was made, not the file's own timestamp.

Everything is gated on Android (`checkPlatform`) or on the `content://` scheme, so iOS and desktop behaviour is unchanged. iOS still copies through `originFile`; that needs a different fix and is not part of this PR.

## Test plan

Automated, on Flutter 3.41.9 as pinned in `.fvmrc`:

| Command | Result |
| --- | --- |
| `fvm flutter analyze` | No issues found |
| `fvm dart format --set-exit-if-changed lib test` | 286 files, 0 changed |
| `fvm flutter test` | 71 passed |
| `fvm flutter build apk --debug --target-platform android-arm64` | Built |
| `./gradlew :app:lintDebug` | Two errors, both pre-existing in `AndroidManifest.xml` (`ProtectedPermissions`, `QueryAllPackagesPermission`); nothing new |

Analyze and the APK build were run at each of the three commits individually, so each one compiles on its own.

Manual testing environment:

| | |
| --- | --- |
| Device | Samsung SM-F966W (Galaxy Z Fold 7) |
| OS | Android 16, SDK 36 |
| Build | `1.18.2+64`, debug, `android-arm64` |
| Relevant plugins | photo_manager 3.12.0, share_handler_android 0.0.11, wechat_assets_picker 10.1.3, uri_content 3.1.1 |
| Permissions | `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` and `ACCESS_MEDIA_LOCATION` all granted |

| Case | Result |
| --- | --- |
| Media picker, a dozen large videos | Returns instantly; previously tens of seconds |
| Share from gallery, a dozen large videos | No lag; previously an apparent freeze |
| Share a single image (`ACTION_SEND`) | Works |
| Share several images (`ACTION_SEND_MULTIPLE`) | Works |
| Share while the app is running | Works |
| Share while the app is not running | Works |
| Thumbnails, images and videos | Appear immediately; videos previously had none |
| Location EXIF through the media picker | Preserved; latitude, longitude and altitude all intact on the received file |
| Byte integrity | A 4.6 MB Samsung motion photo arrived complete: EXIF, the embedded MP4 (`ftyp`/`moov`/`mdat`) and the trailing vendor `SEF` block all survived |

Not covered, and worth a reviewer's attention:

- The path taken when `ACCESS_MEDIA_LOCATION` is denied. Android grants it silently alongside the media permission rather than prompting separately, and `_pickMedia` re-requests it on every pick, so revoking it through `adb` is undone as soon as the picker opens. Only the granted case was measured.
- Text-only sharing still routes through share_handler by design, but was not exercised.
- The pre-Android 10 fallbacks (no `loadThumbnail`, no `setRequireOriginal`) were not run; the test device is Android 16.

## Note

Shared content URIs carry a temporary grant rather than a persistable one, so a selection made from a share is only valid while the activity lives. That matches the current behaviour: the engine, isolates and in-memory selection die with the activity anyway, and the cache is cleared on every app start.