### PR TITLE
fix(linux): pick tray icon from OS brightness

### DIFF
--- a/app/lib/util/native/tray_helper.dart
+++ b/app/lib/util/native/tray_helper.dart
@@ -17,6 +17,38 @@ enum TrayEntry {
   close,
 }
 
+/// Linux tray icon path: Flatpak uses a themed icon name; other builds pick a
+/// monochrome asset from [brightness] so light panels stay readable.
+@visibleForTesting
+String resolveLinuxTrayIcon({required bool isFlatpak, required Brightness brightness}) {
+  if (isFlatpak) {
+    // Must exist in /app/share/icons/hicolor/*x*/apps.
+    return 'org.localsend.localsend_app-tray';
+  }
+  return brightness == Brightness.dark ? Assets.img.logo32White.path : Assets.img.logo32Black.path;
+}
+
+Future<void> _setLinuxTrayIcon() async {
+  final icon = resolveLinuxTrayIcon(
+    isFlatpak: await File('/.flatpak-info').exists(),
+    brightness: PlatformDispatcher.instance.platformBrightness,
+  );
+  _logger.info('Using "$icon" as path of system tray icon');
+  await tm.trayManager.setIcon(icon);
+}
+
+/// Re-apply the Linux tray icon after OS light/dark changes.
+Future<void> updateLinuxTrayIcon() async {
+  if (!checkPlatform([TargetPlatform.linux])) {
+    return;
+  }
+  try {
+    await _setLinuxTrayIcon();
+  } catch (e) {
+    _logger.warning('Failed to update tray icon', e);
+  }
+}
+
 Future<void> initTray() async {
   if (!checkPlatformHasTray()) {
     return;
@@ -28,15 +60,7 @@ Future<void> initTray() async {
       // The menu bar icon will created in AppDelegate.swift
       return;
     } else if (checkPlatform([TargetPlatform.linux])) {
-      String icon;
-      if (await File('/.flatpak-info').exists()) {
-        // Icon for Flatpak, which must exist in /app/share/icons/hicolor/*x*/apps.
-        icon = 'org.localsend.localsend_app-tray';
-      } else {
-        icon = Assets.img.logo32White.path;
-      }
-      _logger.info('Using "$icon" as path of system tray icon');
-      await tm.trayManager.setIcon(icon);
+      await _setLinuxTrayIcon();
     } else {
       await tm.trayManager.setIcon(Assets.img.logo32.path);
     }

--- a/app/lib/widget/watcher/tray_watcher.dart
+++ b/app/lib/widget/watcher/tray_watcher.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
@@ -15,7 +16,7 @@ class TrayWatcher extends StatefulWidget {
   State<TrayWatcher> createState() => _TrayWatcherState();
 }
 
-class _TrayWatcherState extends State<TrayWatcher> with TrayListener {
+class _TrayWatcherState extends State<TrayWatcher> with TrayListener, WidgetsBindingObserver {
   @override
   Widget build(BuildContext context) {
     return widget.child;
@@ -25,12 +26,19 @@ class _TrayWatcherState extends State<TrayWatcher> with TrayListener {
   void initState() {
     super.initState();
     trayManager.addListener(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     trayManager.removeListener(this);
     super.dispose();
+  }
+
+  @override
+  void didChangePlatformBrightness() {
+    unawaited(updateLinuxTrayIcon());
   }
 
   @override

--- a/app/test/unit/util/native/tray_helper_test.dart
+++ b/app/test/unit/util/native/tray_helper_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:localsend_app/gen/assets.gen.dart';
+import 'package:localsend_app/util/native/tray_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('resolveLinuxTrayIcon uses themed name for Flatpak', () {
+    expect(
+      resolveLinuxTrayIcon(isFlatpak: true, brightness: Brightness.light),
+      'org.localsend.localsend_app-tray',
+    );
+    expect(
+      resolveLinuxTrayIcon(isFlatpak: true, brightness: Brightness.dark),
+      'org.localsend.localsend_app-tray',
+    );
+  });
+
+  test('resolveLinuxTrayIcon picks black on light and white on dark', () {
+    expect(
+      resolveLinuxTrayIcon(isFlatpak: false, brightness: Brightness.light),
+      Assets.img.logo32Black.path,
+    );
+    expect(
+      resolveLinuxTrayIcon(isFlatpak: false, brightness: Brightness.dark),
+      Assets.img.logo32White.path,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Non-Flatpak Linux tray icons no longer always use the white asset (invisible on light panels, #3312).
- Pick `logo-32-black` / `logo-32-white` from OS brightness and refresh when it changes; Flatpak still uses the themed tray icon name.

## Test plan
- [ ] Linux non-Flatpak (e.g. AUR `localsend-bin`): light Plasma/GNOME panel shows a dark tray icon
- [ ] Same build: dark panel shows a white tray icon
- [ ] Toggle OS light/dark while LocalSend is running — tray icon updates
- [ ] Flatpak build still uses `org.localsend.localsend_app-tray`
- [ ] `fvm flutter test test/unit/util/native/tray_helper_test.dart`